### PR TITLE
Call fetchResultsDataSourceHasResults: delegate method with NO

### DIFF
--- a/Pod/Classes/Optional Data Sources/VOKCollectionDataSource.m
+++ b/Pod/Classes/Optional Data Sources/VOKCollectionDataSource.m
@@ -116,7 +116,7 @@
 {
     NSInteger sectionCount = [[self.fetchedResultsController sections] count];
 
-    // If there are no sections, the numberOfRowsInSection: method is never called,
+    // If there are no sections, the numberOfItemsInSection: method is never called,
     // so the delegeate fetchResultsDataSourceHasResults: method isn't called
     // with NO. Do so here, if necessary.
     if (sectionCount == 0 && [self.delegate respondsToSelector:@selector(fetchResultsDataSourceHasResults:)]) {

--- a/Pod/Classes/Optional Data Sources/VOKCollectionDataSource.m
+++ b/Pod/Classes/Optional Data Sources/VOKCollectionDataSource.m
@@ -114,7 +114,15 @@
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
 {
-    return [[self.fetchedResultsController sections] count];
+    NSInteger sectionCount = [[self.fetchedResultsController sections] count];
+
+    // If there are no sections, the numberOfRowsInSection: method is never called,
+    // so the delegeate fetchResultsDataSourceHasResults: method isn't called
+    // with NO. Do so here, if necessary.
+    if (sectionCount == 0 && [self.delegate respondsToSelector:@selector(fetchResultsDataSourceHasResults:)]) {
+        [self.delegate fetchResultsDataSourceHasResults:NO];
+    }
+    return sectionCount;
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
@@ -213,7 +213,15 @@
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
-    return [[_fetchedResultsController sections] count];
+    NSInteger sectionCount = [[_fetchedResultsController sections] count];
+
+    // If there are no sections, the numberOfRowsInSection: method is never called,
+    // so the delegeate fetchResultsDataSourceHasResults: method isn't called
+    // with NO. Do so here, if necessary.
+    if (sectionCount == 0 && [_delegate respondsToSelector:@selector(fetchResultsDataSourceHasResults:)]) {
+        [_delegate fetchResultsDataSourceHasResults:NO];
+    }
+    return sectionCount;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section


### PR DESCRIPTION
When there are no results in the fetched results controller, the number of sections is 0, so it doesn't bother calling `collectionView:numberOfItemsInSection:` or `tableView:numberOfRowsInSection:`, as the case may be, so the delegate `fetchResultsDataSourceHasResults:` method was never called with a NO argument.

This change calls that delegate method in the numberOfSections method if the section count is 0.

Fixes #21