### PR TITLE
Respect fetchLimit when updating items, not just sections

### DIFF
--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "1.1.3"
+  s.version          = "1.1.4"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
I messed up in #32: our `controllerDidChangeContent:` method handles section and item changes separately…for…reasons? I had implemented and tested #32 in a separate project, then copied the code over piece-by-piece (because that project had an older version of Vokoder, this was easier than replacing the entire file and doing the `git add -p` dance), and missed that this logic is basically repeated twice in that method.

@vokal/ios-developers code review please? Especially from someone more familiar with the collection view data source?