### PR TITLE
Import UIKit in the fetched results data source

### DIFF
--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
@@ -3,6 +3,8 @@
 //  CoreData
 //
 
+#import <UIKit/UIKit.h>
+
 #import "VOKCoreDataManager.h"
 
 @protocol VOKFetchedResultsDataSourceDelegate <NSObject>


### PR DESCRIPTION
I guess I've never tried to use this without importing UIKit from the Prefix header or something. Or, maybe something changed in Xcode 6.3, but on a fresh project, Xcode was griping that it doesn't know anything about UITableViewDataSource or delegate.

@vokal/ios-developers I'm surprised no one else has run into this, which leads me to believe that I'm doing it wrong. What do you think?