### PR TITLE
Date formatter update

### DIFF
--- a/Pod/Classes/VOKManagedObjectMap.h
+++ b/Pod/Classes/VOKManagedObjectMap.h
@@ -84,4 +84,18 @@
  */
 + (NSArray *)mapsFromDictionary:(NSDictionary *)mapDict;
 
+/**
+ Default formatter used for date fields. This is the RFC 3339 format, with
+ milliseconds included.
+ @return            Default date formatter
+ */
++ (NSDateFormatter *)vok_defaultDateFormatter;
+
+/**
+ Default formatter used for date fields. This is the RFC 3339 format, just like
+ the one returned by vok_defaultDateFormatter, but with milliseconds ommitted.
+ @return            Default date formatter, without the milliseconds
+ */
++ (NSDateFormatter *)vok_dateFormatterWithoutMicroseconds;
+
 @end

--- a/Pod/Classes/VOKManagedObjectMap.h
+++ b/Pod/Classes/VOKManagedObjectMap.h
@@ -86,15 +86,22 @@
 
 /**
  Default formatter used for date fields. This is the RFC 3339 format, with
- milliseconds included.
+ microseconds included. Note that iOS only stores milliseconds, so you'll get
+ three trailing zeros when formatting a date using this format.
+ 
+ Sample value: 1983-07-24T03:22:15.321123Z
+ 
  @return            Default date formatter
  */
 + (NSDateFormatter *)vok_defaultDateFormatter;
 
 /**
  Default formatter used for date fields. This is the RFC 3339 format, just like
- the one returned by vok_defaultDateFormatter, but with milliseconds ommitted.
- @return            Default date formatter, without the milliseconds
+ the one returned by vok_defaultDateFormatter, but with microseconds ommitted.
+ 
+ Sample value: 1983-07-24T03:22:15Z
+ 
+ @return            Default date formatter, without the microseconds
  */
 + (NSDateFormatter *)vok_dateFormatterWithoutMicroseconds;
 

--- a/Pod/Classes/VOKManagedObjectMap.m
+++ b/Pod/Classes/VOKManagedObjectMap.m
@@ -73,7 +73,6 @@
     return DateFormatterWithoutMicroseconds;
 }
 
-
 #pragma mark - Description
 
 - (NSString *)description

--- a/Pod/Classes/VOKManagedObjectMap.m
+++ b/Pod/Classes/VOKManagedObjectMap.m
@@ -53,12 +53,26 @@
     static NSDateFormatter *DefaultDateFormatter;
     dispatch_once(&pred, ^{
         DefaultDateFormatter = [NSDateFormatter new];
-        [DefaultDateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+        [DefaultDateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"];
         [DefaultDateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
     });
 
     return DefaultDateFormatter;
 }
+
++ (NSDateFormatter *)vok_dateFormatterWithoutMicroseconds
+{
+    static dispatch_once_t formatter_dispatch_token = 0;
+    static NSDateFormatter *DateFormatterWithoutMicroseconds;
+    dispatch_once(&formatter_dispatch_token, ^{
+        DateFormatterWithoutMicroseconds = [NSDateFormatter new];
+        [DateFormatterWithoutMicroseconds setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+        [DateFormatterWithoutMicroseconds setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+    });
+
+    return DateFormatterWithoutMicroseconds;
+}
+
 
 #pragma mark - Description
 

--- a/Pod/Classes/VOKManagedObjectMapper.m
+++ b/Pod/Classes/VOKManagedObjectMapper.m
@@ -9,11 +9,6 @@
 #import "VOKCoreDataManager.h"
 #import "VOKCoreDataManagerInternalMacros.h"
 
-@interface VOKManagedObjectMap (VOKdefaultFormatters)
-+ (NSDateFormatter *)vok_defaultDateFormatter;
-
-@end
-
 @interface VOKManagedObjectDefaultMapper : VOKManagedObjectMapper
 
 @end

--- a/SampleProject/VOKCoreDataManagerTests/ManagedObjectImportExportTests.m
+++ b/SampleProject/VOKCoreDataManagerTests/ManagedObjectImportExportTests.m
@@ -726,7 +726,9 @@ static NSString *const THING_HAT_COUNT_KEY = @"thing_hats";
 {
     return @[[VOKManagedObjectMap mapWithForeignKeyPath:FIRST_NAME_DEFAULT_KEY coreDataKey:FIRST_NAME_DEFAULT_KEY],
              [VOKManagedObjectMap mapWithForeignKeyPath:LAST_NAME_DEFAULT_KEY coreDataKey:LAST_NAME_DEFAULT_KEY],
-             [VOKManagedObjectMap mapWithForeignKeyPath:BIRTHDAY_DEFAULT_KEY coreDataKey:BIRTHDAY_DEFAULT_KEY dateFormatter:[VOKManagedObjectMap vok_dateFormatterWithoutMicroseconds]],
+             [VOKManagedObjectMap mapWithForeignKeyPath:BIRTHDAY_DEFAULT_KEY
+                                            coreDataKey:BIRTHDAY_DEFAULT_KEY
+                                          dateFormatter:[VOKManagedObjectMap vok_dateFormatterWithoutMicroseconds]],
              [VOKManagedObjectMap mapWithForeignKeyPath:CATS_DEFAULT_KEY coreDataKey:CATS_DEFAULT_KEY],
              [VOKManagedObjectMap mapWithForeignKeyPath:COOL_RANCH_DEFAULT_KEY coreDataKey:COOL_RANCH_DEFAULT_KEY]];
 }

--- a/SampleProject/VOKCoreDataManagerTests/ManagedObjectImportExportTests.m
+++ b/SampleProject/VOKCoreDataManagerTests/ManagedObjectImportExportTests.m
@@ -602,8 +602,8 @@ static NSString *const THING_HAT_COUNT_KEY = @"thing_hats";
 
 - (NSDictionary *)makeClientPersonDictForMapperWithoutMicroseconds
 {
-    // Server can return microseconds, but NSDate will only store milliseconds
-    // For testing, copy the server response and reduce the accuracy for comparing
+    // For testing, copy the server response and strip off the microseconds to
+    // test the format that omits them
     NSMutableDictionary *mutableDict = [[self makeServerPersonDictForDefaultMapper] mutableCopy];
     [mutableDict setValue:@"1983-07-24T03:22:15Z" forKey:BIRTHDAY_DEFAULT_KEY];
     return mutableDict;

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "1.1.5"
+  s.version          = "1.1.6"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
Update the default date formatter to use microseconds, and update tests to reflect this change. I also exposed the formatter class methods in `VOKManagedObjectMap`, which is a debatable change.

@vokal/ios-developers What do you think?