### PR TITLE
Set NSFRC's delegate to nil on dealloc

### DIFF
--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
@@ -407,10 +407,7 @@
          self.tableView.dataSource = nil;
     }
 
-    if (_fetchedResultsController.delegate) {
-        _fetchedResultsController.delegate = nil;
-    }
-    
+    _fetchedResultsController.delegate = nil;
 }
 
 @end

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
@@ -406,6 +406,10 @@
     if (self.tableView.dataSource == self) {
          self.tableView.dataSource = nil;
     }
+
+    if (_fetchedResultsController.delegate) {
+        _fetchedResultsController.delegate = nil;
+    }
     
 }
 


### PR DESCRIPTION
What do you guys think of this? I was finding that intermittently NSFRC would send messages to a deallocated datasource, as the delegate wasn't set to nil by anything else. Seemed to only happen when lots of data and view churn was happening simultaneously.