### PR TITLE
new convenience method to import in background and return MOs or at least MOIDs

### DIFF
--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.h
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.h
@@ -7,6 +7,9 @@
 
 @interface NSManagedObject (VOKManagedObjectAdditions)
 
+/// A completion block after an asynchronous operation on a temporary context. NSManagedObject's are not threadsafe.
+typedef void(^VOKManagedObjectReturnBlock)(NSArray *arrayOfManagedObjects);
+
 /**
  Checks for NSNull before seting a value.
  @param value   The input object.
@@ -48,9 +51,10 @@
 + (instancetype)vok_newInstanceWithContext:(NSManagedObjectContext *)contextOrNil;
 
 /*
- Create or update many NSManagedObjects, respecting overwriteObjectsWithServerChanges.
- This should only be used to set all properties of an entity, any mapped attributes not included in the input dictionaries will be set to nil.
- This will overwrite ALL of an NSManagedObject's properties.
+ Create or update many NSManagedObjects, respecting overwriteObjectsWithServerChanges and ignoreNullValueOverwrites.
+ This should only be used to set all properties of an entity. 
+ By default any mapped attributes not included in the input dictionaries will be set to nil.
+ This will overwrite ALL of an NSManagedObject's properties unless ignoreNullValueOverwrites is YES;
  @param inputArray      An array of dictionaries with foreign data to inport.
  @param contextOfNil    The managed object context to update and/or insert the objects. If nil, the main context will be used.
  @return                An array of this subclass of NSManagedObject.
@@ -58,14 +62,25 @@
 + (NSArray *)vok_addWithArray:(NSArray *)inputArray forManagedObjectContext:(NSManagedObjectContext *)contextOrNil;
 
 /*
- Create or update a single NSManagedObject, respecting overwriteObjectsWithServerChanges.
- This should only be used to set all properties of an entity, any mapped attributes not included in the input dictionaries will be set to nil.
- This will overwrite ALL of an NSManagedObject's properties.
+ Create or update many NSManagedObjects, respecting overwriteObjectsWithServerChanges and ignoreNullValueOverwrites.
+ This should only be used to set all properties of an entity.
+ By default any mapped attributes not included in the input dictionaries will be set to nil.
+ This will overwrite ALL of an NSManagedObject's properties unless ignoreNullValueOverwrites is YES;
  @param inputDict       A dictionary with foreign data to inport.
  @param contextOfNil    The managed object context to update and/or insert the object. If nil, the main context will be used.
  @return                An instance of this subclass of NSManagedObject.
  **/
 + (instancetype)vok_addWithDictionary:(NSDictionary *)inputDict forManagedObjectContext:(NSManagedObjectContext *)contextOrNil;
+
+/*
+ Create or update many NSManagedObjects, respecting overwriteObjectsWithServerChanges and ignoreNullValueOverwrites.
+ This should only be used to set all properties of an entity.
+ By default any mapped attributes not included in the input dictionaries will be set to nil.
+ This will overwrite ALL of an NSManagedObject's properties unless ignoreNullValueOverwrites is YES;
+ @param inputArray      An array of dictionaries with foreign data to input on a background queue in a temporary context.
+ @param completion      A block to execute after the background operation. The array will contain the objects just imported/updated.
+ **/
++ (void)vok_addWithArrayInBackground:(NSArray *)inputArray completion:(VOKManagedObjectReturnBlock)completion;
 
 /*
  Convenience method to create a fetch request.

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
@@ -74,11 +74,13 @@
     return [[VOKCoreDataManager sharedInstance] managedObjectOfClass:self inContext:context];
 }
 
-#pragma mark - Add Objects
+#pragma mark - Add and Edit Objects
 
 + (NSArray *)vok_addWithArray:(NSArray *)inputArray forManagedObjectContext:(NSManagedObjectContext *)contextOrNil
 {
-    return [[VOKCoreDataManager sharedInstance] importArray:inputArray forClass:[self class] withContext:contextOrNil];
+    return [[VOKCoreDataManager sharedInstance] importArray:inputArray
+                                                   forClass:[self class]
+                                                withContext:contextOrNil];
 }
 
 + (instancetype)vok_addWithDictionary:(NSDictionary *)inputDict forManagedObjectContext:(NSManagedObjectContext *)contextOrNil
@@ -87,14 +89,30 @@
         return nil;
     }
 
-    NSArray *array = [[VOKCoreDataManager sharedInstance] importArray:@[inputDict] forClass:[self class] withContext:contextOrNil];
-    
+    NSArray *array = [[VOKCoreDataManager sharedInstance] importArray:@[inputDict]
+                                                             forClass:[self class]
+                                                          withContext:contextOrNil];    
     if ([array count]) {
         return [array firstObject];
     } else {
         return nil;
     }
 }
+
++ (void)vok_addWithArrayInBackground:(NSArray *)inputArray completion:(VOKManagedObjectReturnBlock)completion
+{
+    [VOKCoreDataManager importArrayInBackground:inputArray
+                                       forClass:[self class]
+                                     completion:^(NSArray *arrayOfManagedObjectIDs) {
+                                         NSMutableArray *returnArray = [NSMutableArray array];
+                                         NSManagedObjectContext *moc = [[VOKCoreDataManager sharedInstance] managedObjectContext];
+                                         for (NSManagedObjectID *objectID in arrayOfManagedObjectIDs) {
+                                             [returnArray addObject:[moc objectWithID:objectID]];
+                                         }
+                                         completion([returnArray copy]);
+                                     }];
+}
+
 
 #pragma mark - Fetching
 

--- a/Pod/Classes/VOKCoreDataManager.h
+++ b/Pod/Classes/VOKCoreDataManager.h
@@ -25,8 +25,9 @@ typedef NS_ENUM (NSInteger, VOKMigrationFailureOption) {
 /// The action block for asynchronous writing to a temporary context.
 typedef void(^VOKWriteBlock)(NSManagedObjectContext *tempContext);
 
-/// The return block for asynchronous object deserialization on a temporary context. NSManagedObjectID's are threadsafe.
-typedef void(^VOKBackgroundWriteCompletionBlock)(NSArray *arrayOfManagedObjectIDs);
+/// A completion block after an asynchronous operation on a temporary context. NSManagedObjectID's are threadsafe.
+typedef void(^VOKObjectIDReturnBlock)(NSArray *arrayOfManagedObjectIDs);
+
 
 @interface VOKCoreDataManager : NSObject
 
@@ -265,7 +266,7 @@ typedef void(^VOKBackgroundWriteCompletionBlock)(NSArray *arrayOfManagedObjectID
  */
 + (void)importArrayInBackground:(NSArray *)inputArray
                        forClass:(Class)objectClass
-                     completion:(VOKBackgroundWriteCompletionBlock)completion;
+                     completion:(VOKObjectIDReturnBlock)completion;
 
 /**
  Saves any temporary managed object context and merges those changes with the main managed object context in a thread-safe way.

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -501,7 +501,7 @@ static VOKCoreDataManager *VOK_SharedObject;
 
 + (void)importArrayInBackground:(NSArray *)inputArray
                        forClass:(Class)objectClass
-                     completion:(VOKBackgroundWriteCompletionBlock)completion
+                     completion:(VOKObjectIDReturnBlock)completion
 {
     [[VOKCoreDataManager sharedInstance]  managedObjectContext];
     [VOK_WritingQueue addOperationWithBlock:^{

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -485,7 +485,7 @@ static VOKCoreDataManager *VOK_SharedObject;
 + (void)writeToTemporaryContext:(VOKWriteBlock)writeBlock
                      completion:(void (^)(void))completion
 {
-    [[VOKCoreDataManager sharedInstance]  managedObjectContext];
+    [[VOKCoreDataManager sharedInstance] managedObjectContext];
     NSAssert(writeBlock, @"Write block must not be nil");
     [VOK_WritingQueue addOperationWithBlock:^{
 
@@ -503,7 +503,7 @@ static VOKCoreDataManager *VOK_SharedObject;
                        forClass:(Class)objectClass
                      completion:(VOKObjectIDReturnBlock)completion
 {
-    [[VOKCoreDataManager sharedInstance]  managedObjectContext];
+    [[VOKCoreDataManager sharedInstance] managedObjectContext];
     [VOK_WritingQueue addOperationWithBlock:^{
         
         NSManagedObjectContext *tempContext = [[VOKCoreDataManager sharedInstance] temporaryContext];

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ or
 
 ###Using Vokoders Mapper
 
-Vokoder offers a lightweight mapper for importing Foundation objects into Core Data. Arrays of dictionarys can be imported with ease once maps are set up. If no maps are provided Vokoder will use its default maps. The default map assumes that foreign keys have the same names as your core data attributes. It will make its best effort to identify dates and numbers.
+Vokoder offers a lightweight mapper for importing Foundation objects into Core Data. Arrays of dictionaries can be imported with ease once maps are set up. If no maps are provided Vokoder will use its default maps. The default maps assume that foreign keys have the same names as your core data attributes. It will make its best effort to identify dates and numbers.
 
-Setting up your own maps is more reliable. Macros are provided to make it fun and easy. Here's an example of setting up a mapper for an arbitrary managed object subclass. Mappers are not persisted between app launches, so be sure to setup your maps every time your application starts.
+Setting up your own maps is recommended. Macros are provided to make it fun and easy. Below is an example of setting up a mapper for an arbitrary managed object subclass. Mappers are not persisted between app launches, so be sure to setup your maps every time your application starts.
 
 ```objective-c
 // A date formatter will enable Vokoder to turn strings into NSDates
@@ -62,7 +62,7 @@ NSArray *maps = @[
 // VOK_CDSELECTOR will prevent you from specifying a nonexistent attribute
 VOKManagedObjectMapper *mapper = [VOKManagedObjectMapper mapperWithUniqueKey:VOK_CDSELECTOR(ticketNumber)
                                                                      andMaps:maps];
-// By default missing parameters and null parameters in the import data will nil out an attribute
+// By default missing parameters and null parameters in the import data will nil out an attribute's value
 // With ignoreNullValueOverwrites set to YES the maps will leave set attributes alone unless new data is provided.
 mapper.ignoreNullValueOverwrites = YES;
 // By default Vokoder will complain about every single parameter that can't be set
@@ -73,11 +73,11 @@ mapper.ignoreOptionalNullValues = YES;
                                             forClass:[SomeManagedObjectSubclass class]];
 ```
 
-Once the mapper is set Vokoder can round trip Foundation objects to managed objects and back to Foundation objects.
+Once the mapper is set Vokoder can turn Foundation objects in to managed objects and then back again to Foundation objects.
 
 ###Importing Safely
 
-Vokoder offers many ways to work with Core Data. The simplest and most approachable interface is offered through the VOKManagedObjectAdditions category. Given an array of dictionaries Vokoder will create or edit managed objects on a background queue and then safely return managed objects to the main queue through the completion block.
+Vokoder offers many ways to get data into Core Data. The simplest and most approachable interface is offered through the VOKManagedObjectAdditions category. Given an array of dictionaries Vokoder will create or edit managed objects on a background queue and then safely return managed objects to the main queue through the completion block.
 
 ```objective-c
 [SomeManagedObjectSubclass vok_addWithArrayInBackground:importArray
@@ -88,7 +88,7 @@ Vokoder offers many ways to work with Core Data. The simplest and most approacha
 
 ```
 
-For more control over background operations the VOKCoreDataManager class offers a more generic method. Vokoder will handle the queues and provide a temporary context, but will not automatically import or return anything. 
+For more control over background operations the VOKCoreDataManager class offers more generic methods. Vokoder can handle queues and provide a temporary context without automatically importing or returning anything. 
 
 ```objective-c
 + (void)writeToTemporaryContext:(VOKWriteBlock)writeBlock completion:(void (^)(void))completion;

--- a/SampleProject/VIViewController.m
+++ b/SampleProject/VIViewController.m
@@ -14,11 +14,11 @@
     [super loadView];
 
     UIBarButtonItem *reloadButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh
-                                                                                           target:self
-                                                                                           action:@selector(reloadData)];
+                                                                                  target:self
+                                                                                  action:@selector(reloadData)];
     UIBarButtonItem *reloadInBackgroundButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemOrganize
-                                                                                          target:self
-                                                                                          action:@selector(reloadDataInBackground)];
+                                                                                              target:self
+                                                                                              action:@selector(reloadDataInBackground)];
     UIBarButtonItem *deleteSomeStuffButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemTrash
                                                                                            target:self
                                                                                            action:@selector(deleteDataInBackground)];

--- a/SampleProject/VIViewController.m
+++ b/SampleProject/VIViewController.m
@@ -95,7 +95,6 @@
         NSLog(@"%@", [VIPerson vok_addWithDictionary:[self dictForCustomMapper] forManagedObjectContext:context]);
         j++;
     }
-    [[VOKCoreDataManager sharedInstance] saveMainContext];
 }
 
 #pragma mark - Fake Data Makers

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "1.1.6"
+  s.version          = "1.1.7"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
Turns out I've written something like [this](https://github.com/seanwolter/Vokoder/commit/29b73f669fd03adc90211636c8e20f6b0f835140#diff-7146a6b3c1018a27cc0a184a8beb4a6dR102) a few times. Seems like the time to make importing and returning an array a little easier.

Also:
I think this fixes https://github.com/vokal/Vokoder/issues/1 and https://github.com/vokal/Vokoder/issues/39 . I decided to delete most of the stuff in the class extension.