### PR TITLE
Fix the pod spec lint issue.

### DIFF
--- a/Paging Data Source Example/Podfile.lock
+++ b/Paging Data Source Example/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (1.3.0):
-    - Vokoder/Core (= 1.3.0)
-    - Vokoder/DataSources (= 1.3.0)
-  - Vokoder/Core (1.3.0):
+  - Vokoder (1.3.1):
+    - Vokoder/Core (= 1.3.1)
+    - Vokoder/DataSources (= 1.3.1)
+  - Vokoder/Core (1.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (1.3.0):
+  - Vokoder/DataSources (1.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 1.3.0)
-    - Vokoder/DataSources/FetchedResults (= 1.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 1.3.0)
-  - Vokoder/DataSources/Collection (1.3.0):
+    - Vokoder/DataSources/Collection (= 1.3.1)
+    - Vokoder/DataSources/FetchedResults (= 1.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 1.3.1)
+  - Vokoder/DataSources/Collection (1.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (1.3.0):
+  - Vokoder/DataSources/FetchedResults (1.3.1):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (1.3.0):
+  - Vokoder/DataSources/PagingFetchedResults (1.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -28,6 +28,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: a0df009661b524b84712984bfa62af586c173a55
+  Vokoder: 1a89327504093c719b11c43a78cfc5c0501a4efd
 
 COCOAPODS: 0.37.2

--- a/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "1.3.0"
+    "tag": "1.3.1"
   },
   "platforms": {
     "ios": "7.0"

--- a/Paging Data Source Example/Pods/Manifest.lock
+++ b/Paging Data Source Example/Pods/Manifest.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (1.3.0):
-    - Vokoder/Core (= 1.3.0)
-    - Vokoder/DataSources (= 1.3.0)
-  - Vokoder/Core (1.3.0):
+  - Vokoder (1.3.1):
+    - Vokoder/Core (= 1.3.1)
+    - Vokoder/DataSources (= 1.3.1)
+  - Vokoder/Core (1.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (1.3.0):
+  - Vokoder/DataSources (1.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 1.3.0)
-    - Vokoder/DataSources/FetchedResults (= 1.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 1.3.0)
-  - Vokoder/DataSources/Collection (1.3.0):
+    - Vokoder/DataSources/Collection (= 1.3.1)
+    - Vokoder/DataSources/FetchedResults (= 1.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 1.3.1)
+  - Vokoder/DataSources/Collection (1.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (1.3.0):
+  - Vokoder/DataSources/FetchedResults (1.3.1):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (1.3.0):
+  - Vokoder/DataSources/PagingFetchedResults (1.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -28,6 +28,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: a0df009661b524b84712984bfa62af586c173a55
+  Vokoder: 1a89327504093c719b11c43a78cfc5c0501a4efd
 
 COCOAPODS: 0.37.2

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,471 +7,471 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0168610B2686C2FB3E4A9562 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 729C78A178AE689ACC40CA34 /* Foundation.framework */; };
-		04A4FF39C0141A580DB2B11B /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B910F19C6FA8435CF3957AE /* VOKFetchedResultsDataSource.h */; };
-		04BBFE18E90747DDAA42592F /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D1E0F9DF5AE2AE42AAD0C98F /* VOKCollectionDataSource.h */; };
-		086F4B9770161BF83AA8CD5B /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F7E83619715DB55DB876DA9 /* VOKPagingFetchedResultsDataSource.h */; };
-		0B8D499404FA8638E340E766 /* Pods-Paging Data Source Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A529D08657D9DBE70F1BAB3 /* Pods-Paging Data Source Example-dummy.m */; };
-		11C0140D5DB61C495C764073 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F9A647B3B3EBA5FA89AE0BA /* VOKManagedObjectMapper.h */; };
-		138ABCD68577BBB46C71BC69 /* Pods-Paging Data Source Example-Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F94DFE2C66B0403A4F2BA8B2 /* Pods-Paging Data Source Example-Vokoder-dummy.m */; };
-		142E46E1C075CB5E6675F682 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 80199AD60311A6837F1B7950 /* VOKCoreDataManagerInternalMacros.h */; };
-		17A332725AC579B9C6BE2EF1 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 02B780094B6D8222809E7F31 /* VOKManagedObjectMapper.m */; };
-		1BC89B48437D29C27AB413DD /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = C1E80B62BECC480A0FCA9B4B /* VOKDefaultPagingAccessory.m */; };
-		1DF9D78E6526898B815CACF3 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5DBA9DE06C737F48994B0 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m */; };
-		295EE40B9B29E7AE8061FDE5 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D7980A8DB21FEB74D734253 /* VOKDefaultPagingAccessory.h */; };
-		354D98FCB65FA0F684E96470 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 729C78A178AE689ACC40CA34 /* Foundation.framework */; };
-		3A5D8F55DF52EDC296A668B7 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 71136819973CAD436262759D /* VOKPagingFetchedResultsDataSource.m */; };
-		3C53D276B7862B25776AF68D /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 08CBFFB479E6F90F3C428CA5 /* VOKCoreDataManager.h */; };
-		4807974D1ACCA8FAD1780AE5 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 28923859671E76797C3C2888 /* VOKFetchedResultsDataSource.m */; };
-		503FEE14CEC9CF2164D0E842 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = BD89A43211C81BD301770887 /* VOKManagedObjectMap.h */; };
-		543DD3C0E180A505EE25C972 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = A607AB1885D2FCFECBFC0687 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		68265077C3AB29D3E45B6A32 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0119C7BF58153399A9AA690C /* VOKCoreDataManager.m */; };
-		81FC7146B93D41DF23DA987B /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 11FC65BCA8C5C1E84AFA2A47 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		923F526A4D060C823987FD37 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B0FE17B901C1DF6863C6AAE7 /* NSManagedObject+VOKManagedObjectAdditions.h */; };
-		B22943A7075EC2C19C358E63 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E6FCC443A937563572281F /* VOKMappableModel.h */; };
-		B3DC9334296BF41407AD7310 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 658CC86E630F629CE28471A0 /* ILGClasses.h */; };
-		D4BB386B12F2118F124C6390 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 729C78A178AE689ACC40CA34 /* Foundation.framework */; };
-		D7FDA5F49B0123EF8B0883C0 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = C87E02C6DDC0F878B78EF885 /* VOKManagedObjectMap.m */; };
-		D8B2F043A3273B968D617F7E /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3ACDBA97DF71A3C0A8EBA7DC /* CoreData.framework */; };
-		DF34EA35DF16B26A112079C4 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 0659057EACEDB1AE3E2FF0D5 /* VOKCollectionDataSource.m */; };
+		00E07C326A645FB06374EC04 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF3441DD1BD85B7C81AC34FF /* Foundation.framework */; };
+		0E82BCB1E319D7DD3E02FC7A /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B519117CE157DC0133F0C70 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		0FEEAD2438C9B134F75EF547 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B11DFB14202081C8B24169D /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		1503CD19E4AC5D623D6C57AD /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C770792E16960EFEBD1B5F5F /* VOKCollectionDataSource.m */; };
+		2028F0570847E431D0D6B9C8 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 1457FEFBE23618947D11DE2E /* VOKCollectionDataSource.h */; };
+		27394CB094B017A4AA2B4E58 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B8F59FBE2C63E927CD97E2FF /* VOKCoreDataManager.m */; };
+		27E5788960E285CAFA7EEFDD /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 310367659493797777FA81DA /* VOKPagingFetchedResultsDataSource.m */; };
+		2DF3533A4C9045D7B39CC03D /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 124A4965AC2C604D201BF979 /* VOKCoreDataManagerInternalMacros.h */; };
+		4FA3259D8B5AD9A0E21DCBA1 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A6EA1EB05E9F94CA7F3C5212 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m */; };
+		5813B23FAACCE03EB96DA367 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = FDA633EB67C400882CD04280 /* VOKManagedObjectMap.m */; };
+		5A14564514A32B275A1FB282 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CC47EB66E89847E80F64DE0 /* VOKFetchedResultsDataSource.m */; };
+		636AFB0A5BB0BA4FBC67286D /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 991FD1793B0066292017E0B3 /* NSManagedObject+VOKManagedObjectAdditions.h */; };
+		68E879681B38A8133B9DFABA /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67D83BFE9FBCA4CA1106ED00 /* CoreData.framework */; };
+		750492D9B007FC1B218C361C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF3441DD1BD85B7C81AC34FF /* Foundation.framework */; };
+		76E6B0144B458797FB0A18ED /* Pods-Paging Data Source Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A6FB27EFDA24B3A13AEF7AA /* Pods-Paging Data Source Example-dummy.m */; };
+		7C7984BC3C0F54802F9D1E0C /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 1257F4AB38BDCDBA69CC3BFD /* VOKPagingFetchedResultsDataSource.h */; };
+		853BB73399024489D9CEAE4D /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 10B99166F2EAB46EC7B26A9E /* VOKManagedObjectMapper.h */; };
+		863CDCAC2CD5F8AF731DF165 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = 908D284C4DA682786E883DB9 /* VOKDefaultPagingAccessory.m */; };
+		9B7789DB1195B7B64FED7FA7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF3441DD1BD85B7C81AC34FF /* Foundation.framework */; };
+		A319D9AF46ED81C40EC5D419 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 655EE9475A16EF706978EF54 /* VOKManagedObjectMap.h */; };
+		AC085D02F559847F1E555592 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BA58B1C61EA58C1ABAEC654C /* VOKCoreDataManager.h */; };
+		B8A9EE27177F3A6546B08FB9 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E3EFEB85477AA68B9C995CC /* ILGClasses.h */; };
+		BCBB3337C937DAB26D47C6BF /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 09F52655DC2613DED783F145 /* VOKDefaultPagingAccessory.h */; };
+		DC3779C0025EDF2DD0C7ADAE /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F722F06B88B7805BDAE8E3 /* VOKManagedObjectMapper.m */; };
+		DEE45D8150BC692321945E72 /* Pods-Paging Data Source Example-Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C05FB1A8176C8F10981669F1 /* Pods-Paging Data Source Example-Vokoder-dummy.m */; };
+		ECA4718FBF1389BDFE9D1AB7 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 29F5F49A69C847A6CD24331B /* VOKMappableModel.h */; };
+		F42883CF21E658E9B2E75196 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BCA3A8FDC6714100880EC57 /* VOKFetchedResultsDataSource.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		19F500D054756C30BBE6A138 /* PBXContainerItemProxy */ = {
+		41BC06F1185BCA05FB3AB71E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 53C0A2E3383644D3A31F90A3 /* Project object */;
+			containerPortal = 2BFADA3CDB76F77DBB155234 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D01F6DA2324F7AF192C821CB;
-			remoteInfo = "Pods-Paging Data Source Example-Vokoder";
-		};
-		7FCE0D33EC3B27BA2A0E79F5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 53C0A2E3383644D3A31F90A3 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = AF08C7801A40CFB4E62E9A3A;
+			remoteGlobalIDString = C102B8C9884E78365BF14F1A;
 			remoteInfo = "Pods-Paging Data Source Example-ILGDynamicObjC";
 		};
-		88573DF23BCCCBA773558D0B /* PBXContainerItemProxy */ = {
+		692CA483DD8F9A8C0FB7CF47 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 53C0A2E3383644D3A31F90A3 /* Project object */;
+			containerPortal = 2BFADA3CDB76F77DBB155234 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = AF08C7801A40CFB4E62E9A3A;
+			remoteGlobalIDString = E2C01E9D8E24D95FE689851F;
+			remoteInfo = "Pods-Paging Data Source Example-Vokoder";
+		};
+		74D4C398749F503F086AAAFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2BFADA3CDB76F77DBB155234 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C102B8C9884E78365BF14F1A;
 			remoteInfo = "Pods-Paging Data Source Example-ILGDynamicObjC";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0119C7BF58153399A9AA690C /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
-		02B780094B6D8222809E7F31 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
-		0659057EACEDB1AE3E2FF0D5 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
-		08CBFFB479E6F90F3C428CA5 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
-		0ABD46C3A9A191652BFDDEBA /* Pods-Paging Data Source Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Paging Data Source Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		11FC65BCA8C5C1E84AFA2A47 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
-		1599B07B8A96F0E829496706 /* Pods-Paging Data Source Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.debug.xcconfig"; sourceTree = "<group>"; };
-		1A529D08657D9DBE70F1BAB3 /* Pods-Paging Data Source Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-dummy.m"; sourceTree = "<group>"; };
-		1D7980A8DB21FEB74D734253 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
-		28923859671E76797C3C2888 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		29113B9F42A204EAE4DE99C2 /* Pods-Paging Data Source Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-resources.sh"; sourceTree = "<group>"; };
-		2F9A647B3B3EBA5FA89AE0BA /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
-		36B5F0CB22AEB6761C77CB3E /* Pods-Paging Data Source Example-Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Paging Data Source Example-Vokoder-prefix.pch"; sourceTree = "<group>"; };
-		37EB2CD6865F64D7B0BF13FE /* Pods-Paging Data Source Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.release.xcconfig"; sourceTree = "<group>"; };
-		3ACDBA97DF71A3C0A8EBA7DC /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
-		3B41A2767D3AEC18E58C782A /* libPods-Paging Data Source Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Paging Data Source Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		5192BF1FAC59BB862809E170 /* libPods-Paging Data Source Example-Vokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Paging Data Source Example-Vokoder.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		5F4C27F44990A7306325BB7D /* Pods-Paging Data Source Example-Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example-Vokoder.xcconfig"; sourceTree = "<group>"; };
-		658CC86E630F629CE28471A0 /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
-		71136819973CAD436262759D /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		718E9E8DCEC59787D9C7FA35 /* libPods-Paging Data Source Example-ILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Paging Data Source Example-ILGDynamicObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		729C78A178AE689ACC40CA34 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		77156A4DEADAAC0583D0D926 /* Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
-		7F7E83619715DB55DB876DA9 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
-		80199AD60311A6837F1B7950 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
-		8AD5DBA9DE06C737F48994B0 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
-		8B910F19C6FA8435CF3957AE /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
-		8F891EFD74F73203BD22126E /* Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig"; sourceTree = "<group>"; };
-		A607AB1885D2FCFECBFC0687 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
-		B0EF6A8E523373B981C0DE44 /* Pods-Paging Data Source Example-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Paging Data Source Example-environment.h"; sourceTree = "<group>"; };
-		B0FE17B901C1DF6863C6AAE7 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
-		B19C0DB9E21A9C48691A0304 /* Pods-Paging Data Source Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Paging Data Source Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		BD89A43211C81BD301770887 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
-		BF38E4E2D83926AAA16009F7 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		C1E80B62BECC480A0FCA9B4B /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
-		C87E02C6DDC0F878B78EF885 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
-		D1E0F9DF5AE2AE42AAD0C98F /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
-		D2E6FCC443A937563572281F /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
-		E5C66DA4FADD4D1614105943 /* Pods-Paging Data Source Example-ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example-ILGDynamicObjC.xcconfig"; sourceTree = "<group>"; };
-		F93DDF2CFFBFEA5C0E57CDC1 /* Pods-Paging Data Source Example-Vokoder-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example-Vokoder-Private.xcconfig"; sourceTree = "<group>"; };
-		F94DFE2C66B0403A4F2BA8B2 /* Pods-Paging Data Source Example-Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-Vokoder-dummy.m"; sourceTree = "<group>"; };
+		09F52655DC2613DED783F145 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
+		0C7B42CB3E5B0C034C52565E /* Pods-Paging Data Source Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-resources.sh"; sourceTree = "<group>"; };
+		10B99166F2EAB46EC7B26A9E /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
+		124A4965AC2C604D201BF979 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
+		1257F4AB38BDCDBA69CC3BFD /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		13AC27B9500718A2739C4DD6 /* libPods-Paging Data Source Example-ILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Paging Data Source Example-ILGDynamicObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1457FEFBE23618947D11DE2E /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
+		1CC47EB66E89847E80F64DE0 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		2645CC430A1306D2979F81E6 /* Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
+		29F5F49A69C847A6CD24331B /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
+		2FA479D7D1797279A3E2FE3C /* Pods-Paging Data Source Example-ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example-ILGDynamicObjC.xcconfig"; sourceTree = "<group>"; };
+		310367659493797777FA81DA /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		48CF30649C8B990BAFB0C59E /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		4B953F453ABCB12A14204827 /* Pods-Paging Data Source Example-Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example-Vokoder.xcconfig"; sourceTree = "<group>"; };
+		4BCA3A8FDC6714100880EC57 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		58D469E4272554439558F964 /* Pods-Paging Data Source Example-Vokoder-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example-Vokoder-Private.xcconfig"; sourceTree = "<group>"; };
+		5B519117CE157DC0133F0C70 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
+		655EE9475A16EF706978EF54 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
+		65F722F06B88B7805BDAE8E3 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
+		67D83BFE9FBCA4CA1106ED00 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		6E3EFEB85477AA68B9C995CC /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
+		6F8174152609505486485A36 /* libPods-Paging Data Source Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Paging Data Source Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A6FB27EFDA24B3A13AEF7AA /* Pods-Paging Data Source Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-dummy.m"; sourceTree = "<group>"; };
+		7B11DFB14202081C8B24169D /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
+		86BF8D6F43CD613036DD6D1B /* Pods-Paging Data Source Example-Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Paging Data Source Example-Vokoder-prefix.pch"; sourceTree = "<group>"; };
+		8EB18887028DD735E7A52CA0 /* Pods-Paging Data Source Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Paging Data Source Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		908D284C4DA682786E883DB9 /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
+		95CEDC59C91B2D19B106DB8A /* Pods-Paging Data Source Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.release.xcconfig"; sourceTree = "<group>"; };
+		991FD1793B0066292017E0B3 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
+		A4D475B7DC8041737DF64AF3 /* Pods-Paging Data Source Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.debug.xcconfig"; sourceTree = "<group>"; };
+		A6EA1EB05E9F94CA7F3C5212 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
+		AF3441DD1BD85B7C81AC34FF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		B8F59FBE2C63E927CD97E2FF /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		BA58B1C61EA58C1ABAEC654C /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
+		C05FB1A8176C8F10981669F1 /* Pods-Paging Data Source Example-Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-Vokoder-dummy.m"; sourceTree = "<group>"; };
+		C770792E16960EFEBD1B5F5F /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
+		CBE500A20F04CDFA6F822489 /* Pods-Paging Data Source Example-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Paging Data Source Example-environment.h"; sourceTree = "<group>"; };
+		D776D397C6F5DA57CDE59C15 /* libPods-Paging Data Source Example-Vokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Paging Data Source Example-Vokoder.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC3298905754B84ED069F196 /* Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig"; sourceTree = "<group>"; };
+		E39D4A861F3CE4741F5EE8AA /* Pods-Paging Data Source Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Paging Data Source Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		FDA633EB67C400882CD04280 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		583FAADA2C131353D1CAB5A1 /* Frameworks */ = {
+		6DD4DD91DB0D145A156968E7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0168610B2686C2FB3E4A9562 /* Foundation.framework in Frameworks */,
+				00E07C326A645FB06374EC04 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8CF0BC6C6F850D7392F03C5B /* Frameworks */ = {
+		A1CE8AD0F0426DA699FF00D7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8B2F043A3273B968D617F7E /* CoreData.framework in Frameworks */,
-				354D98FCB65FA0F684E96470 /* Foundation.framework in Frameworks */,
+				68E879681B38A8133B9DFABA /* CoreData.framework in Frameworks */,
+				750492D9B007FC1B218C361C /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DEF6F6FD3CDEDC4B680162C4 /* Frameworks */ = {
+		BDEC679B56391F1029FD11BE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D4BB386B12F2118F124C6390 /* Foundation.framework in Frameworks */,
+				9B7789DB1195B7B64FED7FA7 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1CFF0287AD9C9C1FE94AC43D /* Pods-Paging Data Source Example */ = {
+		02B2FA30EF5981CBDA840CE7 = {
 			isa = PBXGroup;
 			children = (
-				0ABD46C3A9A191652BFDDEBA /* Pods-Paging Data Source Example-acknowledgements.markdown */,
-				B19C0DB9E21A9C48691A0304 /* Pods-Paging Data Source Example-acknowledgements.plist */,
-				1A529D08657D9DBE70F1BAB3 /* Pods-Paging Data Source Example-dummy.m */,
-				B0EF6A8E523373B981C0DE44 /* Pods-Paging Data Source Example-environment.h */,
-				29113B9F42A204EAE4DE99C2 /* Pods-Paging Data Source Example-resources.sh */,
-				1599B07B8A96F0E829496706 /* Pods-Paging Data Source Example.debug.xcconfig */,
-				37EB2CD6865F64D7B0BF13FE /* Pods-Paging Data Source Example.release.xcconfig */,
+				48CF30649C8B990BAFB0C59E /* Podfile */,
+				32679C5CF9EAC3D1E1F9F280 /* Development Pods */,
+				D1B5088847F5DF3EAC9069D2 /* Frameworks */,
+				E88BAE61ABA8D7B9513045A7 /* Pods */,
+				205EDFEDBD819D9B83C54879 /* Products */,
+				140AADF5E985A2D4DA03E1E2 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		039503A967447CA668E7EB49 /* Optional Data Sources */ = {
+			isa = PBXGroup;
+			children = (
+				1457FEFBE23618947D11DE2E /* VOKCollectionDataSource.h */,
+				C770792E16960EFEBD1B5F5F /* VOKCollectionDataSource.m */,
+			);
+			path = "Optional Data Sources";
+			sourceTree = "<group>";
+		};
+		04DD15575E849C7945F5C09F /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				67D83BFE9FBCA4CA1106ED00 /* CoreData.framework */,
+				AF3441DD1BD85B7C81AC34FF /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		0AB91E97B6EB9692645CEB33 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				039503A967447CA668E7EB49 /* Optional Data Sources */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		140AADF5E985A2D4DA03E1E2 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				169C2415B51C639781825B81 /* Pods-Paging Data Source Example */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		169C2415B51C639781825B81 /* Pods-Paging Data Source Example */ = {
+			isa = PBXGroup;
+			children = (
+				8EB18887028DD735E7A52CA0 /* Pods-Paging Data Source Example-acknowledgements.markdown */,
+				E39D4A861F3CE4741F5EE8AA /* Pods-Paging Data Source Example-acknowledgements.plist */,
+				7A6FB27EFDA24B3A13AEF7AA /* Pods-Paging Data Source Example-dummy.m */,
+				CBE500A20F04CDFA6F822489 /* Pods-Paging Data Source Example-environment.h */,
+				0C7B42CB3E5B0C034C52565E /* Pods-Paging Data Source Example-resources.sh */,
+				A4D475B7DC8041737DF64AF3 /* Pods-Paging Data Source Example.debug.xcconfig */,
+				95CEDC59C91B2D19B106DB8A /* Pods-Paging Data Source Example.release.xcconfig */,
 			);
 			name = "Pods-Paging Data Source Example";
 			path = "Target Support Files/Pods-Paging Data Source Example";
 			sourceTree = "<group>";
 		};
-		203527C272CDF1D2DC31346D /* Development Pods */ = {
+		171645E0E45DA2751F43674E /* Vokoder */ = {
 			isa = PBXGroup;
 			children = (
-				DEE597D6EA26F111C377BD7A /* Vokoder */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		3DD196D1C9244F5BDE0B917D /* Optional Data Sources */ = {
-			isa = PBXGroup;
-			children = (
-				8B910F19C6FA8435CF3957AE /* VOKFetchedResultsDataSource.h */,
-				28923859671E76797C3C2888 /* VOKFetchedResultsDataSource.m */,
-			);
-			path = "Optional Data Sources";
-			sourceTree = "<group>";
-		};
-		4999EBA97DCD8DB77F58CC49 /* DataSources */ = {
-			isa = PBXGroup;
-			children = (
-				F2C3510CFED169D2B2C6E4E8 /* Collection */,
-				6E1F2C0B1225C59BE9DAC336 /* FetchedResults */,
-				560D66CCD528750337264AED /* PagingFetchedResults */,
-			);
-			name = DataSources;
-			sourceTree = "<group>";
-		};
-		4D63233E5096FEDD50CBB8FB /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				3B41A2767D3AEC18E58C782A /* libPods-Paging Data Source Example.a */,
-				718E9E8DCEC59787D9C7FA35 /* libPods-Paging Data Source Example-ILGDynamicObjC.a */,
-				5192BF1FAC59BB862809E170 /* libPods-Paging Data Source Example-Vokoder.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		5537B5F39DBE63B9E81CE4C9 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				B0FE17B901C1DF6863C6AAE7 /* NSManagedObject+VOKManagedObjectAdditions.h */,
-				11FC65BCA8C5C1E84AFA2A47 /* NSManagedObject+VOKManagedObjectAdditions.m */,
-				08CBFFB479E6F90F3C428CA5 /* VOKCoreDataManager.h */,
-				0119C7BF58153399A9AA690C /* VOKCoreDataManager.m */,
-				BD89A43211C81BD301770887 /* VOKManagedObjectMap.h */,
-				C87E02C6DDC0F878B78EF885 /* VOKManagedObjectMap.m */,
-				2F9A647B3B3EBA5FA89AE0BA /* VOKManagedObjectMapper.h */,
-				02B780094B6D8222809E7F31 /* VOKManagedObjectMapper.m */,
-				D2E6FCC443A937563572281F /* VOKMappableModel.h */,
-				7AD4F0F5B0261F2CB1F2C010 /* Internal */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		560D66CCD528750337264AED /* PagingFetchedResults */ = {
-			isa = PBXGroup;
-			children = (
-				B46BF5980ECC727363D6D948 /* Pod */,
-			);
-			name = PagingFetchedResults;
-			sourceTree = "<group>";
-		};
-		63C837472D549F2B4028F07D /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				AAECC0F38AFDC6D173BC1CFE /* Pod */,
-			);
-			name = Core;
-			sourceTree = "<group>";
-		};
-		64C533B5C29BD0610D3CAAC1 = {
-			isa = PBXGroup;
-			children = (
-				BF38E4E2D83926AAA16009F7 /* Podfile */,
-				203527C272CDF1D2DC31346D /* Development Pods */,
-				D38EB1E3B37DA358B197D895 /* Frameworks */,
-				6F8741877FC9FE2AA0F6CEAC /* Pods */,
-				4D63233E5096FEDD50CBB8FB /* Products */,
-				B323EAB5A07D526721832389 /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		6E1F2C0B1225C59BE9DAC336 /* FetchedResults */ = {
-			isa = PBXGroup;
-			children = (
-				7A17DEEA8EA80AC014658269 /* Pod */,
-			);
-			name = FetchedResults;
-			sourceTree = "<group>";
-		};
-		6F8741877FC9FE2AA0F6CEAC /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				81C38DAAC4F15DCF4DF00968 /* ILGDynamicObjC */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		7969880783AF2D96694C6FC9 /* ILGClasses */ = {
-			isa = PBXGroup;
-			children = (
-				658CC86E630F629CE28471A0 /* ILGClasses.h */,
-				A607AB1885D2FCFECBFC0687 /* ILGClasses.m */,
-			);
-			name = ILGClasses;
-			sourceTree = "<group>";
-		};
-		7A17DEEA8EA80AC014658269 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				9E0FD15EFB769FA3BEF5C2DA /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		7AD4F0F5B0261F2CB1F2C010 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				80199AD60311A6837F1B7950 /* VOKCoreDataManagerInternalMacros.h */,
-			);
-			path = Internal;
-			sourceTree = "<group>";
-		};
-		81C38DAAC4F15DCF4DF00968 /* ILGDynamicObjC */ = {
-			isa = PBXGroup;
-			children = (
-				7969880783AF2D96694C6FC9 /* ILGClasses */,
-				B178AD794B49BFB68BFF189E /* Support Files */,
-			);
-			path = ILGDynamicObjC;
-			sourceTree = "<group>";
-		};
-		8BC798A1E0504EC5A225C745 /* Optional Data Sources */ = {
-			isa = PBXGroup;
-			children = (
-				D1E0F9DF5AE2AE42AAD0C98F /* VOKCollectionDataSource.h */,
-				0659057EACEDB1AE3E2FF0D5 /* VOKCollectionDataSource.m */,
-			);
-			path = "Optional Data Sources";
-			sourceTree = "<group>";
-		};
-		9167C2F7F05069912EC6CC44 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				FB0CC8129CC9E03DB7ABACC6 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		9E0FD15EFB769FA3BEF5C2DA /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				3DD196D1C9244F5BDE0B917D /* Optional Data Sources */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		A640523864D9A6B0347F1656 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				3ACDBA97DF71A3C0A8EBA7DC /* CoreData.framework */,
-				729C78A178AE689ACC40CA34 /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		AAECC0F38AFDC6D173BC1CFE /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				5537B5F39DBE63B9E81CE4C9 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		B08391F10B481D2B3BC482B6 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				C8B59810B724624AEBC047AD /* Optional Data Sources */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		B178AD794B49BFB68BFF189E /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				E5C66DA4FADD4D1614105943 /* Pods-Paging Data Source Example-ILGDynamicObjC.xcconfig */,
-				8F891EFD74F73203BD22126E /* Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig */,
-				8AD5DBA9DE06C737F48994B0 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m */,
-				77156A4DEADAAC0583D0D926 /* Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-Paging Data Source Example-ILGDynamicObjC";
-			sourceTree = "<group>";
-		};
-		B323EAB5A07D526721832389 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				1CFF0287AD9C9C1FE94AC43D /* Pods-Paging Data Source Example */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		B46BF5980ECC727363D6D948 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				B08391F10B481D2B3BC482B6 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		C8B59810B724624AEBC047AD /* Optional Data Sources */ = {
-			isa = PBXGroup;
-			children = (
-				1D7980A8DB21FEB74D734253 /* VOKDefaultPagingAccessory.h */,
-				C1E80B62BECC480A0FCA9B4B /* VOKDefaultPagingAccessory.m */,
-				7F7E83619715DB55DB876DA9 /* VOKPagingFetchedResultsDataSource.h */,
-				71136819973CAD436262759D /* VOKPagingFetchedResultsDataSource.m */,
-			);
-			path = "Optional Data Sources";
-			sourceTree = "<group>";
-		};
-		CCD4CC501836E6731865FCE4 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				5F4C27F44990A7306325BB7D /* Pods-Paging Data Source Example-Vokoder.xcconfig */,
-				F93DDF2CFFBFEA5C0E57CDC1 /* Pods-Paging Data Source Example-Vokoder-Private.xcconfig */,
-				F94DFE2C66B0403A4F2BA8B2 /* Pods-Paging Data Source Example-Vokoder-dummy.m */,
-				36B5F0CB22AEB6761C77CB3E /* Pods-Paging Data Source Example-Vokoder-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "Paging Data Source Example/Pods/Target Support Files/Pods-Paging Data Source Example-Vokoder";
-			sourceTree = "<group>";
-		};
-		D38EB1E3B37DA358B197D895 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				A640523864D9A6B0347F1656 /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		DEE597D6EA26F111C377BD7A /* Vokoder */ = {
-			isa = PBXGroup;
-			children = (
-				63C837472D549F2B4028F07D /* Core */,
-				4999EBA97DCD8DB77F58CC49 /* DataSources */,
-				CCD4CC501836E6731865FCE4 /* Support Files */,
+				7BBF4DEFEFD75CF1EDFF812F /* Core */,
+				F8FE1F2D4D2136AF3D8B9D99 /* DataSources */,
+				E7C43C73ECE19FD4ED1DDBA0 /* Support Files */,
 			);
 			name = Vokoder;
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		F2C3510CFED169D2B2C6E4E8 /* Collection */ = {
+		1A89A38BA05D853D1715F840 /* Optional Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				9167C2F7F05069912EC6CC44 /* Pod */,
+				09F52655DC2613DED783F145 /* VOKDefaultPagingAccessory.h */,
+				908D284C4DA682786E883DB9 /* VOKDefaultPagingAccessory.m */,
+				1257F4AB38BDCDBA69CC3BFD /* VOKPagingFetchedResultsDataSource.h */,
+				310367659493797777FA81DA /* VOKPagingFetchedResultsDataSource.m */,
+			);
+			path = "Optional Data Sources";
+			sourceTree = "<group>";
+		};
+		1BBA019B7A5387019EE0004A /* ILGDynamicObjC */ = {
+			isa = PBXGroup;
+			children = (
+				E5637BE08550F1ED3828F768 /* ILGClasses */,
+				F61B2631C3D034D8FB22B9D5 /* Support Files */,
+			);
+			path = ILGDynamicObjC;
+			sourceTree = "<group>";
+		};
+		205EDFEDBD819D9B83C54879 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6F8174152609505486485A36 /* libPods-Paging Data Source Example.a */,
+				13AC27B9500718A2739C4DD6 /* libPods-Paging Data Source Example-ILGDynamicObjC.a */,
+				D776D397C6F5DA57CDE59C15 /* libPods-Paging Data Source Example-Vokoder.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		293C4A582406957E3F8B014C /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				124A4965AC2C604D201BF979 /* VOKCoreDataManagerInternalMacros.h */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		32679C5CF9EAC3D1E1F9F280 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				171645E0E45DA2751F43674E /* Vokoder */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		3DD617EBB6AEBD283F80E3C7 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				991FD1793B0066292017E0B3 /* NSManagedObject+VOKManagedObjectAdditions.h */,
+				5B519117CE157DC0133F0C70 /* NSManagedObject+VOKManagedObjectAdditions.m */,
+				BA58B1C61EA58C1ABAEC654C /* VOKCoreDataManager.h */,
+				B8F59FBE2C63E927CD97E2FF /* VOKCoreDataManager.m */,
+				655EE9475A16EF706978EF54 /* VOKManagedObjectMap.h */,
+				FDA633EB67C400882CD04280 /* VOKManagedObjectMap.m */,
+				10B99166F2EAB46EC7B26A9E /* VOKManagedObjectMapper.h */,
+				65F722F06B88B7805BDAE8E3 /* VOKManagedObjectMapper.m */,
+				29F5F49A69C847A6CD24331B /* VOKMappableModel.h */,
+				293C4A582406957E3F8B014C /* Internal */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		509B870E3606DDA6FAA8360B /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				1A89A38BA05D853D1715F840 /* Optional Data Sources */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		7BBF4DEFEFD75CF1EDFF812F /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				A71CA7A91EBB24D21F1EDE48 /* Pod */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
+		81BD6B67E5CD6548AEF242FA /* Collection */ = {
+			isa = PBXGroup;
+			children = (
+				9D235CA0306BF4BD387D7818 /* Pod */,
 			);
 			name = Collection;
 			sourceTree = "<group>";
 		};
-		FB0CC8129CC9E03DB7ABACC6 /* Classes */ = {
+		8865F8BD75BD080202861072 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				8BC798A1E0504EC5A225C745 /* Optional Data Sources */,
+				BD988948B754BB002286B88F /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		89F81539F503FE394A38B91E /* Optional Data Sources */ = {
+			isa = PBXGroup;
+			children = (
+				4BCA3A8FDC6714100880EC57 /* VOKFetchedResultsDataSource.h */,
+				1CC47EB66E89847E80F64DE0 /* VOKFetchedResultsDataSource.m */,
+			);
+			path = "Optional Data Sources";
+			sourceTree = "<group>";
+		};
+		9D235CA0306BF4BD387D7818 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				0AB91E97B6EB9692645CEB33 /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		A71CA7A91EBB24D21F1EDE48 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				3DD617EBB6AEBD283F80E3C7 /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		A9CEDA6AECAF164EB0FDDB65 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				509B870E3606DDA6FAA8360B /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		BD988948B754BB002286B88F /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				89F81539F503FE394A38B91E /* Optional Data Sources */,
 			);
 			path = Classes;
+			sourceTree = "<group>";
+		};
+		CD5062434C27E2836E0A2F1F /* PagingFetchedResults */ = {
+			isa = PBXGroup;
+			children = (
+				A9CEDA6AECAF164EB0FDDB65 /* Pod */,
+			);
+			name = PagingFetchedResults;
+			sourceTree = "<group>";
+		};
+		D1B5088847F5DF3EAC9069D2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				04DD15575E849C7945F5C09F /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D76BF595CA7B2C46D80A888A /* FetchedResults */ = {
+			isa = PBXGroup;
+			children = (
+				8865F8BD75BD080202861072 /* Pod */,
+			);
+			name = FetchedResults;
+			sourceTree = "<group>";
+		};
+		E5637BE08550F1ED3828F768 /* ILGClasses */ = {
+			isa = PBXGroup;
+			children = (
+				6E3EFEB85477AA68B9C995CC /* ILGClasses.h */,
+				7B11DFB14202081C8B24169D /* ILGClasses.m */,
+			);
+			name = ILGClasses;
+			sourceTree = "<group>";
+		};
+		E7C43C73ECE19FD4ED1DDBA0 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				4B953F453ABCB12A14204827 /* Pods-Paging Data Source Example-Vokoder.xcconfig */,
+				58D469E4272554439558F964 /* Pods-Paging Data Source Example-Vokoder-Private.xcconfig */,
+				C05FB1A8176C8F10981669F1 /* Pods-Paging Data Source Example-Vokoder-dummy.m */,
+				86BF8D6F43CD613036DD6D1B /* Pods-Paging Data Source Example-Vokoder-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "Paging Data Source Example/Pods/Target Support Files/Pods-Paging Data Source Example-Vokoder";
+			sourceTree = "<group>";
+		};
+		E88BAE61ABA8D7B9513045A7 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1BBA019B7A5387019EE0004A /* ILGDynamicObjC */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		F61B2631C3D034D8FB22B9D5 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				2FA479D7D1797279A3E2FE3C /* Pods-Paging Data Source Example-ILGDynamicObjC.xcconfig */,
+				DC3298905754B84ED069F196 /* Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig */,
+				A6EA1EB05E9F94CA7F3C5212 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m */,
+				2645CC430A1306D2979F81E6 /* Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-Paging Data Source Example-ILGDynamicObjC";
+			sourceTree = "<group>";
+		};
+		F8FE1F2D4D2136AF3D8B9D99 /* DataSources */ = {
+			isa = PBXGroup;
+			children = (
+				81BD6B67E5CD6548AEF242FA /* Collection */,
+				D76BF595CA7B2C46D80A888A /* FetchedResults */,
+				CD5062434C27E2836E0A2F1F /* PagingFetchedResults */,
+			);
+			name = DataSources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		B44384BCBE0249C8DDBF2205 /* Headers */ = {
+		134BF91295BFAB11891CB235 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				923F526A4D060C823987FD37 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				04BBFE18E90747DDAA42592F /* VOKCollectionDataSource.h in Headers */,
-				3C53D276B7862B25776AF68D /* VOKCoreDataManager.h in Headers */,
-				142E46E1C075CB5E6675F682 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				295EE40B9B29E7AE8061FDE5 /* VOKDefaultPagingAccessory.h in Headers */,
-				04A4FF39C0141A580DB2B11B /* VOKFetchedResultsDataSource.h in Headers */,
-				503FEE14CEC9CF2164D0E842 /* VOKManagedObjectMap.h in Headers */,
-				11C0140D5DB61C495C764073 /* VOKManagedObjectMapper.h in Headers */,
-				B22943A7075EC2C19C358E63 /* VOKMappableModel.h in Headers */,
-				086F4B9770161BF83AA8CD5B /* VOKPagingFetchedResultsDataSource.h in Headers */,
+				636AFB0A5BB0BA4FBC67286D /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				2028F0570847E431D0D6B9C8 /* VOKCollectionDataSource.h in Headers */,
+				AC085D02F559847F1E555592 /* VOKCoreDataManager.h in Headers */,
+				2DF3533A4C9045D7B39CC03D /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				BCBB3337C937DAB26D47C6BF /* VOKDefaultPagingAccessory.h in Headers */,
+				F42883CF21E658E9B2E75196 /* VOKFetchedResultsDataSource.h in Headers */,
+				A319D9AF46ED81C40EC5D419 /* VOKManagedObjectMap.h in Headers */,
+				853BB73399024489D9CEAE4D /* VOKManagedObjectMapper.h in Headers */,
+				ECA4718FBF1389BDFE9D1AB7 /* VOKMappableModel.h in Headers */,
+				7C7984BC3C0F54802F9D1E0C /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F15CF35D89A0276A80974B64 /* Headers */ = {
+		BE4A8878C21C83FFBC292051 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3DC9334296BF41407AD7310 /* ILGClasses.h in Headers */,
+				B8A9EE27177F3A6546B08FB9 /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		1C54BB48D7B5CF9BACD15A96 /* Pods-Paging Data Source Example */ = {
+		225DAD07AB73BEEBA101B107 /* Pods-Paging Data Source Example */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 40BE2B2C65A38ACA5EF55416 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example" */;
+			buildConfigurationList = FA608589CF891F57A3F4F235 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example" */;
 			buildPhases = (
-				1C3AE0462263E9CD7CF8685E /* Sources */,
-				DEF6F6FD3CDEDC4B680162C4 /* Frameworks */,
+				CE4393051CAFB81E1EE500FD /* Sources */,
+				6DD4DD91DB0D145A156968E7 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				C8F05AB2E36FAD9241BF291A /* PBXTargetDependency */,
-				7EA9F238EF0572C75E0DA36B /* PBXTargetDependency */,
+				53C4D693B80D885AF6C00AD1 /* PBXTargetDependency */,
+				BB0A0139D1383D78BB32B576 /* PBXTargetDependency */,
 			);
 			name = "Pods-Paging Data Source Example";
 			productName = "Pods-Paging Data Source Example";
-			productReference = 3B41A2767D3AEC18E58C782A /* libPods-Paging Data Source Example.a */;
+			productReference = 6F8174152609505486485A36 /* libPods-Paging Data Source Example.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		AF08C7801A40CFB4E62E9A3A /* Pods-Paging Data Source Example-ILGDynamicObjC */ = {
+		C102B8C9884E78365BF14F1A /* Pods-Paging Data Source Example-ILGDynamicObjC */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 16CF4B5AD243E208EDD0238C /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example-ILGDynamicObjC" */;
+			buildConfigurationList = 808783577333E39E8D132368 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example-ILGDynamicObjC" */;
 			buildPhases = (
-				73DAF32C3FC0C220A78DA18E /* Sources */,
-				583FAADA2C131353D1CAB5A1 /* Frameworks */,
-				F15CF35D89A0276A80974B64 /* Headers */,
+				A4F801F6D757FB8119E62800 /* Sources */,
+				BDEC679B56391F1029FD11BE /* Frameworks */,
+				BE4A8878C21C83FFBC292051 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -479,115 +479,115 @@
 			);
 			name = "Pods-Paging Data Source Example-ILGDynamicObjC";
 			productName = "Pods-Paging Data Source Example-ILGDynamicObjC";
-			productReference = 718E9E8DCEC59787D9C7FA35 /* libPods-Paging Data Source Example-ILGDynamicObjC.a */;
+			productReference = 13AC27B9500718A2739C4DD6 /* libPods-Paging Data Source Example-ILGDynamicObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		D01F6DA2324F7AF192C821CB /* Pods-Paging Data Source Example-Vokoder */ = {
+		E2C01E9D8E24D95FE689851F /* Pods-Paging Data Source Example-Vokoder */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 9483A020DFFD460328866471 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example-Vokoder" */;
+			buildConfigurationList = B91BE8F525BC58EB1FAB89FF /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example-Vokoder" */;
 			buildPhases = (
-				F68E8A9B4D4A1F40B5D31D7F /* Sources */,
-				8CF0BC6C6F850D7392F03C5B /* Frameworks */,
-				B44384BCBE0249C8DDBF2205 /* Headers */,
+				E93D219ACBD22FBA712EE9DE /* Sources */,
+				A1CE8AD0F0426DA699FF00D7 /* Frameworks */,
+				134BF91295BFAB11891CB235 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				F68F4394866BE14C43421497 /* PBXTargetDependency */,
+				9F2E88538F3DFAF4C4BCEFB8 /* PBXTargetDependency */,
 			);
 			name = "Pods-Paging Data Source Example-Vokoder";
 			productName = "Pods-Paging Data Source Example-Vokoder";
-			productReference = 5192BF1FAC59BB862809E170 /* libPods-Paging Data Source Example-Vokoder.a */;
+			productReference = D776D397C6F5DA57CDE59C15 /* libPods-Paging Data Source Example-Vokoder.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		53C0A2E3383644D3A31F90A3 /* Project object */ = {
+		2BFADA3CDB76F77DBB155234 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0640;
 			};
-			buildConfigurationList = 6250EF8B498A8A69D50035AC /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = D26A503551C08C0F2C5D38E5 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 64C533B5C29BD0610D3CAAC1;
-			productRefGroup = 4D63233E5096FEDD50CBB8FB /* Products */;
+			mainGroup = 02B2FA30EF5981CBDA840CE7;
+			productRefGroup = 205EDFEDBD819D9B83C54879 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				1C54BB48D7B5CF9BACD15A96 /* Pods-Paging Data Source Example */,
-				AF08C7801A40CFB4E62E9A3A /* Pods-Paging Data Source Example-ILGDynamicObjC */,
-				D01F6DA2324F7AF192C821CB /* Pods-Paging Data Source Example-Vokoder */,
+				225DAD07AB73BEEBA101B107 /* Pods-Paging Data Source Example */,
+				C102B8C9884E78365BF14F1A /* Pods-Paging Data Source Example-ILGDynamicObjC */,
+				E2C01E9D8E24D95FE689851F /* Pods-Paging Data Source Example-Vokoder */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		1C3AE0462263E9CD7CF8685E /* Sources */ = {
+		A4F801F6D757FB8119E62800 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B8D499404FA8638E340E766 /* Pods-Paging Data Source Example-dummy.m in Sources */,
+				0FEEAD2438C9B134F75EF547 /* ILGClasses.m in Sources */,
+				4FA3259D8B5AD9A0E21DCBA1 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		73DAF32C3FC0C220A78DA18E /* Sources */ = {
+		CE4393051CAFB81E1EE500FD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				543DD3C0E180A505EE25C972 /* ILGClasses.m in Sources */,
-				1DF9D78E6526898B815CACF3 /* Pods-Paging Data Source Example-ILGDynamicObjC-dummy.m in Sources */,
+				76E6B0144B458797FB0A18ED /* Pods-Paging Data Source Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F68E8A9B4D4A1F40B5D31D7F /* Sources */ = {
+		E93D219ACBD22FBA712EE9DE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				81FC7146B93D41DF23DA987B /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				138ABCD68577BBB46C71BC69 /* Pods-Paging Data Source Example-Vokoder-dummy.m in Sources */,
-				DF34EA35DF16B26A112079C4 /* VOKCollectionDataSource.m in Sources */,
-				68265077C3AB29D3E45B6A32 /* VOKCoreDataManager.m in Sources */,
-				1BC89B48437D29C27AB413DD /* VOKDefaultPagingAccessory.m in Sources */,
-				4807974D1ACCA8FAD1780AE5 /* VOKFetchedResultsDataSource.m in Sources */,
-				D7FDA5F49B0123EF8B0883C0 /* VOKManagedObjectMap.m in Sources */,
-				17A332725AC579B9C6BE2EF1 /* VOKManagedObjectMapper.m in Sources */,
-				3A5D8F55DF52EDC296A668B7 /* VOKPagingFetchedResultsDataSource.m in Sources */,
+				0E82BCB1E319D7DD3E02FC7A /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				DEE45D8150BC692321945E72 /* Pods-Paging Data Source Example-Vokoder-dummy.m in Sources */,
+				1503CD19E4AC5D623D6C57AD /* VOKCollectionDataSource.m in Sources */,
+				27394CB094B017A4AA2B4E58 /* VOKCoreDataManager.m in Sources */,
+				863CDCAC2CD5F8AF731DF165 /* VOKDefaultPagingAccessory.m in Sources */,
+				5A14564514A32B275A1FB282 /* VOKFetchedResultsDataSource.m in Sources */,
+				5813B23FAACCE03EB96DA367 /* VOKManagedObjectMap.m in Sources */,
+				DC3779C0025EDF2DD0C7ADAE /* VOKManagedObjectMapper.m in Sources */,
+				27E5788960E285CAFA7EEFDD /* VOKPagingFetchedResultsDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		7EA9F238EF0572C75E0DA36B /* PBXTargetDependency */ = {
+		53C4D693B80D885AF6C00AD1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-Paging Data Source Example-ILGDynamicObjC";
+			target = C102B8C9884E78365BF14F1A /* Pods-Paging Data Source Example-ILGDynamicObjC */;
+			targetProxy = 41BC06F1185BCA05FB3AB71E /* PBXContainerItemProxy */;
+		};
+		9F2E88538F3DFAF4C4BCEFB8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-Paging Data Source Example-ILGDynamicObjC";
+			target = C102B8C9884E78365BF14F1A /* Pods-Paging Data Source Example-ILGDynamicObjC */;
+			targetProxy = 74D4C398749F503F086AAAFD /* PBXContainerItemProxy */;
+		};
+		BB0A0139D1383D78BB32B576 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-Paging Data Source Example-Vokoder";
-			target = D01F6DA2324F7AF192C821CB /* Pods-Paging Data Source Example-Vokoder */;
-			targetProxy = 19F500D054756C30BBE6A138 /* PBXContainerItemProxy */;
-		};
-		C8F05AB2E36FAD9241BF291A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-Paging Data Source Example-ILGDynamicObjC";
-			target = AF08C7801A40CFB4E62E9A3A /* Pods-Paging Data Source Example-ILGDynamicObjC */;
-			targetProxy = 88573DF23BCCCBA773558D0B /* PBXContainerItemProxy */;
-		};
-		F68F4394866BE14C43421497 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-Paging Data Source Example-ILGDynamicObjC";
-			target = AF08C7801A40CFB4E62E9A3A /* Pods-Paging Data Source Example-ILGDynamicObjC */;
-			targetProxy = 7FCE0D33EC3B27BA2A0E79F5 /* PBXContainerItemProxy */;
+			target = E2C01E9D8E24D95FE689851F /* Pods-Paging Data Source Example-Vokoder */;
+			targetProxy = 692CA483DD8F9A8C0FB7CF47 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		339493C9EF0211E30F364B9F /* Release */ = {
+		365C7DCCE1A86AA41C99133B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F93DDF2CFFBFEA5C0E57CDC1 /* Pods-Paging Data Source Example-Vokoder-Private.xcconfig */;
+			baseConfigurationReference = 58D469E4272554439558F964 /* Pods-Paging Data Source Example-Vokoder-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-Paging Data Source Example-Vokoder/Pods-Paging Data Source Example-Vokoder-prefix.pch";
@@ -601,7 +601,39 @@
 			};
 			name = Release;
 		};
-		366FFCE58F07F3E8504A7203 /* Release */ = {
+		48D805EBD20349AB8357F74A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 95CEDC59C91B2D19B106DB8A /* Pods-Paging Data Source Example.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		4EA17E4E881B1D64641A6370 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A4D475B7DC8041737DF64AF3 /* Pods-Paging Data Source Example.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		673EE6F24CE09B5B5ADFECC5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -635,41 +667,9 @@
 			};
 			name = Release;
 		};
-		54DEA8F72C7E2E80E66E3293 /* Release */ = {
+		74B930CE34691D42B2DAB332 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 37EB2CD6865F64D7B0BF13FE /* Pods-Paging Data Source Example.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		A0AF9247333E7986B0954690 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1599B07B8A96F0E829496706 /* Pods-Paging Data Source Example.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		ACE038C5B35F4D4368EB7072 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8F891EFD74F73203BD22126E /* Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig */;
+			baseConfigurationReference = DC3298905754B84ED069F196 /* Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-Paging Data Source Example-ILGDynamicObjC/Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch";
@@ -683,39 +683,7 @@
 			};
 			name = Release;
 		};
-		AFBD5DEF58124C42FAF7A9F3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8F891EFD74F73203BD22126E /* Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-Paging Data Source Example-ILGDynamicObjC/Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		B7078DEB70566FE4B58FE20A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F93DDF2CFFBFEA5C0E57CDC1 /* Pods-Paging Data Source Example-Vokoder-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-Paging Data Source Example-Vokoder/Pods-Paging Data Source Example-Vokoder-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		B732567F97859F7A20BC1554 /* Debug */ = {
+		BE621102886C9285C6ED579B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -754,46 +722,78 @@
 			};
 			name = Debug;
 		};
+		C5F0332DB6C1B7BB7FD3D84C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DC3298905754B84ED069F196 /* Pods-Paging Data Source Example-ILGDynamicObjC-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-Paging Data Source Example-ILGDynamicObjC/Pods-Paging Data Source Example-ILGDynamicObjC-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		CB67C46531F476E60DE5E3BE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 58D469E4272554439558F964 /* Pods-Paging Data Source Example-Vokoder-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-Paging Data Source Example-Vokoder/Pods-Paging Data Source Example-Vokoder-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		16CF4B5AD243E208EDD0238C /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example-ILGDynamicObjC" */ = {
+		808783577333E39E8D132368 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example-ILGDynamicObjC" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				AFBD5DEF58124C42FAF7A9F3 /* Debug */,
-				ACE038C5B35F4D4368EB7072 /* Release */,
+				C5F0332DB6C1B7BB7FD3D84C /* Debug */,
+				74B930CE34691D42B2DAB332 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		40BE2B2C65A38ACA5EF55416 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example" */ = {
+		B91BE8F525BC58EB1FAB89FF /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example-Vokoder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A0AF9247333E7986B0954690 /* Debug */,
-				54DEA8F72C7E2E80E66E3293 /* Release */,
+				CB67C46531F476E60DE5E3BE /* Debug */,
+				365C7DCCE1A86AA41C99133B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6250EF8B498A8A69D50035AC /* Build configuration list for PBXProject "Pods" */ = {
+		D26A503551C08C0F2C5D38E5 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B732567F97859F7A20BC1554 /* Debug */,
-				366FFCE58F07F3E8504A7203 /* Release */,
+				BE621102886C9285C6ED579B /* Debug */,
+				673EE6F24CE09B5B5ADFECC5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		9483A020DFFD460328866471 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example-Vokoder" */ = {
+		FA608589CF891F57A3F4F235 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B7078DEB70566FE4B58FE20A /* Debug */,
-				339493C9EF0211E30F364B9F /* Release */,
+				4EA17E4E881B1D64641A6370 /* Debug */,
+				48D805EBD20349AB8357F74A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 53C0A2E3383644D3A31F90A3 /* Project object */;
+	rootObject = 2BFADA3CDB76F77DBB155234 /* Project object */;
 }

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-Paging Data Source Example-Vokoder.xcscheme
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-Paging Data Source Example-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D01F6DA2324F7AF192C821CB"
+               BlueprintIdentifier = "E2C01E9D8E24D95FE689851F"
                BuildableName = "libPods-Paging Data Source Example-Vokoder.a"
                BlueprintName = "Pods-Paging Data Source Example-Vokoder"
                ReferencedContainer = "container:Pods.xcodeproj">

--- a/Paging Data Source Example/Pods/Target Support Files/Pods-Paging Data Source Example/Pods-Paging Data Source Example-environment.h
+++ b/Paging Data Source Example/Pods/Target Support Files/Pods-Paging Data Source Example/Pods-Paging Data Source Example-environment.h
@@ -16,35 +16,35 @@
 #define COCOAPODS_POD_AVAILABLE_Vokoder
 #define COCOAPODS_VERSION_MAJOR_Vokoder 1
 #define COCOAPODS_VERSION_MINOR_Vokoder 3
-#define COCOAPODS_VERSION_PATCH_Vokoder 0
+#define COCOAPODS_VERSION_PATCH_Vokoder 1
 
 // Vokoder/Core
 #define COCOAPODS_POD_AVAILABLE_Vokoder_Core
 #define COCOAPODS_VERSION_MAJOR_Vokoder_Core 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_Core 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_Core 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_Core 1
 
 // Vokoder/DataSources
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources 1
 
 // Vokoder/DataSources/Collection
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_Collection
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_Collection 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_Collection 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_Collection 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_Collection 1
 
 // Vokoder/DataSources/FetchedResults
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_FetchedResults
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_FetchedResults 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_FetchedResults 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_FetchedResults 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_FetchedResults 1
 
 // Vokoder/DataSources/PagingFetchedResults
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_PagingFetchedResults
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_PagingFetchedResults 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_PagingFetchedResults 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_PagingFetchedResults 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_PagingFetchedResults 1
 

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -6,7 +6,7 @@
 #import "VOKCoreDataManager.h"
 #import "VOKCoreDataManagerInternalMacros.h"
 
-#import <ILGClasses.h>
+#import <ILGDynamicObjC/ILGClasses.h>
 
 #import "VOKMappableModel.h"
 

--- a/SampleProject/Podfile.lock
+++ b/SampleProject/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (1.3.0):
-    - Vokoder/Core (= 1.3.0)
-    - Vokoder/DataSources (= 1.3.0)
-  - Vokoder/Core (1.3.0):
+  - Vokoder (1.3.1):
+    - Vokoder/Core (= 1.3.1)
+    - Vokoder/DataSources (= 1.3.1)
+  - Vokoder/Core (1.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (1.3.0):
+  - Vokoder/DataSources (1.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 1.3.0)
-    - Vokoder/DataSources/FetchedResults (= 1.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 1.3.0)
-  - Vokoder/DataSources/Collection (1.3.0):
+    - Vokoder/DataSources/Collection (= 1.3.1)
+    - Vokoder/DataSources/FetchedResults (= 1.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 1.3.1)
+  - Vokoder/DataSources/Collection (1.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (1.3.0):
+  - Vokoder/DataSources/FetchedResults (1.3.1):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (1.3.0):
+  - Vokoder/DataSources/PagingFetchedResults (1.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -28,6 +28,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: a0df009661b524b84712984bfa62af586c173a55
+  Vokoder: 1a89327504093c719b11c43a78cfc5c0501a4efd
 
 COCOAPODS: 0.37.2

--- a/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "1.3.0"
+    "tag": "1.3.1"
   },
   "platforms": {
     "ios": "7.0"

--- a/SampleProject/Pods/Manifest.lock
+++ b/SampleProject/Pods/Manifest.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (1.3.0):
-    - Vokoder/Core (= 1.3.0)
-    - Vokoder/DataSources (= 1.3.0)
-  - Vokoder/Core (1.3.0):
+  - Vokoder (1.3.1):
+    - Vokoder/Core (= 1.3.1)
+    - Vokoder/DataSources (= 1.3.1)
+  - Vokoder/Core (1.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (1.3.0):
+  - Vokoder/DataSources (1.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 1.3.0)
-    - Vokoder/DataSources/FetchedResults (= 1.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 1.3.0)
-  - Vokoder/DataSources/Collection (1.3.0):
+    - Vokoder/DataSources/Collection (= 1.3.1)
+    - Vokoder/DataSources/FetchedResults (= 1.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 1.3.1)
+  - Vokoder/DataSources/Collection (1.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (1.3.0):
+  - Vokoder/DataSources/FetchedResults (1.3.1):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (1.3.0):
+  - Vokoder/DataSources/PagingFetchedResults (1.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -28,6 +28,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: a0df009661b524b84712984bfa62af586c173a55
+  Vokoder: 1a89327504093c719b11c43a78cfc5c0501a4efd
 
 COCOAPODS: 0.37.2

--- a/SampleProject/Pods/Pods.xcodeproj/project.pbxproj
+++ b/SampleProject/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,596 +7,596 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		01409387B124CB24BF4C8D89 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DEFE45A30142A6EF1759457 /* VOKCollectionDataSource.m */; };
-		0F16DF322BB7F5F5A8FD3D90 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = B56DBB010175394AD01AB12B /* VOKManagedObjectMapper.h */; };
-		1326A199B468C6D5C0FD38FB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AB02B1DA42EC8DBE72DFBF /* Foundation.framework */; };
-		19CD89582E78CE5D52D7019B /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 881B930B9900C6085EDD8B2D /* ILGClasses.h */; };
-		1FBBA2C0B52C6677484A3503 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F1E06CD7AC5D1FF8C99D3DA6 /* NSManagedObject+VOKManagedObjectAdditions.h */; };
-		2F715CEF73CB9E868B8661F0 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D7996F54BA32D185C1026A4 /* VOKFetchedResultsDataSource.m */; };
-		309A5BB5ED14E49C6CF4173C /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = B1CDC2D63BF84F9D7C150CCB /* VOKDefaultPagingAccessory.h */; };
-		33D70915190812DD11755229 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = F8CF8D32198F048EAA55A2E0 /* VOKManagedObjectMap.m */; };
-		3A9999C2C481CB6CBC24A310 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2AC32312A2F94ADCE880D0 /* VOKCoreDataManagerInternalMacros.h */; };
-		41970CBC038E201DD86E7DA0 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A2A2542D89A0030DE08727 /* VOKCoreDataManager.m */; };
-		49FD1DF47E594BEAF971167D /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 27FA172F5B90AA134A1E29B7 /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m */; };
-		4EC1FC8D00075CFBE73079CC /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A2A2542D89A0030DE08727 /* VOKCoreDataManager.m */; };
-		4ED51C63CD4BE5D91474ED4C /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 94000D63406F8B149396E63A /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		587031C9D3436D1DBB9465BD /* Pods-VOKCoreDataManager-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B793AA504F96340A4B5FA5 /* Pods-VOKCoreDataManager-dummy.m */; };
-		58B57607160AE879795EB7F8 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = A70A6D0E873F7133B0AD219C /* VOKDefaultPagingAccessory.m */; };
-		5BB93941F62220CF986EF75D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AB02B1DA42EC8DBE72DFBF /* Foundation.framework */; };
-		5CFFBA05134AE1E7297AA2AF /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F93083927EAF91BA71249BE3 /* VOKCoreDataManager.h */; };
-		60E6057B649CFC76FC14D783 /* Pods-VOKCoreDataManager-Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D7CEF34D4569A6AD5DF394E3 /* Pods-VOKCoreDataManager-Vokoder-dummy.m */; };
-		634596446B8FA7329E74349C /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24C100C5C009450217DE15D0 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m */; };
-		671D008F115745FB4EFDB613 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AB02B1DA42EC8DBE72DFBF /* Foundation.framework */; };
-		686C98AC0CF8FA49F4F18BDB /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 87BAB012F35AF93067A4B797 /* VOKPagingFetchedResultsDataSource.h */; };
-		6D093BEEC9F9CBADE23E1E94 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 881B930B9900C6085EDD8B2D /* ILGClasses.h */; };
-		6D1303FD139F8A3CF83391A8 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D7996F54BA32D185C1026A4 /* VOKFetchedResultsDataSource.m */; };
-		70069A8DE87C4643ABBD5C85 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E260050D68626EC82DCE3AEA /* VOKManagedObjectMap.h */; };
-		734247DA47530BD9C79390D9 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = B1CDC2D63BF84F9D7C150CCB /* VOKDefaultPagingAccessory.h */; };
-		742471B7045D0BA9B7BEE1BD /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2AC32312A2F94ADCE880D0 /* VOKCoreDataManagerInternalMacros.h */; };
-		79EB6554B70E1ECA51D8B0F5 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA196C5AF0232121C895BCBD /* CoreData.framework */; };
-		7E0D3D62732D623F669FC51D /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B4BD330FF6814884A83AF785 /* VOKMappableModel.h */; };
-		831A60D8AF9DCBFA7894D4C0 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E371DDB8850435090698969C /* Pods-VOKCoreDataManager Tests-dummy.m */; };
-		99FB922455D52C2D03B507C5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AB02B1DA42EC8DBE72DFBF /* Foundation.framework */; };
-		9A06DF99B900C7B01D2F0D29 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A41C476E33523E723574BB5E /* VOKCollectionDataSource.h */; };
-		9D3F6B9AD3A4D262A8F07E9E /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1619D3D878608B00C62DE8F5 /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m */; };
-		A057FEB6FCF15853146993C2 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = B56DBB010175394AD01AB12B /* VOKManagedObjectMapper.h */; };
-		A91268B7EED5585FBA172290 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = E2A8F743444C742C687E29B9 /* VOKManagedObjectMapper.m */; };
-		AC94DB6296CF9F5CA33B4393 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E260050D68626EC82DCE3AEA /* VOKManagedObjectMap.h */; };
-		AEB0240CDA51921D63B24677 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B4BD330FF6814884A83AF785 /* VOKMappableModel.h */; };
-		AF781990445F8F7FA58DBBD4 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 94000D63406F8B149396E63A /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		B16BBEAA2296DE39135722AA /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = E2A8F743444C742C687E29B9 /* VOKManagedObjectMapper.m */; };
-		B78B6CCEB53071138821FC00 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = F8CF8D32198F048EAA55A2E0 /* VOKManagedObjectMap.m */; };
-		BAB2F3E84B53132A40700112 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4A1AFC7BDA6EEEDD0771FE /* VOKPagingFetchedResultsDataSource.m */; };
-		BE8515B6C4D130CAAA10A6A2 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = A70A6D0E873F7133B0AD219C /* VOKDefaultPagingAccessory.m */; };
-		C1D725DE1DC68BC2B349779E /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 87BAB012F35AF93067A4B797 /* VOKPagingFetchedResultsDataSource.h */; };
-		C6DEDECDF00304D95D6AD50F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AB02B1DA42EC8DBE72DFBF /* Foundation.framework */; };
-		C77698DB3297B6F831F95B39 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F1E06CD7AC5D1FF8C99D3DA6 /* NSManagedObject+VOKManagedObjectAdditions.h */; };
-		D520C3CF2D1BF5D967AB21B1 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F93083927EAF91BA71249BE3 /* VOKCoreDataManager.h */; };
-		D696D6E950A9AC5CFF99DBBC /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DEFE45A30142A6EF1759457 /* VOKCollectionDataSource.m */; };
-		D877760DAE1E30B1BF93E376 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 741D61CB089E3411B10A4664 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		DB4CC14E0EAAF06A082476A5 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FBE711C9724D0E2B6255A72F /* VOKFetchedResultsDataSource.h */; };
-		E68BE4E8058DF769793A4969 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A41C476E33523E723574BB5E /* VOKCollectionDataSource.h */; };
-		E8CC88633D51A9A0E02D7EA6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3AB02B1DA42EC8DBE72DFBF /* Foundation.framework */; };
-		F118F383857B1E3B994844EA /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FBE711C9724D0E2B6255A72F /* VOKFetchedResultsDataSource.h */; };
-		F58F25788EA080E80DD8A3B3 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4A1AFC7BDA6EEEDD0771FE /* VOKPagingFetchedResultsDataSource.m */; };
-		F773F2878A1CB9077E97C77F /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 741D61CB089E3411B10A4664 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		FB87317E3D5190C053FC0E86 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA196C5AF0232121C895BCBD /* CoreData.framework */; };
+		022660E6EC60FEC81A5FAB80 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D540AF912CC40339F56E6369 /* Foundation.framework */; };
+		02E4856FAA93C0D4E8B97498 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D540AF912CC40339F56E6369 /* Foundation.framework */; };
+		0451A1F9440D3697A54471A2 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F456BD9CA020BEA60264EE4 /* NSManagedObject+VOKManagedObjectAdditions.h */; };
+		047199CEC81ABA1E3EC521A2 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 1836DD1CC07DECBBDE0771A5 /* VOKCollectionDataSource.h */; };
+		0898E1C0712DF4F0F10033F0 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A4C54B42D1E8ADE0AAAED2 /* VOKPagingFetchedResultsDataSource.m */; };
+		0E42C649FD56833E1542D588 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 23B9B133011CC4342471151E /* VOKCoreDataManagerInternalMacros.h */; };
+		1677A4D8B4D320B92710E3CA /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DBB6F370E9DA012CD8473C /* VOKDefaultPagingAccessory.h */; };
+		16DF7D6EBC324E822A81D430 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DAE209C416E12955AE4DC6B /* VOKDefaultPagingAccessory.m */; };
+		197B8A9A0413846ABED8417F /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B830BD88AF22248AC8363D /* VOKMappableModel.h */; };
+		221295BB9E681F92F11FEB90 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 1836DD1CC07DECBBDE0771A5 /* VOKCollectionDataSource.h */; };
+		2790C9F1C31255CAAAF186D6 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A4C54B42D1E8ADE0AAAED2 /* VOKPagingFetchedResultsDataSource.m */; };
+		2E83A502910CA0BADE9A874D /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 38FF559E9C669554261BE0B5 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m */; };
+		3632CDFD086A5441A6622A1B /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DAE209C416E12955AE4DC6B /* VOKDefaultPagingAccessory.m */; };
+		3AF52CE45C7C765C723673ED /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D117E86FB8CCE8E43605B76 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		3E167120B7F354384D08BA29 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = F9B15D7FAD36A6E0090B4095 /* VOKManagedObjectMapper.m */; };
+		475591892E92E1DBE139B0CB /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D117E86FB8CCE8E43605B76 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		47BF87DD45F0BE01C2200F04 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D540AF912CC40339F56E6369 /* Foundation.framework */; };
+		4FBBE4609ED5B6F6FAEFC612 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = CCAC33DEA5FE13893912B771 /* VOKFetchedResultsDataSource.h */; };
+		50C946B3F451A8E520A61CD9 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 23B9B133011CC4342471151E /* VOKCoreDataManagerInternalMacros.h */; };
+		556E043212A500A63D394EFC /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 0924190D1079F6E287C40733 /* VOKCollectionDataSource.m */; };
+		69F8852A21C5F03E292C4DE8 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 34DCEE3165E011661F543510 /* VOKCoreDataManager.h */; };
+		79F58E526C0D46AEB1DDFCFE /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 94411A4281308266C3E66306 /* ILGClasses.h */; };
+		813282608B047D4BA9E5CCDB /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 0924190D1079F6E287C40733 /* VOKCollectionDataSource.m */; };
+		8814F6BCEBB2DC1C31E3A237 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D540AF912CC40339F56E6369 /* Foundation.framework */; };
+		881AB6BE02C694C2950F8CC0 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = DB83A330DFCDE2E2CB7542EB /* VOKManagedObjectMap.h */; };
+		89CB1ACF7FC732AF8935D978 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E95E87D154FD13E5BE1BE9E6 /* Pods-VOKCoreDataManager Tests-dummy.m */; };
+		8BEC778BD518F9F5D63446B8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D540AF912CC40339F56E6369 /* Foundation.framework */; };
+		900457642A55D42C250ADC4D /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E3D4D34591070F4FBC65D22 /* VOKManagedObjectMapper.h */; };
+		9A22C3BE79E732F376212980 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 25D42F7B56CD1010CFCD3B76 /* VOKFetchedResultsDataSource.m */; };
+		9A3D04834FB7C4E60BAFDB34 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BB9444032EF9416A0C22588 /* CoreData.framework */; };
+		9A8DC9DA981CCAEEBAE87C28 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DBB6F370E9DA012CD8473C /* VOKDefaultPagingAccessory.h */; };
+		9C6F00CD9084D9F38A78F732 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 99F09A83FC36CC55627B3ACE /* VOKManagedObjectMap.m */; };
+		A79B3DC526FBAAB45591297F /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = CCAC33DEA5FE13893912B771 /* VOKFetchedResultsDataSource.h */; };
+		AAE7AE0A762EFBB7F0D50197 /* Pods-VOKCoreDataManager-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A9911477F780DA4151CFD319 /* Pods-VOKCoreDataManager-dummy.m */; };
+		AF909D6231B66BB32373B930 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 99F09A83FC36CC55627B3ACE /* VOKManagedObjectMap.m */; };
+		B0B7DE62C389938DBCEBA369 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 34DCEE3165E011661F543510 /* VOKCoreDataManager.h */; };
+		B2149899B91BE4444A1D65FB /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BB9444032EF9416A0C22588 /* CoreData.framework */; };
+		C1A121A4365FE89CEA721C69 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 94411A4281308266C3E66306 /* ILGClasses.h */; };
+		C2FD346EB228791F25234E65 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = F9B15D7FAD36A6E0090B4095 /* VOKManagedObjectMapper.m */; };
+		C99CB84149719CA7483338C9 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 25D42F7B56CD1010CFCD3B76 /* VOKFetchedResultsDataSource.m */; };
+		CA81E4E1FE307526DB041B44 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 80BEE5EFC0BD25B02DBC1749 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		CB25AB69E8993B4E66073E68 /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A668B73DEE0BCB7A9B2A1216 /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m */; };
+		CFCE14597C362A4AF71B6834 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 760E2EB2C0875EC68F723C98 /* VOKCoreDataManager.m */; };
+		D3848BDD6B036FB88725FE88 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = DB83A330DFCDE2E2CB7542EB /* VOKManagedObjectMap.h */; };
+		DB0F48E0617254B27E8312E6 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 80BEE5EFC0BD25B02DBC1749 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E48724C83AEB52B010081031 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 36B9FA6129C6B04489B17E97 /* VOKPagingFetchedResultsDataSource.h */; };
+		E66BB553288683D8E3743849 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 36B9FA6129C6B04489B17E97 /* VOKPagingFetchedResultsDataSource.h */; };
+		E6D5689C2D3855E69D2790E9 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E3D4D34591070F4FBC65D22 /* VOKManagedObjectMapper.h */; };
+		E72170AEBBC5A3FBFFB26416 /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CAD965D5B0C86CA9FD6A000A /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m */; };
+		EB0B3DCBD653A4828B22BA65 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B830BD88AF22248AC8363D /* VOKMappableModel.h */; };
+		F2C2D2BAEA52D196E1C183F3 /* Pods-VOKCoreDataManager-Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = ABE155BA07FEC89E4355560A /* Pods-VOKCoreDataManager-Vokoder-dummy.m */; };
+		F462A256F5A5571E55BE6418 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D540AF912CC40339F56E6369 /* Foundation.framework */; };
+		F59C87D34F8CBE5AAD99055A /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 760E2EB2C0875EC68F723C98 /* VOKCoreDataManager.m */; };
+		FC980E7B40FBC0DFC775C881 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F456BD9CA020BEA60264EE4 /* NSManagedObject+VOKManagedObjectAdditions.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		31F1D6DE254E7769452C11AD /* PBXContainerItemProxy */ = {
+		463742C6FC9FFF01912753BC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = CEB64B834B69927EC84ABA66 /* Project object */;
+			containerPortal = F3B8429DD8D21BA989EAE56A /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = B03ADFB8F6D23CC0250D91F6;
-			remoteInfo = "Pods-VOKCoreDataManager-Vokoder";
-		};
-		51E8DEB05925F3F2796BF663 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CEB64B834B69927EC84ABA66 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 52C6D37073F52FAB7152A2D5;
-			remoteInfo = "Pods-VOKCoreDataManager Tests-Vokoder";
-		};
-		B9583152ED0E455F5E7AC441 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CEB64B834B69927EC84ABA66 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 47157868C4DA39D578411302;
+			remoteGlobalIDString = 4379B747CC4BAADB1E7EEE9F;
 			remoteInfo = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC";
 		};
-		C38FD4A3EC9E8E3014EFA9F2 /* PBXContainerItemProxy */ = {
+		6145B43CB457A613E84A1E52 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = CEB64B834B69927EC84ABA66 /* Project object */;
+			containerPortal = F3B8429DD8D21BA989EAE56A /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = CA1D0271ECD33FE1844A7194;
+			remoteGlobalIDString = CD9E212033A446A0FE0D47CD;
 			remoteInfo = "Pods-VOKCoreDataManager-ILGDynamicObjC";
 		};
-		C49B299407C223871BEB44A4 /* PBXContainerItemProxy */ = {
+		618F9BA23B265CD946A7634A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = CEB64B834B69927EC84ABA66 /* Project object */;
+			containerPortal = F3B8429DD8D21BA989EAE56A /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 47157868C4DA39D578411302;
+			remoteGlobalIDString = 4379B747CC4BAADB1E7EEE9F;
 			remoteInfo = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC";
 		};
-		E56E407CD97730A7490B9AA2 /* PBXContainerItemProxy */ = {
+		6EE1A73D3258EC4FFA94F7F9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = CEB64B834B69927EC84ABA66 /* Project object */;
+			containerPortal = F3B8429DD8D21BA989EAE56A /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = CA1D0271ECD33FE1844A7194;
+			remoteGlobalIDString = 7E271A0A8F57DD8B77416817;
+			remoteInfo = "Pods-VOKCoreDataManager-Vokoder";
+		};
+		91BA57E4E07B195DFC9E9490 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F3B8429DD8D21BA989EAE56A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F1EA661BB05FEA6EC7257036;
+			remoteInfo = "Pods-VOKCoreDataManager Tests-Vokoder";
+		};
+		AB3A018916F4A82284E10FA3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F3B8429DD8D21BA989EAE56A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CD9E212033A446A0FE0D47CD;
 			remoteInfo = "Pods-VOKCoreDataManager-ILGDynamicObjC";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		035AA1789323C4C70F002A2A /* Pods-VOKCoreDataManager-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-acknowledgements.plist"; sourceTree = "<group>"; };
-		03B4283705CCE1DFF6ACF0CB /* libPods-VOKCoreDataManager-ILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager-ILGDynamicObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		04392BE20EDCE121E1C5ADEF /* libPods-VOKCoreDataManager-Vokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager-Vokoder.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		07B793AA504F96340A4B5FA5 /* Pods-VOKCoreDataManager-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-dummy.m"; sourceTree = "<group>"; };
-		102E3D5D91FE235D83314CC7 /* libPods-VOKCoreDataManager Tests-ILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager Tests-ILGDynamicObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1619D3D878608B00C62DE8F5 /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-Vokoder-dummy.m"; sourceTree = "<group>"; };
-		17F513FEAE7B143E663A28AF /* Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch"; path = "../Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
-		220E286B3EAE6504A981970A /* Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch"; sourceTree = "<group>"; };
-		24C100C5C009450217DE15D0 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
-		27FA172F5B90AA134A1E29B7 /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m"; path = "../Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
-		2A5845B84846183CBE4F2831 /* Pods-VOKCoreDataManager-Vokoder-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager-Vokoder-Private.xcconfig"; path = "../Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-Private.xcconfig"; sourceTree = "<group>"; };
-		34B7F290F0865B09902A3FD7 /* Pods-VOKCoreDataManager-Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager-Vokoder.xcconfig"; path = "../Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder.xcconfig"; sourceTree = "<group>"; };
-		37673F636C50ABB0BB169C6B /* Pods-VOKCoreDataManager Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		3BE0D44485D76668EB4FCD3A /* Pods-VOKCoreDataManager-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKCoreDataManager-environment.h"; sourceTree = "<group>"; };
-		3D7996F54BA32D185C1026A4 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		3DEFE45A30142A6EF1759457 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
-		5331A505F565187F9A5CB9DB /* Pods-VOKCoreDataManager Tests-Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests-Vokoder.xcconfig"; sourceTree = "<group>"; };
-		5E83ED4A770B2316D9AC7307 /* Pods-VOKCoreDataManager-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-acknowledgements.markdown"; sourceTree = "<group>"; };
-		70A2A2542D89A0030DE08727 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
-		735D8C5144D8734225916A61 /* Pods-VOKCoreDataManager Tests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKCoreDataManager Tests-environment.h"; sourceTree = "<group>"; };
-		741D61CB089E3411B10A4664 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
-		7F796A787B419964AC227F29 /* libPods-VOKCoreDataManager Tests-Vokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager Tests-Vokoder.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		87BAB012F35AF93067A4B797 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
-		881B930B9900C6085EDD8B2D /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
-		8AA748A900DFB1B527861A4D /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		8B2AC32312A2F94ADCE880D0 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
-		8B4A1AFC7BDA6EEEDD0771FE /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		9096BFF0D21B71B014C658B3 /* Pods-VOKCoreDataManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.debug.xcconfig"; sourceTree = "<group>"; };
-		94000D63406F8B149396E63A /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
-		A3AB02B1DA42EC8DBE72DFBF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		A41C476E33523E723574BB5E /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
-		A4672299FA6C73062C780F52 /* Pods-VOKCoreDataManager-Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-VOKCoreDataManager-Vokoder-prefix.pch"; path = "../Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-prefix.pch"; sourceTree = "<group>"; };
-		A70A6D0E873F7133B0AD219C /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
-		B1CDC2D63BF84F9D7C150CCB /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
-		B4BD330FF6814884A83AF785 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
-		B56DBB010175394AD01AB12B /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
-		BAB1E99A57739863711CFCC8 /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		BE94EC5A477AB4B458A5041D /* Pods-VOKCoreDataManager Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-resources.sh"; sourceTree = "<group>"; };
-		BFEF89AD67D2A20818E4C651 /* libPods-VOKCoreDataManager Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C7E40C2C663800270A7E2F07 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
-		CB2C34D5FAA08442D7169827 /* Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig"; path = "../Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig"; sourceTree = "<group>"; };
-		D2C1CB16A0AFCCD9A6A34B7A /* Pods-VOKCoreDataManager Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.release.xcconfig"; sourceTree = "<group>"; };
-		D77372E1996028EDD7AF0A9C /* libPods-VOKCoreDataManager.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D7CEF34D4569A6AD5DF394E3 /* Pods-VOKCoreDataManager-Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-VOKCoreDataManager-Vokoder-dummy.m"; path = "../Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-dummy.m"; sourceTree = "<group>"; };
-		DA196C5AF0232121C895BCBD /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
-		DC286F66C0D9BD92282F56E8 /* Pods-VOKCoreDataManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.release.xcconfig"; sourceTree = "<group>"; };
-		E260050D68626EC82DCE3AEA /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
-		E2A8F743444C742C687E29B9 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
-		E371DDB8850435090698969C /* Pods-VOKCoreDataManager Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-dummy.m"; sourceTree = "<group>"; };
-		E4F2F5906D87BB75A3BA0195 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig"; sourceTree = "<group>"; };
-		E9CEC707B254484EDE7923AF /* Pods-VOKCoreDataManager-ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager-ILGDynamicObjC.xcconfig"; path = "../Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC.xcconfig"; sourceTree = "<group>"; };
-		EFE81A928ABCECD150B36C5A /* Pods-VOKCoreDataManager-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-resources.sh"; sourceTree = "<group>"; };
-		F1E06CD7AC5D1FF8C99D3DA6 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
-		F278D49EC7C93E90E95066C3 /* Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig"; sourceTree = "<group>"; };
-		F39E5B2E99991D369D2C4257 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		F789C31D1956E33A9E188C5A /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC.xcconfig"; sourceTree = "<group>"; };
-		F8CF8D32198F048EAA55A2E0 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
-		F93083927EAF91BA71249BE3 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
-		FBE711C9724D0E2B6255A72F /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		01750595BFEC8660CEE2A5AB /* libPods-VOKCoreDataManager-ILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager-ILGDynamicObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		09020780360F79081DFF7581 /* Pods-VOKCoreDataManager-Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-VOKCoreDataManager-Vokoder-prefix.pch"; path = "../Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-prefix.pch"; sourceTree = "<group>"; };
+		0924190D1079F6E287C40733 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
+		107D9F92D2890DD0D9E1695C /* Pods-VOKCoreDataManager-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-resources.sh"; sourceTree = "<group>"; };
+		12E2D48C7559957388737565 /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		1486DBBE53FDE6A7CE44BC90 /* Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig"; sourceTree = "<group>"; };
+		14DBB6F370E9DA012CD8473C /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
+		1836DD1CC07DECBBDE0771A5 /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
+		1F6980464344214CB1161A33 /* Pods-VOKCoreDataManager Tests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKCoreDataManager Tests-environment.h"; sourceTree = "<group>"; };
+		23B9B133011CC4342471151E /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
+		2572D59B88D74E04154D55D4 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC.xcconfig"; sourceTree = "<group>"; };
+		25D42F7B56CD1010CFCD3B76 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		2DAE209C416E12955AE4DC6B /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
+		33B1A44FFEE3ECB97F5AA7AF /* libPods-VOKCoreDataManager.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		34DCEE3165E011661F543510 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
+		36B9FA6129C6B04489B17E97 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		38FF559E9C669554261BE0B5 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
+		3F456BD9CA020BEA60264EE4 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
+		477925C00FA8602E8C8B8F82 /* libPods-VOKCoreDataManager Tests-Vokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager Tests-Vokoder.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		478B804F51FAF7EEF8B74D31 /* libPods-VOKCoreDataManager Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4834F98B6A6457239246B5B4 /* Pods-VOKCoreDataManager-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-acknowledgements.plist"; sourceTree = "<group>"; };
+		55B830BD88AF22248AC8363D /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
+		5BACC0D6B8FD5D0F21BFC42A /* Pods-VOKCoreDataManager-Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager-Vokoder.xcconfig"; path = "../Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder.xcconfig"; sourceTree = "<group>"; };
+		5BB9444032EF9416A0C22588 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		5F585F3AA2EF85CE0C1E09AA /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig"; sourceTree = "<group>"; };
+		6D117E86FB8CCE8E43605B76 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
+		70F9DB81C5BFA116966C8DC7 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		760E2EB2C0875EC68F723C98 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		80BEE5EFC0BD25B02DBC1749 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
+		8E3D4D34591070F4FBC65D22 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
+		94411A4281308266C3E66306 /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
+		96A4C54B42D1E8ADE0AAAED2 /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		98F818433D2D2374B5AA9CB4 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		99F09A83FC36CC55627B3ACE /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
+		A4DDE02C90EB3AE1737B1293 /* Pods-VOKCoreDataManager Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-resources.sh"; sourceTree = "<group>"; };
+		A4E0A00CD00E0EA133F0B119 /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		A668B73DEE0BCB7A9B2A1216 /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m"; path = "../Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
+		A6EF8B7EFD2E1CCC47DF8708 /* Pods-VOKCoreDataManager-Vokoder-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager-Vokoder-Private.xcconfig"; path = "../Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-Private.xcconfig"; sourceTree = "<group>"; };
+		A87E66F5815A0CC39F3AC8E3 /* Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch"; sourceTree = "<group>"; };
+		A9911477F780DA4151CFD319 /* Pods-VOKCoreDataManager-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-dummy.m"; sourceTree = "<group>"; };
+		AB32427738678514440C7619 /* Pods-VOKCoreDataManager-ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager-ILGDynamicObjC.xcconfig"; path = "../Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC.xcconfig"; sourceTree = "<group>"; };
+		ABE155BA07FEC89E4355560A /* Pods-VOKCoreDataManager-Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-VOKCoreDataManager-Vokoder-dummy.m"; path = "../Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-dummy.m"; sourceTree = "<group>"; };
+		AE4B99AF380D98D98E01337C /* Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch"; path = "../Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
+		AEB0C3DCF82D54AE1C9019C1 /* Pods-VOKCoreDataManager-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-acknowledgements.markdown"; sourceTree = "<group>"; };
+		B70DC95B4ECF0B8E4E26D623 /* Pods-VOKCoreDataManager Tests-Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests-Vokoder.xcconfig"; sourceTree = "<group>"; };
+		C4EA93CA39DEB88884C56A83 /* libPods-VOKCoreDataManager-Vokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager-Vokoder.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAD965D5B0C86CA9FD6A000A /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-Vokoder-dummy.m"; sourceTree = "<group>"; };
+		CCAC33DEA5FE13893912B771 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		CDB0A3BD0052B4B5D3F460C0 /* Pods-VOKCoreDataManager Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.release.xcconfig"; sourceTree = "<group>"; };
+		D540AF912CC40339F56E6369 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		D61BDCCB1832C5C6F746F0B8 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
+		DB83A330DFCDE2E2CB7542EB /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
+		DD0EE22B736E7363E5122AFC /* Pods-VOKCoreDataManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.release.xcconfig"; sourceTree = "<group>"; };
+		E607CCC8F641E48DD61B167C /* Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig"; path = "../Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig"; sourceTree = "<group>"; };
+		E7436E5ACEC05DF54F1FD44B /* Pods-VOKCoreDataManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.debug.xcconfig"; sourceTree = "<group>"; };
+		E95E87D154FD13E5BE1BE9E6 /* Pods-VOKCoreDataManager Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-dummy.m"; sourceTree = "<group>"; };
+		F9B15D7FAD36A6E0090B4095 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
+		FB95DE809394C47E41A46261 /* libPods-VOKCoreDataManager Tests-ILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager Tests-ILGDynamicObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FFFC4C3D25D0F61C8ACAD079 /* Pods-VOKCoreDataManager-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKCoreDataManager-environment.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		396F8421CE18E0E00E80080A /* Frameworks */ = {
+		0E2253CB3741FBD449E4F1CA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				99FB922455D52C2D03B507C5 /* Foundation.framework in Frameworks */,
+				47BF87DD45F0BE01C2200F04 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3DB390AFBFF44AA3FC2D3F48 /* Frameworks */ = {
+		733B89071C8679B995486F4D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E8CC88633D51A9A0E02D7EA6 /* Foundation.framework in Frameworks */,
+				B2149899B91BE4444A1D65FB /* CoreData.framework in Frameworks */,
+				02E4856FAA93C0D4E8B97498 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8785889543236CCB6F594793 /* Frameworks */ = {
+		8923EA9F4364D6595D485D22 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5BB93941F62220CF986EF75D /* Foundation.framework in Frameworks */,
+				8814F6BCEBB2DC1C31E3A237 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CAF2907B779FBA7227984CE7 /* Frameworks */ = {
+		893ED239C563A649121D7AF1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FB87317E3D5190C053FC0E86 /* CoreData.framework in Frameworks */,
-				671D008F115745FB4EFDB613 /* Foundation.framework in Frameworks */,
+				9A3D04834FB7C4E60BAFDB34 /* CoreData.framework in Frameworks */,
+				022660E6EC60FEC81A5FAB80 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFB59AE793A5FD915E791920 /* Frameworks */ = {
+		B81AA1F2E65B8236B828D9D2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6DEDECDF00304D95D6AD50F /* Foundation.framework in Frameworks */,
+				8BEC778BD518F9F5D63446B8 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ED655247FC8523F7D4630E10 /* Frameworks */ = {
+		D71BA424AA1B3C2F55AF0F9C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				79EB6554B70E1ECA51D8B0F5 /* CoreData.framework in Frameworks */,
-				1326A199B468C6D5C0FD38FB /* Foundation.framework in Frameworks */,
+				F462A256F5A5571E55BE6418 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0776319FFFBE50D0B946B6FA /* Support Files */ = {
+		002B1E11D1BCBF5706CCF4C3 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				5331A505F565187F9A5CB9DB /* Pods-VOKCoreDataManager Tests-Vokoder.xcconfig */,
-				F278D49EC7C93E90E95066C3 /* Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig */,
-				1619D3D878608B00C62DE8F5 /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m */,
-				220E286B3EAE6504A981970A /* Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch */,
-				34B7F290F0865B09902A3FD7 /* Pods-VOKCoreDataManager-Vokoder.xcconfig */,
-				2A5845B84846183CBE4F2831 /* Pods-VOKCoreDataManager-Vokoder-Private.xcconfig */,
-				D7CEF34D4569A6AD5DF394E3 /* Pods-VOKCoreDataManager-Vokoder-dummy.m */,
-				A4672299FA6C73062C780F52 /* Pods-VOKCoreDataManager-Vokoder-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager Tests-Vokoder";
-			sourceTree = "<group>";
-		};
-		08CD8DD09E656E731F1954EF /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				E71AD50BE7215C45B2981B63 /* ILGDynamicObjC */,
+				84B1A879989444A4338130AC /* ILGDynamicObjC */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		099C98465096777170E31EEA /* Core */ = {
+		0892B65474EF12E9843DBB92 /* DataSources */ = {
 			isa = PBXGroup;
 			children = (
-				71E07FE4534FC2EFD75B4722 /* Pod */,
-			);
-			name = Core;
-			sourceTree = "<group>";
-		};
-		159963B64AE95652EB750E8B /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				F789C31D1956E33A9E188C5A /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC.xcconfig */,
-				E4F2F5906D87BB75A3BA0195 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig */,
-				24C100C5C009450217DE15D0 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m */,
-				C7E40C2C663800270A7E2F07 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch */,
-				E9CEC707B254484EDE7923AF /* Pods-VOKCoreDataManager-ILGDynamicObjC.xcconfig */,
-				CB2C34D5FAA08442D7169827 /* Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig */,
-				27FA172F5B90AA134A1E29B7 /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m */,
-				17F513FEAE7B143E663A28AF /* Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-VOKCoreDataManager Tests-ILGDynamicObjC";
-			sourceTree = "<group>";
-		};
-		28E323B968CC36A89BFFAD2E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				D77372E1996028EDD7AF0A9C /* libPods-VOKCoreDataManager.a */,
-				BFEF89AD67D2A20818E4C651 /* libPods-VOKCoreDataManager Tests.a */,
-				102E3D5D91FE235D83314CC7 /* libPods-VOKCoreDataManager Tests-ILGDynamicObjC.a */,
-				7F796A787B419964AC227F29 /* libPods-VOKCoreDataManager Tests-Vokoder.a */,
-				03B4283705CCE1DFF6ACF0CB /* libPods-VOKCoreDataManager-ILGDynamicObjC.a */,
-				04392BE20EDCE121E1C5ADEF /* libPods-VOKCoreDataManager-Vokoder.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		2F274BC5049CA39B5EB614ED /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				77893B0B8496A0734F0C727E /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		3325D6B813E7560214C66E32 /* PagingFetchedResults */ = {
-			isa = PBXGroup;
-			children = (
-				2F274BC5049CA39B5EB614ED /* Pod */,
-			);
-			name = PagingFetchedResults;
-			sourceTree = "<group>";
-		};
-		45B290716A2FBCF333B65B9E /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				C77BBB6BFF0C168073EE1E95 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		49F05C8C44DAB71F985E66DA /* Collection */ = {
-			isa = PBXGroup;
-			children = (
-				45B290716A2FBCF333B65B9E /* Pod */,
-			);
-			name = Collection;
-			sourceTree = "<group>";
-		};
-		4C6D428EFAC96D6C571FE455 = {
-			isa = PBXGroup;
-			children = (
-				F39E5B2E99991D369D2C4257 /* Podfile */,
-				73AE622041158DF88851F03A /* Development Pods */,
-				91CFB8D11C9EE6D1E370DC39 /* Frameworks */,
-				08CD8DD09E656E731F1954EF /* Pods */,
-				28E323B968CC36A89BFFAD2E /* Products */,
-				EFD247F2D4A470CC6ED09FB9 /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		5C57A3848B3D3B306A396641 /* Vokoder */ = {
-			isa = PBXGroup;
-			children = (
-				099C98465096777170E31EEA /* Core */,
-				8299E54A17D950765D2FCCA2 /* DataSources */,
-				0776319FFFBE50D0B946B6FA /* Support Files */,
-			);
-			name = Vokoder;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		5CBBE52505A6C0F68F651F2E /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				F1E06CD7AC5D1FF8C99D3DA6 /* NSManagedObject+VOKManagedObjectAdditions.h */,
-				741D61CB089E3411B10A4664 /* NSManagedObject+VOKManagedObjectAdditions.m */,
-				F93083927EAF91BA71249BE3 /* VOKCoreDataManager.h */,
-				70A2A2542D89A0030DE08727 /* VOKCoreDataManager.m */,
-				E260050D68626EC82DCE3AEA /* VOKManagedObjectMap.h */,
-				F8CF8D32198F048EAA55A2E0 /* VOKManagedObjectMap.m */,
-				B56DBB010175394AD01AB12B /* VOKManagedObjectMapper.h */,
-				E2A8F743444C742C687E29B9 /* VOKManagedObjectMapper.m */,
-				B4BD330FF6814884A83AF785 /* VOKMappableModel.h */,
-				F403E7C415A67A8DE30DE4D7 /* Internal */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		637476F2A9564A52B105443B /* Optional Data Sources */ = {
-			isa = PBXGroup;
-			children = (
-				B1CDC2D63BF84F9D7C150CCB /* VOKDefaultPagingAccessory.h */,
-				A70A6D0E873F7133B0AD219C /* VOKDefaultPagingAccessory.m */,
-				87BAB012F35AF93067A4B797 /* VOKPagingFetchedResultsDataSource.h */,
-				8B4A1AFC7BDA6EEEDD0771FE /* VOKPagingFetchedResultsDataSource.m */,
-			);
-			path = "Optional Data Sources";
-			sourceTree = "<group>";
-		};
-		697C45C9336128DAEC481EE7 /* Pods-VOKCoreDataManager */ = {
-			isa = PBXGroup;
-			children = (
-				5E83ED4A770B2316D9AC7307 /* Pods-VOKCoreDataManager-acknowledgements.markdown */,
-				035AA1789323C4C70F002A2A /* Pods-VOKCoreDataManager-acknowledgements.plist */,
-				07B793AA504F96340A4B5FA5 /* Pods-VOKCoreDataManager-dummy.m */,
-				3BE0D44485D76668EB4FCD3A /* Pods-VOKCoreDataManager-environment.h */,
-				EFE81A928ABCECD150B36C5A /* Pods-VOKCoreDataManager-resources.sh */,
-				9096BFF0D21B71B014C658B3 /* Pods-VOKCoreDataManager.debug.xcconfig */,
-				DC286F66C0D9BD92282F56E8 /* Pods-VOKCoreDataManager.release.xcconfig */,
-			);
-			name = "Pods-VOKCoreDataManager";
-			path = "Target Support Files/Pods-VOKCoreDataManager";
-			sourceTree = "<group>";
-		};
-		71E07FE4534FC2EFD75B4722 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				5CBBE52505A6C0F68F651F2E /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		73AE622041158DF88851F03A /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				5C57A3848B3D3B306A396641 /* Vokoder */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		73F3786E1CF4E74E14F59351 /* ILGClasses */ = {
-			isa = PBXGroup;
-			children = (
-				881B930B9900C6085EDD8B2D /* ILGClasses.h */,
-				94000D63406F8B149396E63A /* ILGClasses.m */,
-			);
-			name = ILGClasses;
-			sourceTree = "<group>";
-		};
-		77893B0B8496A0734F0C727E /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				637476F2A9564A52B105443B /* Optional Data Sources */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		8299E54A17D950765D2FCCA2 /* DataSources */ = {
-			isa = PBXGroup;
-			children = (
-				49F05C8C44DAB71F985E66DA /* Collection */,
-				DB918B1AB5512D4E684028C9 /* FetchedResults */,
-				3325D6B813E7560214C66E32 /* PagingFetchedResults */,
+				C3D7BDC34DDB855D464F7400 /* Collection */,
+				7E2E4396E80888C76B9C6C29 /* FetchedResults */,
+				0A5E006C7FCF9C83A194E0BC /* PagingFetchedResults */,
 			);
 			name = DataSources;
 			sourceTree = "<group>";
 		};
-		83B6656A98397FFB576934D3 /* Optional Data Sources */ = {
+		0A5E006C7FCF9C83A194E0BC /* PagingFetchedResults */ = {
 			isa = PBXGroup;
 			children = (
-				FBE711C9724D0E2B6255A72F /* VOKFetchedResultsDataSource.h */,
-				3D7996F54BA32D185C1026A4 /* VOKFetchedResultsDataSource.m */,
+				501BAC2EDD6008B3003F66EB /* Pod */,
 			);
-			path = "Optional Data Sources";
+			name = PagingFetchedResults;
 			sourceTree = "<group>";
 		};
-		91CFB8D11C9EE6D1E370DC39 /* Frameworks */ = {
+		163AA7A737F0DD70EE2AA797 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				ED09F23138A553F6750A89FB /* iOS */,
+				BA48FFDD184D7098F80365B7 /* Vokoder */,
 			);
-			name = Frameworks;
+			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		9CA01345389F5B02D6070128 /* Optional Data Sources */ = {
+		24C0A12438B4F17301B3BDED /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				A41C476E33523E723574BB5E /* VOKCollectionDataSource.h */,
-				3DEFE45A30142A6EF1759457 /* VOKCollectionDataSource.m */,
+				D937ED3C1E0B9A378353EA4B /* Classes */,
 			);
-			path = "Optional Data Sources";
+			path = Pod;
 			sourceTree = "<group>";
 		};
-		C77BBB6BFF0C168073EE1E95 /* Classes */ = {
+		257E91119E233D48556F51EB = {
 			isa = PBXGroup;
 			children = (
-				9CA01345389F5B02D6070128 /* Optional Data Sources */,
+				70F9DB81C5BFA116966C8DC7 /* Podfile */,
+				163AA7A737F0DD70EE2AA797 /* Development Pods */,
+				B13DCC739D7C69F0FEE66374 /* Frameworks */,
+				002B1E11D1BCBF5706CCF4C3 /* Pods */,
+				A4E9B3DFE8A4B59C05E97C8C /* Products */,
+				5D3FEFF9666D2740C87AA94A /* Targets Support Files */,
 			);
-			path = Classes;
 			sourceTree = "<group>";
 		};
-		D8232640DAF4882DC95AE07C /* Classes */ = {
+		2DEF382745135601BCD882C8 /* Pods-VOKCoreDataManager Tests */ = {
 			isa = PBXGroup;
 			children = (
-				83B6656A98397FFB576934D3 /* Optional Data Sources */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		DB918B1AB5512D4E684028C9 /* FetchedResults */ = {
-			isa = PBXGroup;
-			children = (
-				E8AD7014EEE9F02DF402E700 /* Pod */,
-			);
-			name = FetchedResults;
-			sourceTree = "<group>";
-		};
-		DD61513D4F48AEC2B15F7266 /* Pods-VOKCoreDataManager Tests */ = {
-			isa = PBXGroup;
-			children = (
-				8AA748A900DFB1B527861A4D /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */,
-				BAB1E99A57739863711CFCC8 /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */,
-				E371DDB8850435090698969C /* Pods-VOKCoreDataManager Tests-dummy.m */,
-				735D8C5144D8734225916A61 /* Pods-VOKCoreDataManager Tests-environment.h */,
-				BE94EC5A477AB4B458A5041D /* Pods-VOKCoreDataManager Tests-resources.sh */,
-				37673F636C50ABB0BB169C6B /* Pods-VOKCoreDataManager Tests.debug.xcconfig */,
-				D2C1CB16A0AFCCD9A6A34B7A /* Pods-VOKCoreDataManager Tests.release.xcconfig */,
+				12E2D48C7559957388737565 /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */,
+				A4E0A00CD00E0EA133F0B119 /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */,
+				E95E87D154FD13E5BE1BE9E6 /* Pods-VOKCoreDataManager Tests-dummy.m */,
+				1F6980464344214CB1161A33 /* Pods-VOKCoreDataManager Tests-environment.h */,
+				A4DDE02C90EB3AE1737B1293 /* Pods-VOKCoreDataManager Tests-resources.sh */,
+				98F818433D2D2374B5AA9CB4 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */,
+				CDB0A3BD0052B4B5D3F460C0 /* Pods-VOKCoreDataManager Tests.release.xcconfig */,
 			);
 			name = "Pods-VOKCoreDataManager Tests";
 			path = "Target Support Files/Pods-VOKCoreDataManager Tests";
 			sourceTree = "<group>";
 		};
-		E71AD50BE7215C45B2981B63 /* ILGDynamicObjC */ = {
+		39918941744510333E750534 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				73F3786E1CF4E74E14F59351 /* ILGClasses */,
-				159963B64AE95652EB750E8B /* Support Files */,
-			);
-			path = ILGDynamicObjC;
-			sourceTree = "<group>";
-		};
-		E8AD7014EEE9F02DF402E700 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				D8232640DAF4882DC95AE07C /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		ED09F23138A553F6750A89FB /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				DA196C5AF0232121C895BCBD /* CoreData.framework */,
-				A3AB02B1DA42EC8DBE72DFBF /* Foundation.framework */,
+				5BB9444032EF9416A0C22588 /* CoreData.framework */,
+				D540AF912CC40339F56E6369 /* Foundation.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		EFD247F2D4A470CC6ED09FB9 /* Targets Support Files */ = {
+		3DF0889722FB22721BD8A6AB /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				697C45C9336128DAEC481EE7 /* Pods-VOKCoreDataManager */,
-				DD61513D4F48AEC2B15F7266 /* Pods-VOKCoreDataManager Tests */,
+				7E025F6385F43EEB0BFA8231 /* Optional Data Sources */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		501BAC2EDD6008B3003F66EB /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				7F2DFCF7FC52B99D98E4B11A /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		5D3FEFF9666D2740C87AA94A /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				8AF128B0343784436991C6D4 /* Pods-VOKCoreDataManager */,
+				2DEF382745135601BCD882C8 /* Pods-VOKCoreDataManager Tests */,
 			);
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		F403E7C415A67A8DE30DE4D7 /* Internal */ = {
+		7074AB8C0C93E6D0919C024D /* Optional Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				8B2AC32312A2F94ADCE880D0 /* VOKCoreDataManagerInternalMacros.h */,
+				CCAC33DEA5FE13893912B771 /* VOKFetchedResultsDataSource.h */,
+				25D42F7B56CD1010CFCD3B76 /* VOKFetchedResultsDataSource.m */,
+			);
+			path = "Optional Data Sources";
+			sourceTree = "<group>";
+		};
+		7E025F6385F43EEB0BFA8231 /* Optional Data Sources */ = {
+			isa = PBXGroup;
+			children = (
+				1836DD1CC07DECBBDE0771A5 /* VOKCollectionDataSource.h */,
+				0924190D1079F6E287C40733 /* VOKCollectionDataSource.m */,
+			);
+			path = "Optional Data Sources";
+			sourceTree = "<group>";
+		};
+		7E2E4396E80888C76B9C6C29 /* FetchedResults */ = {
+			isa = PBXGroup;
+			children = (
+				E9F61900913C2F8D04976324 /* Pod */,
+			);
+			name = FetchedResults;
+			sourceTree = "<group>";
+		};
+		7F2DFCF7FC52B99D98E4B11A /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				D637F0ADD80251A7BCFCC66E /* Optional Data Sources */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		81CEC1C6FDB6F8E84A903043 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				24C0A12438B4F17301B3BDED /* Pod */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
+		84B1A879989444A4338130AC /* ILGDynamicObjC */ = {
+			isa = PBXGroup;
+			children = (
+				FE3A12F9B761C58144720AA5 /* ILGClasses */,
+				91C1C55EECB246FF4EFE58F3 /* Support Files */,
+			);
+			path = ILGDynamicObjC;
+			sourceTree = "<group>";
+		};
+		8AF128B0343784436991C6D4 /* Pods-VOKCoreDataManager */ = {
+			isa = PBXGroup;
+			children = (
+				AEB0C3DCF82D54AE1C9019C1 /* Pods-VOKCoreDataManager-acknowledgements.markdown */,
+				4834F98B6A6457239246B5B4 /* Pods-VOKCoreDataManager-acknowledgements.plist */,
+				A9911477F780DA4151CFD319 /* Pods-VOKCoreDataManager-dummy.m */,
+				FFFC4C3D25D0F61C8ACAD079 /* Pods-VOKCoreDataManager-environment.h */,
+				107D9F92D2890DD0D9E1695C /* Pods-VOKCoreDataManager-resources.sh */,
+				E7436E5ACEC05DF54F1FD44B /* Pods-VOKCoreDataManager.debug.xcconfig */,
+				DD0EE22B736E7363E5122AFC /* Pods-VOKCoreDataManager.release.xcconfig */,
+			);
+			name = "Pods-VOKCoreDataManager";
+			path = "Target Support Files/Pods-VOKCoreDataManager";
+			sourceTree = "<group>";
+		};
+		91C1C55EECB246FF4EFE58F3 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				2572D59B88D74E04154D55D4 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC.xcconfig */,
+				5F585F3AA2EF85CE0C1E09AA /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig */,
+				38FF559E9C669554261BE0B5 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m */,
+				D61BDCCB1832C5C6F746F0B8 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch */,
+				AB32427738678514440C7619 /* Pods-VOKCoreDataManager-ILGDynamicObjC.xcconfig */,
+				E607CCC8F641E48DD61B167C /* Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig */,
+				A668B73DEE0BCB7A9B2A1216 /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m */,
+				AE4B99AF380D98D98E01337C /* Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-VOKCoreDataManager Tests-ILGDynamicObjC";
+			sourceTree = "<group>";
+		};
+		994A49B43C57EE42660C5E7B /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				7074AB8C0C93E6D0919C024D /* Optional Data Sources */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		9BB9E402F2AE3C3B93A0CAFD /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				23B9B133011CC4342471151E /* VOKCoreDataManagerInternalMacros.h */,
 			);
 			path = Internal;
+			sourceTree = "<group>";
+		};
+		A4E9B3DFE8A4B59C05E97C8C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				33B1A44FFEE3ECB97F5AA7AF /* libPods-VOKCoreDataManager.a */,
+				478B804F51FAF7EEF8B74D31 /* libPods-VOKCoreDataManager Tests.a */,
+				FB95DE809394C47E41A46261 /* libPods-VOKCoreDataManager Tests-ILGDynamicObjC.a */,
+				477925C00FA8602E8C8B8F82 /* libPods-VOKCoreDataManager Tests-Vokoder.a */,
+				01750595BFEC8660CEE2A5AB /* libPods-VOKCoreDataManager-ILGDynamicObjC.a */,
+				C4EA93CA39DEB88884C56A83 /* libPods-VOKCoreDataManager-Vokoder.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B13DCC739D7C69F0FEE66374 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				39918941744510333E750534 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B1792DB8F8911283C483D82E /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				3DF0889722FB22721BD8A6AB /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		BA48FFDD184D7098F80365B7 /* Vokoder */ = {
+			isa = PBXGroup;
+			children = (
+				81CEC1C6FDB6F8E84A903043 /* Core */,
+				0892B65474EF12E9843DBB92 /* DataSources */,
+				CFA2E303187082408F00718F /* Support Files */,
+			);
+			name = Vokoder;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		C3D7BDC34DDB855D464F7400 /* Collection */ = {
+			isa = PBXGroup;
+			children = (
+				B1792DB8F8911283C483D82E /* Pod */,
+			);
+			name = Collection;
+			sourceTree = "<group>";
+		};
+		CFA2E303187082408F00718F /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B70DC95B4ECF0B8E4E26D623 /* Pods-VOKCoreDataManager Tests-Vokoder.xcconfig */,
+				1486DBBE53FDE6A7CE44BC90 /* Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig */,
+				CAD965D5B0C86CA9FD6A000A /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m */,
+				A87E66F5815A0CC39F3AC8E3 /* Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch */,
+				5BACC0D6B8FD5D0F21BFC42A /* Pods-VOKCoreDataManager-Vokoder.xcconfig */,
+				A6EF8B7EFD2E1CCC47DF8708 /* Pods-VOKCoreDataManager-Vokoder-Private.xcconfig */,
+				ABE155BA07FEC89E4355560A /* Pods-VOKCoreDataManager-Vokoder-dummy.m */,
+				09020780360F79081DFF7581 /* Pods-VOKCoreDataManager-Vokoder-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager Tests-Vokoder";
+			sourceTree = "<group>";
+		};
+		D637F0ADD80251A7BCFCC66E /* Optional Data Sources */ = {
+			isa = PBXGroup;
+			children = (
+				14DBB6F370E9DA012CD8473C /* VOKDefaultPagingAccessory.h */,
+				2DAE209C416E12955AE4DC6B /* VOKDefaultPagingAccessory.m */,
+				36B9FA6129C6B04489B17E97 /* VOKPagingFetchedResultsDataSource.h */,
+				96A4C54B42D1E8ADE0AAAED2 /* VOKPagingFetchedResultsDataSource.m */,
+			);
+			path = "Optional Data Sources";
+			sourceTree = "<group>";
+		};
+		D937ED3C1E0B9A378353EA4B /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				3F456BD9CA020BEA60264EE4 /* NSManagedObject+VOKManagedObjectAdditions.h */,
+				6D117E86FB8CCE8E43605B76 /* NSManagedObject+VOKManagedObjectAdditions.m */,
+				34DCEE3165E011661F543510 /* VOKCoreDataManager.h */,
+				760E2EB2C0875EC68F723C98 /* VOKCoreDataManager.m */,
+				DB83A330DFCDE2E2CB7542EB /* VOKManagedObjectMap.h */,
+				99F09A83FC36CC55627B3ACE /* VOKManagedObjectMap.m */,
+				8E3D4D34591070F4FBC65D22 /* VOKManagedObjectMapper.h */,
+				F9B15D7FAD36A6E0090B4095 /* VOKManagedObjectMapper.m */,
+				55B830BD88AF22248AC8363D /* VOKMappableModel.h */,
+				9BB9E402F2AE3C3B93A0CAFD /* Internal */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		E9F61900913C2F8D04976324 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				994A49B43C57EE42660C5E7B /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		FE3A12F9B761C58144720AA5 /* ILGClasses */ = {
+			isa = PBXGroup;
+			children = (
+				94411A4281308266C3E66306 /* ILGClasses.h */,
+				80BEE5EFC0BD25B02DBC1749 /* ILGClasses.m */,
+			);
+			name = ILGClasses;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		0B003FB64C4E6261C118C5AF /* Headers */ = {
+		03B170A681F68EDEF5E204F9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C77698DB3297B6F831F95B39 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				E68BE4E8058DF769793A4969 /* VOKCollectionDataSource.h in Headers */,
-				D520C3CF2D1BF5D967AB21B1 /* VOKCoreDataManager.h in Headers */,
-				3A9999C2C481CB6CBC24A310 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				734247DA47530BD9C79390D9 /* VOKDefaultPagingAccessory.h in Headers */,
-				F118F383857B1E3B994844EA /* VOKFetchedResultsDataSource.h in Headers */,
-				70069A8DE87C4643ABBD5C85 /* VOKManagedObjectMap.h in Headers */,
-				0F16DF322BB7F5F5A8FD3D90 /* VOKManagedObjectMapper.h in Headers */,
-				7E0D3D62732D623F669FC51D /* VOKMappableModel.h in Headers */,
-				C1D725DE1DC68BC2B349779E /* VOKPagingFetchedResultsDataSource.h in Headers */,
+				0451A1F9440D3697A54471A2 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				221295BB9E681F92F11FEB90 /* VOKCollectionDataSource.h in Headers */,
+				69F8852A21C5F03E292C4DE8 /* VOKCoreDataManager.h in Headers */,
+				50C946B3F451A8E520A61CD9 /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				9A8DC9DA981CCAEEBAE87C28 /* VOKDefaultPagingAccessory.h in Headers */,
+				A79B3DC526FBAAB45591297F /* VOKFetchedResultsDataSource.h in Headers */,
+				D3848BDD6B036FB88725FE88 /* VOKManagedObjectMap.h in Headers */,
+				E6D5689C2D3855E69D2790E9 /* VOKManagedObjectMapper.h in Headers */,
+				EB0B3DCBD653A4828B22BA65 /* VOKMappableModel.h in Headers */,
+				E66BB553288683D8E3743849 /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		20B4D034308C63C943727C73 /* Headers */ = {
+		36CE8F809D28857876BEFF19 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6D093BEEC9F9CBADE23E1E94 /* ILGClasses.h in Headers */,
+				C1A121A4365FE89CEA721C69 /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4DDCA6ECA861A80E5CC77E63 /* Headers */ = {
+		9AAB88D0FADFA987021FBFAC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1FBBA2C0B52C6677484A3503 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				9A06DF99B900C7B01D2F0D29 /* VOKCollectionDataSource.h in Headers */,
-				5CFFBA05134AE1E7297AA2AF /* VOKCoreDataManager.h in Headers */,
-				742471B7045D0BA9B7BEE1BD /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				309A5BB5ED14E49C6CF4173C /* VOKDefaultPagingAccessory.h in Headers */,
-				DB4CC14E0EAAF06A082476A5 /* VOKFetchedResultsDataSource.h in Headers */,
-				AC94DB6296CF9F5CA33B4393 /* VOKManagedObjectMap.h in Headers */,
-				A057FEB6FCF15853146993C2 /* VOKManagedObjectMapper.h in Headers */,
-				AEB0240CDA51921D63B24677 /* VOKMappableModel.h in Headers */,
-				686C98AC0CF8FA49F4F18BDB /* VOKPagingFetchedResultsDataSource.h in Headers */,
+				79F58E526C0D46AEB1DDFCFE /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D094E7A801C49ECC124E3512 /* Headers */ = {
+		AB465B519C9096D274893C6D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				19CD89582E78CE5D52D7019B /* ILGClasses.h in Headers */,
+				FC980E7B40FBC0DFC775C881 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				047199CEC81ABA1E3EC521A2 /* VOKCollectionDataSource.h in Headers */,
+				B0B7DE62C389938DBCEBA369 /* VOKCoreDataManager.h in Headers */,
+				0E42C649FD56833E1542D588 /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				1677A4D8B4D320B92710E3CA /* VOKDefaultPagingAccessory.h in Headers */,
+				4FBBE4609ED5B6F6FAEFC612 /* VOKFetchedResultsDataSource.h in Headers */,
+				881AB6BE02C694C2950F8CC0 /* VOKManagedObjectMap.h in Headers */,
+				900457642A55D42C250ADC4D /* VOKManagedObjectMapper.h in Headers */,
+				197B8A9A0413846ABED8417F /* VOKMappableModel.h in Headers */,
+				E48724C83AEB52B010081031 /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		47157868C4DA39D578411302 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC */ = {
+		4379B747CC4BAADB1E7EEE9F /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 83DBC91973908D5451955F8E /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests-ILGDynamicObjC" */;
+			buildConfigurationList = 0991EDEC12C9AF16E9A6B504 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests-ILGDynamicObjC" */;
 			buildPhases = (
-				7FBC9C3123F014D5624596A9 /* Sources */,
-				CFB59AE793A5FD915E791920 /* Frameworks */,
-				20B4D034308C63C943727C73 /* Headers */,
+				88512ED62081B3B7E6157F03 /* Sources */,
+				0E2253CB3741FBD449E4F1CA /* Frameworks */,
+				36CE8F809D28857876BEFF19 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -604,88 +604,70 @@
 			);
 			name = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC";
 			productName = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC";
-			productReference = 102E3D5D91FE235D83314CC7 /* libPods-VOKCoreDataManager Tests-ILGDynamicObjC.a */;
+			productReference = FB95DE809394C47E41A46261 /* libPods-VOKCoreDataManager Tests-ILGDynamicObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		52C6D37073F52FAB7152A2D5 /* Pods-VOKCoreDataManager Tests-Vokoder */ = {
+		7E271A0A8F57DD8B77416817 /* Pods-VOKCoreDataManager-Vokoder */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 3B50CFF8F56ECE4A623E256A /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests-Vokoder" */;
+			buildConfigurationList = AB9383679EE5558BCAB1668D /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-Vokoder" */;
 			buildPhases = (
-				3492DFBE534757AA5068B3EA /* Sources */,
-				CAF2907B779FBA7227984CE7 /* Frameworks */,
-				0B003FB64C4E6261C118C5AF /* Headers */,
+				62F9F8990D42F768C938EE83 /* Sources */,
+				893ED239C563A649121D7AF1 /* Frameworks */,
+				AB465B519C9096D274893C6D /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				EC02812CED4CC468795FACE1 /* PBXTargetDependency */,
-			);
-			name = "Pods-VOKCoreDataManager Tests-Vokoder";
-			productName = "Pods-VOKCoreDataManager Tests-Vokoder";
-			productReference = 7F796A787B419964AC227F29 /* libPods-VOKCoreDataManager Tests-Vokoder.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		70476D03B8EDD03F591C7787 /* Pods-VOKCoreDataManager Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 3E1BAA860A4F9E8160D0BB81 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests" */;
-			buildPhases = (
-				BEDF239E4C48E48E8F4836C3 /* Sources */,
-				3DB390AFBFF44AA3FC2D3F48 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				FB68DBF21D7E52670C5C476C /* PBXTargetDependency */,
-				C3606F2663CFBFA712952351 /* PBXTargetDependency */,
-			);
-			name = "Pods-VOKCoreDataManager Tests";
-			productName = "Pods-VOKCoreDataManager Tests";
-			productReference = BFEF89AD67D2A20818E4C651 /* libPods-VOKCoreDataManager Tests.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		B03ADFB8F6D23CC0250D91F6 /* Pods-VOKCoreDataManager-Vokoder */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 168AFA2DEC9604264C553072 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-Vokoder" */;
-			buildPhases = (
-				103837F0FF838CF9DABD3541 /* Sources */,
-				ED655247FC8523F7D4630E10 /* Frameworks */,
-				4DDCA6ECA861A80E5CC77E63 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				2133C8F70B9A6489674BD7A7 /* PBXTargetDependency */,
+				487745592A1321F36662CBCD /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKCoreDataManager-Vokoder";
 			productName = "Pods-VOKCoreDataManager-Vokoder";
-			productReference = 04392BE20EDCE121E1C5ADEF /* libPods-VOKCoreDataManager-Vokoder.a */;
+			productReference = C4EA93CA39DEB88884C56A83 /* libPods-VOKCoreDataManager-Vokoder.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		C8AB9FF585ABE14A7084121B /* Pods-VOKCoreDataManager */ = {
+		B03745AD4FEF0FB2373DD459 /* Pods-VOKCoreDataManager Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 017DE7370D5574DFE5EAEBE4 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager" */;
+			buildConfigurationList = 0B6D80238EA399CAD8453461 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests" */;
 			buildPhases = (
-				0BF64289D259D2BF85D6C290 /* Sources */,
-				396F8421CE18E0E00E80080A /* Frameworks */,
+				00BC40CE9FB12AB91BAA3AAA /* Sources */,
+				D71BA424AA1B3C2F55AF0F9C /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				0748DF136A9C1E666B0E66C5 /* PBXTargetDependency */,
-				114378B611EEA1D1B35AA0F3 /* PBXTargetDependency */,
+				5E6A053B4C3077A796617AEA /* PBXTargetDependency */,
+				05BB6AD223F0C1ECE430AE2E /* PBXTargetDependency */,
+			);
+			name = "Pods-VOKCoreDataManager Tests";
+			productName = "Pods-VOKCoreDataManager Tests";
+			productReference = 478B804F51FAF7EEF8B74D31 /* libPods-VOKCoreDataManager Tests.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		C4AE89E1024503734043B056 /* Pods-VOKCoreDataManager */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1721DBA8314DDC07B0B389F7 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager" */;
+			buildPhases = (
+				466ED1054B76C8E0A079D389 /* Sources */,
+				8923EA9F4364D6595D485D22 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5BD251A8F5816F21FCCBFF32 /* PBXTargetDependency */,
+				75DA7A51F40BA38307406201 /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKCoreDataManager";
 			productName = "Pods-VOKCoreDataManager";
-			productReference = D77372E1996028EDD7AF0A9C /* libPods-VOKCoreDataManager.a */;
+			productReference = 33B1A44FFEE3ECB97F5AA7AF /* libPods-VOKCoreDataManager.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		CA1D0271ECD33FE1844A7194 /* Pods-VOKCoreDataManager-ILGDynamicObjC */ = {
+		CD9E212033A446A0FE0D47CD /* Pods-VOKCoreDataManager-ILGDynamicObjC */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 00553C7D45D75658918D1DA6 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-ILGDynamicObjC" */;
+			buildConfigurationList = 70A90B1D7ED20B42F0F13214 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-ILGDynamicObjC" */;
 			buildPhases = (
-				EFDC02E5EEC898874A753DE2 /* Sources */,
-				8785889543236CCB6F594793 /* Frameworks */,
-				D094E7A801C49ECC124E3512 /* Headers */,
+				75F61F06BCCD6EE5B5FA7B15 /* Sources */,
+				B81AA1F2E65B8236B828D9D2 /* Frameworks */,
+				9AAB88D0FADFA987021FBFAC /* Headers */,
 			);
 			buildRules = (
 			);
@@ -693,151 +675,201 @@
 			);
 			name = "Pods-VOKCoreDataManager-ILGDynamicObjC";
 			productName = "Pods-VOKCoreDataManager-ILGDynamicObjC";
-			productReference = 03B4283705CCE1DFF6ACF0CB /* libPods-VOKCoreDataManager-ILGDynamicObjC.a */;
+			productReference = 01750595BFEC8660CEE2A5AB /* libPods-VOKCoreDataManager-ILGDynamicObjC.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F1EA661BB05FEA6EC7257036 /* Pods-VOKCoreDataManager Tests-Vokoder */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 364D70D809E8788681705451 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests-Vokoder" */;
+			buildPhases = (
+				E971F45211913D7350B3E022 /* Sources */,
+				733B89071C8679B995486F4D /* Frameworks */,
+				03B170A681F68EDEF5E204F9 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B6906B82C7FD84246BBE7076 /* PBXTargetDependency */,
+			);
+			name = "Pods-VOKCoreDataManager Tests-Vokoder";
+			productName = "Pods-VOKCoreDataManager Tests-Vokoder";
+			productReference = 477925C00FA8602E8C8B8F82 /* libPods-VOKCoreDataManager Tests-Vokoder.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		CEB64B834B69927EC84ABA66 /* Project object */ = {
+		F3B8429DD8D21BA989EAE56A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0640;
 			};
-			buildConfigurationList = DD0DBBC795EF2FAC5A7E295B /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = 93EF038C07323C7B74CAB4F0 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 4C6D428EFAC96D6C571FE455;
-			productRefGroup = 28E323B968CC36A89BFFAD2E /* Products */;
+			mainGroup = 257E91119E233D48556F51EB;
+			productRefGroup = A4E9B3DFE8A4B59C05E97C8C /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				C8AB9FF585ABE14A7084121B /* Pods-VOKCoreDataManager */,
-				70476D03B8EDD03F591C7787 /* Pods-VOKCoreDataManager Tests */,
-				47157868C4DA39D578411302 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC */,
-				52C6D37073F52FAB7152A2D5 /* Pods-VOKCoreDataManager Tests-Vokoder */,
-				CA1D0271ECD33FE1844A7194 /* Pods-VOKCoreDataManager-ILGDynamicObjC */,
-				B03ADFB8F6D23CC0250D91F6 /* Pods-VOKCoreDataManager-Vokoder */,
+				C4AE89E1024503734043B056 /* Pods-VOKCoreDataManager */,
+				B03745AD4FEF0FB2373DD459 /* Pods-VOKCoreDataManager Tests */,
+				4379B747CC4BAADB1E7EEE9F /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC */,
+				F1EA661BB05FEA6EC7257036 /* Pods-VOKCoreDataManager Tests-Vokoder */,
+				CD9E212033A446A0FE0D47CD /* Pods-VOKCoreDataManager-ILGDynamicObjC */,
+				7E271A0A8F57DD8B77416817 /* Pods-VOKCoreDataManager-Vokoder */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0BF64289D259D2BF85D6C290 /* Sources */ = {
+		00BC40CE9FB12AB91BAA3AAA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				587031C9D3436D1DBB9465BD /* Pods-VOKCoreDataManager-dummy.m in Sources */,
+				89CB1ACF7FC732AF8935D978 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		103837F0FF838CF9DABD3541 /* Sources */ = {
+		466ED1054B76C8E0A079D389 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D877760DAE1E30B1BF93E376 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				60E6057B649CFC76FC14D783 /* Pods-VOKCoreDataManager-Vokoder-dummy.m in Sources */,
-				01409387B124CB24BF4C8D89 /* VOKCollectionDataSource.m in Sources */,
-				4EC1FC8D00075CFBE73079CC /* VOKCoreDataManager.m in Sources */,
-				BE8515B6C4D130CAAA10A6A2 /* VOKDefaultPagingAccessory.m in Sources */,
-				6D1303FD139F8A3CF83391A8 /* VOKFetchedResultsDataSource.m in Sources */,
-				B78B6CCEB53071138821FC00 /* VOKManagedObjectMap.m in Sources */,
-				A91268B7EED5585FBA172290 /* VOKManagedObjectMapper.m in Sources */,
-				F58F25788EA080E80DD8A3B3 /* VOKPagingFetchedResultsDataSource.m in Sources */,
+				AAE7AE0A762EFBB7F0D50197 /* Pods-VOKCoreDataManager-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3492DFBE534757AA5068B3EA /* Sources */ = {
+		62F9F8990D42F768C938EE83 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F773F2878A1CB9077E97C77F /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				9D3F6B9AD3A4D262A8F07E9E /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m in Sources */,
-				D696D6E950A9AC5CFF99DBBC /* VOKCollectionDataSource.m in Sources */,
-				41970CBC038E201DD86E7DA0 /* VOKCoreDataManager.m in Sources */,
-				58B57607160AE879795EB7F8 /* VOKDefaultPagingAccessory.m in Sources */,
-				2F715CEF73CB9E868B8661F0 /* VOKFetchedResultsDataSource.m in Sources */,
-				33D70915190812DD11755229 /* VOKManagedObjectMap.m in Sources */,
-				B16BBEAA2296DE39135722AA /* VOKManagedObjectMapper.m in Sources */,
-				BAB2F3E84B53132A40700112 /* VOKPagingFetchedResultsDataSource.m in Sources */,
+				475591892E92E1DBE139B0CB /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				F2C2D2BAEA52D196E1C183F3 /* Pods-VOKCoreDataManager-Vokoder-dummy.m in Sources */,
+				813282608B047D4BA9E5CCDB /* VOKCollectionDataSource.m in Sources */,
+				F59C87D34F8CBE5AAD99055A /* VOKCoreDataManager.m in Sources */,
+				16DF7D6EBC324E822A81D430 /* VOKDefaultPagingAccessory.m in Sources */,
+				9A22C3BE79E732F376212980 /* VOKFetchedResultsDataSource.m in Sources */,
+				9C6F00CD9084D9F38A78F732 /* VOKManagedObjectMap.m in Sources */,
+				3E167120B7F354384D08BA29 /* VOKManagedObjectMapper.m in Sources */,
+				0898E1C0712DF4F0F10033F0 /* VOKPagingFetchedResultsDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7FBC9C3123F014D5624596A9 /* Sources */ = {
+		75F61F06BCCD6EE5B5FA7B15 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4ED51C63CD4BE5D91474ED4C /* ILGClasses.m in Sources */,
-				634596446B8FA7329E74349C /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m in Sources */,
+				DB0F48E0617254B27E8312E6 /* ILGClasses.m in Sources */,
+				CB25AB69E8993B4E66073E68 /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BEDF239E4C48E48E8F4836C3 /* Sources */ = {
+		88512ED62081B3B7E6157F03 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				831A60D8AF9DCBFA7894D4C0 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */,
+				CA81E4E1FE307526DB041B44 /* ILGClasses.m in Sources */,
+				2E83A502910CA0BADE9A874D /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EFDC02E5EEC898874A753DE2 /* Sources */ = {
+		E971F45211913D7350B3E022 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AF781990445F8F7FA58DBBD4 /* ILGClasses.m in Sources */,
-				49FD1DF47E594BEAF971167D /* Pods-VOKCoreDataManager-ILGDynamicObjC-dummy.m in Sources */,
+				3AF52CE45C7C765C723673ED /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				E72170AEBBC5A3FBFFB26416 /* Pods-VOKCoreDataManager Tests-Vokoder-dummy.m in Sources */,
+				556E043212A500A63D394EFC /* VOKCollectionDataSource.m in Sources */,
+				CFCE14597C362A4AF71B6834 /* VOKCoreDataManager.m in Sources */,
+				3632CDFD086A5441A6622A1B /* VOKDefaultPagingAccessory.m in Sources */,
+				C99CB84149719CA7483338C9 /* VOKFetchedResultsDataSource.m in Sources */,
+				AF909D6231B66BB32373B930 /* VOKManagedObjectMap.m in Sources */,
+				C2FD346EB228791F25234E65 /* VOKManagedObjectMapper.m in Sources */,
+				2790C9F1C31255CAAAF186D6 /* VOKPagingFetchedResultsDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0748DF136A9C1E666B0E66C5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-VOKCoreDataManager-ILGDynamicObjC";
-			target = CA1D0271ECD33FE1844A7194 /* Pods-VOKCoreDataManager-ILGDynamicObjC */;
-			targetProxy = C38FD4A3EC9E8E3014EFA9F2 /* PBXContainerItemProxy */;
-		};
-		114378B611EEA1D1B35AA0F3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-VOKCoreDataManager-Vokoder";
-			target = B03ADFB8F6D23CC0250D91F6 /* Pods-VOKCoreDataManager-Vokoder */;
-			targetProxy = 31F1D6DE254E7769452C11AD /* PBXContainerItemProxy */;
-		};
-		2133C8F70B9A6489674BD7A7 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-VOKCoreDataManager-ILGDynamicObjC";
-			target = CA1D0271ECD33FE1844A7194 /* Pods-VOKCoreDataManager-ILGDynamicObjC */;
-			targetProxy = E56E407CD97730A7490B9AA2 /* PBXContainerItemProxy */;
-		};
-		C3606F2663CFBFA712952351 /* PBXTargetDependency */ = {
+		05BB6AD223F0C1ECE430AE2E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-VOKCoreDataManager Tests-Vokoder";
-			target = 52C6D37073F52FAB7152A2D5 /* Pods-VOKCoreDataManager Tests-Vokoder */;
-			targetProxy = 51E8DEB05925F3F2796BF663 /* PBXContainerItemProxy */;
+			target = F1EA661BB05FEA6EC7257036 /* Pods-VOKCoreDataManager Tests-Vokoder */;
+			targetProxy = 91BA57E4E07B195DFC9E9490 /* PBXContainerItemProxy */;
 		};
-		EC02812CED4CC468795FACE1 /* PBXTargetDependency */ = {
+		487745592A1321F36662CBCD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-VOKCoreDataManager-ILGDynamicObjC";
+			target = CD9E212033A446A0FE0D47CD /* Pods-VOKCoreDataManager-ILGDynamicObjC */;
+			targetProxy = 6145B43CB457A613E84A1E52 /* PBXContainerItemProxy */;
+		};
+		5BD251A8F5816F21FCCBFF32 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-VOKCoreDataManager-ILGDynamicObjC";
+			target = CD9E212033A446A0FE0D47CD /* Pods-VOKCoreDataManager-ILGDynamicObjC */;
+			targetProxy = AB3A018916F4A82284E10FA3 /* PBXContainerItemProxy */;
+		};
+		5E6A053B4C3077A796617AEA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC";
-			target = 47157868C4DA39D578411302 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC */;
-			targetProxy = B9583152ED0E455F5E7AC441 /* PBXContainerItemProxy */;
+			target = 4379B747CC4BAADB1E7EEE9F /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC */;
+			targetProxy = 618F9BA23B265CD946A7634A /* PBXContainerItemProxy */;
 		};
-		FB68DBF21D7E52670C5C476C /* PBXTargetDependency */ = {
+		75DA7A51F40BA38307406201 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-VOKCoreDataManager-Vokoder";
+			target = 7E271A0A8F57DD8B77416817 /* Pods-VOKCoreDataManager-Vokoder */;
+			targetProxy = 6EE1A73D3258EC4FFA94F7F9 /* PBXContainerItemProxy */;
+		};
+		B6906B82C7FD84246BBE7076 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-VOKCoreDataManager Tests-ILGDynamicObjC";
-			target = 47157868C4DA39D578411302 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC */;
-			targetProxy = C49B299407C223871BEB44A4 /* PBXContainerItemProxy */;
+			target = 4379B747CC4BAADB1E7EEE9F /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC */;
+			targetProxy = 463742C6FC9FFF01912753BC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		0112861D6DCA6A03D179FA6E /* Release */ = {
+		0EEAD3A0888B0D0101A334CC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CB2C34D5FAA08442D7169827 /* Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig */;
+			baseConfigurationReference = 5F585F3AA2EF85CE0C1E09AA /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager Tests-ILGDynamicObjC/Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		0F31DF246D7BF539E7A5E34A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E7436E5ACEC05DF54F1FD44B /* Pods-VOKCoreDataManager.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		14C2E80AA92D0E079B25B86B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E607CCC8F641E48DD61B167C /* Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch";
@@ -851,103 +883,41 @@
 			};
 			name = Release;
 		};
-		02852E955BE0EA8CDA943D68 /* Release */ = {
+		3BE0D48B2428D17FC8DA0AAA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC286F66C0D9BD92282F56E8 /* Pods-VOKCoreDataManager.release.xcconfig */;
 			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
-		105DA04F13B55F2BB8110E9B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F278D49EC7C93E90E95066C3 /* Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager Tests-Vokoder/Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		14F758B1E9F97E84732B854E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E4F2F5906D87BB75A3BA0195 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager Tests-ILGDynamicObjC/Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		1ADA6F91CA1D219EBC8F2A1B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F278D49EC7C93E90E95066C3 /* Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager Tests-Vokoder/Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		1B438A0B5B1052E36217B50B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D2C1CB16A0AFCCD9A6A34B7A /* Pods-VOKCoreDataManager Tests.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		272C19482880B74EC52FED34 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E4F2F5906D87BB75A3BA0195 /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager Tests-ILGDynamicObjC/Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		2EB488284C6C9E2329FAA113 /* Debug */ = {
+		467711CC64F7BEF03296E43D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -986,107 +956,9 @@
 			};
 			name = Debug;
 		};
-		640E716A033110A426B62938 /* Debug */ = {
+		484ACD2A2F18C42D9AF4C048 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CB2C34D5FAA08442D7169827 /* Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		949D6A3BC8151B049224E52A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2A5845B84846183CBE4F2831 /* Pods-VOKCoreDataManager-Vokoder-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		A9B5427AC6B69196C1DCBC55 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 37673F636C50ABB0BB169C6B /* Pods-VOKCoreDataManager Tests.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		AB7C0D4DE61304CB99CBDB70 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9096BFF0D21B71B014C658B3 /* Pods-VOKCoreDataManager.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		C98DC8F9F55ACDB3A1B261DC /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		CEDA5C5EA5EFEC367B76785B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2A5845B84846183CBE4F2831 /* Pods-VOKCoreDataManager-Vokoder-Private.xcconfig */;
+			baseConfigurationReference = A6EF8B7EFD2E1CCC47DF8708 /* Pods-VOKCoreDataManager-Vokoder-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-prefix.pch";
@@ -1100,73 +972,201 @@
 			};
 			name = Release;
 		};
+		62A70F3D9AB85B4D0D3FF18A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A6EF8B7EFD2E1CCC47DF8708 /* Pods-VOKCoreDataManager-Vokoder-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager-Vokoder/Pods-VOKCoreDataManager-Vokoder-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		662A6A27DFB7B86E98C5EF39 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CDB0A3BD0052B4B5D3F460C0 /* Pods-VOKCoreDataManager Tests.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		87009C9F7637D9CA37ADA442 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DD0EE22B736E7363E5122AFC /* Pods-VOKCoreDataManager.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		AD76904D334D8D788EC38399 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E607CCC8F641E48DD61B167C /* Pods-VOKCoreDataManager-ILGDynamicObjC-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager-ILGDynamicObjC/Pods-VOKCoreDataManager-ILGDynamicObjC-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		D8D50F849165B23BA9E457CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5F585F3AA2EF85CE0C1E09AA /* Pods-VOKCoreDataManager Tests-ILGDynamicObjC-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager Tests-ILGDynamicObjC/Pods-VOKCoreDataManager Tests-ILGDynamicObjC-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		D9034790A95C1FE87539D2D8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 98F818433D2D2374B5AA9CB4 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		FAF0705E3E516E0820106F40 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1486DBBE53FDE6A7CE44BC90 /* Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager Tests-Vokoder/Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		FBBF108B46316CFF84996BBD /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1486DBBE53FDE6A7CE44BC90 /* Pods-VOKCoreDataManager Tests-Vokoder-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-VOKCoreDataManager Tests-Vokoder/Pods-VOKCoreDataManager Tests-Vokoder-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		00553C7D45D75658918D1DA6 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-ILGDynamicObjC" */ = {
+		0991EDEC12C9AF16E9A6B504 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests-ILGDynamicObjC" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				640E716A033110A426B62938 /* Debug */,
-				0112861D6DCA6A03D179FA6E /* Release */,
+				D8D50F849165B23BA9E457CD /* Debug */,
+				0EEAD3A0888B0D0101A334CC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		017DE7370D5574DFE5EAEBE4 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager" */ = {
+		0B6D80238EA399CAD8453461 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				AB7C0D4DE61304CB99CBDB70 /* Debug */,
-				02852E955BE0EA8CDA943D68 /* Release */,
+				D9034790A95C1FE87539D2D8 /* Debug */,
+				662A6A27DFB7B86E98C5EF39 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		168AFA2DEC9604264C553072 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-Vokoder" */ = {
+		1721DBA8314DDC07B0B389F7 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				949D6A3BC8151B049224E52A /* Debug */,
-				CEDA5C5EA5EFEC367B76785B /* Release */,
+				0F31DF246D7BF539E7A5E34A /* Debug */,
+				87009C9F7637D9CA37ADA442 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3B50CFF8F56ECE4A623E256A /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests-Vokoder" */ = {
+		364D70D809E8788681705451 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests-Vokoder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1ADA6F91CA1D219EBC8F2A1B /* Debug */,
-				105DA04F13B55F2BB8110E9B /* Release */,
+				FAF0705E3E516E0820106F40 /* Debug */,
+				FBBF108B46316CFF84996BBD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3E1BAA860A4F9E8160D0BB81 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests" */ = {
+		70A90B1D7ED20B42F0F13214 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-ILGDynamicObjC" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A9B5427AC6B69196C1DCBC55 /* Debug */,
-				1B438A0B5B1052E36217B50B /* Release */,
+				AD76904D334D8D788EC38399 /* Debug */,
+				14C2E80AA92D0E079B25B86B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		83DBC91973908D5451955F8E /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests-ILGDynamicObjC" */ = {
+		93EF038C07323C7B74CAB4F0 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				14F758B1E9F97E84732B854E /* Debug */,
-				272C19482880B74EC52FED34 /* Release */,
+				467711CC64F7BEF03296E43D /* Debug */,
+				3BE0D48B2428D17FC8DA0AAA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DD0DBBC795EF2FAC5A7E295B /* Build configuration list for PBXProject "Pods" */ = {
+		AB9383679EE5558BCAB1668D /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-Vokoder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2EB488284C6C9E2329FAA113 /* Debug */,
-				C98DC8F9F55ACDB3A1B261DC /* Release */,
+				62A70F3D9AB85B4D0D3FF18A /* Debug */,
+				484ACD2A2F18C42D9AF4C048 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = CEB64B834B69927EC84ABA66 /* Project object */;
+	rootObject = F3B8429DD8D21BA989EAE56A /* Project object */;
 }

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager Tests-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager Tests-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "52C6D37073F52FAB7152A2D5"
+               BlueprintIdentifier = "F1EA661BB05FEA6EC7257036"
                BuildableName = "libPods-VOKCoreDataManager Tests-Vokoder.a"
                BlueprintName = "Pods-VOKCoreDataManager Tests-Vokoder"
                ReferencedContainer = "container:Pods.xcodeproj">

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B03ADFB8F6D23CC0250D91F6"
+               BlueprintIdentifier = "7E271A0A8F57DD8B77416817"
                BuildableName = "libPods-VOKCoreDataManager-Vokoder.a"
                BlueprintName = "Pods-VOKCoreDataManager-Vokoder"
                ReferencedContainer = "container:Pods.xcodeproj">

--- a/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager Tests/Pods-VOKCoreDataManager Tests-environment.h
+++ b/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager Tests/Pods-VOKCoreDataManager Tests-environment.h
@@ -16,35 +16,35 @@
 #define COCOAPODS_POD_AVAILABLE_Vokoder
 #define COCOAPODS_VERSION_MAJOR_Vokoder 1
 #define COCOAPODS_VERSION_MINOR_Vokoder 3
-#define COCOAPODS_VERSION_PATCH_Vokoder 0
+#define COCOAPODS_VERSION_PATCH_Vokoder 1
 
 // Vokoder/Core
 #define COCOAPODS_POD_AVAILABLE_Vokoder_Core
 #define COCOAPODS_VERSION_MAJOR_Vokoder_Core 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_Core 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_Core 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_Core 1
 
 // Vokoder/DataSources
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources 1
 
 // Vokoder/DataSources/Collection
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_Collection
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_Collection 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_Collection 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_Collection 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_Collection 1
 
 // Vokoder/DataSources/FetchedResults
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_FetchedResults
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_FetchedResults 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_FetchedResults 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_FetchedResults 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_FetchedResults 1
 
 // Vokoder/DataSources/PagingFetchedResults
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_PagingFetchedResults
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_PagingFetchedResults 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_PagingFetchedResults 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_PagingFetchedResults 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_PagingFetchedResults 1
 

--- a/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager/Pods-VOKCoreDataManager-environment.h
+++ b/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager/Pods-VOKCoreDataManager-environment.h
@@ -16,35 +16,35 @@
 #define COCOAPODS_POD_AVAILABLE_Vokoder
 #define COCOAPODS_VERSION_MAJOR_Vokoder 1
 #define COCOAPODS_VERSION_MINOR_Vokoder 3
-#define COCOAPODS_VERSION_PATCH_Vokoder 0
+#define COCOAPODS_VERSION_PATCH_Vokoder 1
 
 // Vokoder/Core
 #define COCOAPODS_POD_AVAILABLE_Vokoder_Core
 #define COCOAPODS_VERSION_MAJOR_Vokoder_Core 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_Core 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_Core 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_Core 1
 
 // Vokoder/DataSources
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources 1
 
 // Vokoder/DataSources/Collection
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_Collection
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_Collection 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_Collection 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_Collection 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_Collection 1
 
 // Vokoder/DataSources/FetchedResults
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_FetchedResults
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_FetchedResults 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_FetchedResults 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_FetchedResults 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_FetchedResults 1
 
 // Vokoder/DataSources/PagingFetchedResults
 #define COCOAPODS_POD_AVAILABLE_Vokoder_DataSources_PagingFetchedResults
 #define COCOAPODS_VERSION_MAJOR_Vokoder_DataSources_PagingFetchedResults 1
 #define COCOAPODS_VERSION_MINOR_Vokoder_DataSources_PagingFetchedResults 3
-#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_PagingFetchedResults 0
+#define COCOAPODS_VERSION_PATCH_Vokoder_DataSources_PagingFetchedResults 1
 

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "1.3.0"
+  s.version          = "1.3.1"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
Xcode 6.4 only on Yosemite is picky as hell about library import paths.

This has that one-line change in the import, plus a version bump to 1.3.1 (since the 1.3.0 tag already exists), and pod updates in the sample projects.

@vokal/ios-developers "Review" please?

(Also, hat-tip to https://github.com/CocoaPods/CocoaPods/issues/3913#issuecomment-128028170, which pointed me in the right direction.)