### PR TITLE
Address #34.

### DIFF
--- a/Pod/Classes/VOKManagedObjectMapper.m
+++ b/Pod/Classes/VOKManagedObjectMapper.m
@@ -156,6 +156,10 @@
 - (id)checkClass:(id)inputObject managedObject:(NSManagedObject *)object key:(NSString *)key
 {
     Class expectedClass = [self expectedClassForObject:object andKey:key];
+    if (!expectedClass) {
+        VOK_CDLog(@"Failed to get class for %@\nProperty: %@", object, key);
+        return nil;
+    }
     if (![inputObject isKindOfClass:expectedClass]) {
         if (!(self.ignoreOptionalNullValues
               && (!inputObject || [[NSNull null] isEqual:inputObject])
@@ -194,6 +198,9 @@
             NSAssert(prop, @"Property named %s doesn't exist on class named %s.  Did you mean to use the default mapper?", propertyName, className);
         } else {
             NSAssert(prop, @"Property named %s doesn't exist on class named %s.", propertyName, className);
+        }
+        if (!prop) {
+            return Nil;
         }
 
         NSString *attributeString = [NSString stringWithCString:property_getAttributes(prop) encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Resolves #34.

Avoid production crashes with additional safety around failure to get a property and/or failure to get a class.  (Programmer-error cases are already covered by assertions.)

Since @chillpop said he was going to version-bump in a subsequent PR, I didn't touch the version and didn't `pod update` in either sample project.

@vokal/ios-developers Code review please?