### PR TITLE
Objective-C generics with backwards compatibility

### DIFF
--- a/Paging Data Source Example/Paging Data Source Example-Info.plist
+++ b/Paging Data Source Example/Paging Data Source Example-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.VOKAL.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Paging Data Source Example/Paging Data Source Example.xcodeproj/project.pbxproj
+++ b/Paging Data Source Example/Paging Data Source Example.xcodeproj/project.pbxproj
@@ -378,7 +378,7 @@
 				GCC_PREFIX_HEADER = "Paging Data Source Example-Prefix.pch";
 				INFOPLIST_FILE = "$(SRCROOT)/Paging Data Source Example-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.VOKAL.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Vokal.Paging-Data-Source-Example";
 				PRODUCT_NAME = "Paging Data Source Example";
 				WRAPPER_EXTENSION = app;
 			};
@@ -396,7 +396,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/Paging Data Source Example-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.VOKAL.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Vokal.Paging-Data-Source-Example";
 				PRODUCT_NAME = "Paging Data Source Example";
 				WRAPPER_EXTENSION = app;
 			};

--- a/Paging Data Source Example/Paging Data Source Example.xcodeproj/project.pbxproj
+++ b/Paging Data Source Example/Paging Data Source Example.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = VI;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0710;
 			};
 			buildConfigurationList = EA5F199A15C196500089AA44 /* Build configuration list for PBXProject "Paging Data Source Example" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -312,8 +312,10 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -350,6 +352,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -375,6 +378,7 @@
 				GCC_PREFIX_HEADER = "Paging Data Source Example-Prefix.pch";
 				INFOPLIST_FILE = "$(SRCROOT)/Paging Data Source Example-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.VOKAL.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "Paging Data Source Example";
 				WRAPPER_EXTENSION = app;
 			};
@@ -392,6 +396,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/Paging Data Source Example-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.VOKAL.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "Paging Data Source Example";
 				WRAPPER_EXTENSION = app;
 			};

--- a/Paging Data Source Example/Paging Data Source Example.xcodeproj/xcshareddata/xcschemes/Paging Data Source Example.xcscheme
+++ b/Paging Data Source Example/Paging Data Source Example.xcodeproj/xcshareddata/xcschemes/Paging Data Source Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,17 +38,21 @@
             ReferencedContainer = "container:Paging Data Source Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "EA5F199F15C196500089AA44"
@@ -61,12 +65,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "EA5F199F15C196500089AA44"

--- a/Paging Data Source Example/Pods/Headers/Private/Vokoder/VOKCoreDataCollectionTypes.h
+++ b/Paging Data Source Example/Pods/Headers/Private/Vokoder/VOKCoreDataCollectionTypes.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/VOKCoreDataCollectionTypes.h

--- a/Paging Data Source Example/Pods/Headers/Public/Vokoder/VOKCoreDataCollectionTypes.h
+++ b/Paging Data Source Example/Pods/Headers/Public/Vokoder/VOKCoreDataCollectionTypes.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/VOKCoreDataCollectionTypes.h

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,31 +7,32 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		03C857F433EBADC560BF858311161C6D /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A1AA0AB047204DFF94882A01CABDAB0 /* VOKManagedObjectMap.m */; };
-		0539AED40B206F78A2B4A6129CC0D437 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 799D0DC509FE60CBDC3AFA01FC4E18EE /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1109C1788E320524CAC366CCA1FDD141 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EC4A254CA884B5DC094BE95EDD3DDC58 /* VOKCoreDataManager.m */; };
-		13CF236EF731735CD35B79D962F5E06E /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F6BF77F8A02B3EB2ACEEBF494764005 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		03C857F433EBADC560BF858311161C6D /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FF2B327DE0A1ABB56F6FB6BD0943AD0 /* VOKManagedObjectMap.m */; };
+		08B907036A6BE96FF55211AA1D8D0AA1 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 84E86AB4578E186E7B2AFF8851D63295 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1109C1788E320524CAC366CCA1FDD141 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A9B9A992A9A2B13E8800A5179B03D58E /* VOKCoreDataManager.m */; };
 		196F157AEBC9B59D29D521F7E076D439 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 770C74B6DCFCEB4BE6325A9388C41FC0 /* VOKFetchedResultsDataSource.m */; };
-		26C169BB742D0E35FEC933F545ABA221 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = FAEAF6B7409CBFDCADB7755154F794D0 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3DFB3E4B860665C799BCB893F67BD7A8 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DE0BE671BFDF4511100322058B15EBB4 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		62CB89BC6D12BB5D82054A6A4EA26F16 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = D7180FA362DCE0EB5719EE0CC8EEA64B /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B3BBEB7DABFB694ED248639540E4947 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 01661146324EA0DA76527EB7035572C1 /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		398C60C9357C24E9E7F7F9BEEE4708F6 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 01661146324EA0DA76527EB7035572C1 /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5549D1D654D66CC8258FB01791AD83CE /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 438540CA566C4EC94C19ABC9F30C8F6C /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		788885E4255D772932135C398E8E1B6A /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = C8F9681D0E406EBCF9D6C6B260DE1EB7 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A2C65393A0A30B04AD143BEC504652F /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF7D4F51C8ADF9C669161A2E5E51B52 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B9A068C1DF7F9839504FABB4BE8BDF6 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = B0A5B40A76DE6D548909461D52504BFF /* VOKDefaultPagingAccessory.m */; };
-		804739B1ED5B5D3712A2997F191A165E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EAFE2B5C296F24A3AB441F8EAD38251 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		804739B1ED5B5D3712A2997F191A165E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A85A884FD8D4E8C7B655F9D8C004432E /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		804DC530169811990D87E81C7CAF1409 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BA03F557966E137F25B95C58B6CAFC6 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		812DFB7D099D2206F9D6926D475575EE /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 82125EC384E942ADA861A80B4E1C54FD /* VOKPagingFetchedResultsDataSource.m */; };
-		8EBEF8CF54C41D440C7E061074868975 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = FDCCD5015CE7D5885031249B2D1A3555 /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A23E4F9A68F21341A3DB857D801AF835 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = D7180FA362DCE0EB5719EE0CC8EEA64B /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A45BC990F32B6D3EAF48C6E3BB1DDAC3 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CB43F468D0CE4D041478891A2B0A15D /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A4BB08ECBCDFB996B1DAB517580C26DE /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 80160FDC40EF6CB58E7CF6AADB1E39D6 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ACA893ABD7E4F7DF2A0DE0EB147B8BE4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		B18C159AD70F20FFE918BDF286F40E6E /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 249D8F839D9397A93D6F37F9786BC499 /* VOKCollectionDataSource.m */; };
-		B69C59CFA5982774C869CDF168F0CDED /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = AEAA35A1757D39CA138E1FC0BBEDF3B5 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9079F74D1398C0370ACB47B775CD6A7 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B96552C6D33CE7BB443666B108DFA30 /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9822FC1C15B548E4B2A3631ED370F0E /* Pods-Paging Data Source Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 76FCE337C61B99F634ADD203BD4589AD /* Pods-Paging Data Source Example-dummy.m */; };
+		B9DF58D6641F80FFDA63D2869B75B88E /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 139657F659FC076EF7C64B990BB09813 /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C1056734ABFD11CED55A7139256063AE /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A283B9D1137B54CD97F1050A5291823 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C40DC6DEFE9B313145B4E9B73E5A2E25 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 75560487D681A7A0484C41F71B8365E9 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C63E5EBD8C9FF3B43E78E087CBAE6C22 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 57DFB1A3C95550F22062BC76F9A4CBDB /* VOKManagedObjectMapper.m */; };
-		CCECE529B32437CBB9152793BCF0E868 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF7D4F51C8ADF9C669161A2E5E51B52 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D36228D7D54130CBDF34796C0E344A81 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 18FA22BA364515E8473F2B89F28817D9 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DE21B421FF8C13F6A08A79004743A88B /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = F57ADA887B804CAFEFED7C5257EBFDA5 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C63E5EBD8C9FF3B43E78E087CBAE6C22 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 937A886B6CD1DB329E8A2DDD44662F8B /* VOKManagedObjectMapper.m */; };
 		ED25BE59A1DE84216F3FDECFBED32BDD /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D190B8553BD3314394B7A68597ECD513 /* CoreData.framework */; };
 		F7CABB38F71CFB24FE49B1C2C47AE740 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
+		F88A460B9436E4F993A373AE377C063B /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 799D0DC509FE60CBDC3AFA01FC4E18EE /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAAA12A123BCB7D8A3E0AF3B8E1C0085 /* ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 83C3DAEA588DA0673D6235CFA7AB31DD /* ILGDynamicObjC-dummy.m */; };
 		FEF747F0B0D8BC3455963BC5AF8604A8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		FFAFBCBF77EC3D261F43F846291787E5 /* Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FD6D489858C816B8AA66D1290CA9634C /* Vokoder-dummy.m */; };
@@ -64,44 +65,45 @@
 /* Begin PBXFileReference section */
 		01661146324EA0DA76527EB7035572C1 /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
 		0B96552C6D33CE7BB443666B108DFA30 /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
-		18FA22BA364515E8473F2B89F28817D9 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
+		139657F659FC076EF7C64B990BB09813 /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
 		249D8F839D9397A93D6F37F9786BC499 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
 		393E4BCB6B84CF48111C6A05EBFFBF46 /* Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Vokoder.xcconfig; sourceTree = "<group>"; };
+		438540CA566C4EC94C19ABC9F30C8F6C /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
 		4B9635343991A2D67AA3055F69FAF95B /* libVokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libVokoder.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		560ADA6B376E62F39B3220D7E9DB5ECE /* Pods-Paging Data Source Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.debug.xcconfig"; sourceTree = "<group>"; };
-		57DFB1A3C95550F22062BC76F9A4CBDB /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
+		5BA03F557966E137F25B95C58B6CAFC6 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
 		65900821EAD1DDD584635E06C1BD834F /* Pods-Paging Data Source Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.release.xcconfig"; sourceTree = "<group>"; };
-		6A1AA0AB047204DFF94882A01CABDAB0 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
 		6A8EAA421133B6B09336773AA3C0F738 /* Pods-Paging Data Source Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-frameworks.sh"; sourceTree = "<group>"; };
-		6EAFE2B5C296F24A3AB441F8EAD38251 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
+		6CB43F468D0CE4D041478891A2B0A15D /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
 		75560487D681A7A0484C41F71B8365E9 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
 		76FCE337C61B99F634ADD203BD4589AD /* Pods-Paging Data Source Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-dummy.m"; sourceTree = "<group>"; };
 		770C74B6DCFCEB4BE6325A9388C41FC0 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
 		799D0DC509FE60CBDC3AFA01FC4E18EE /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		7A283B9D1137B54CD97F1050A5291823 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
+		80160FDC40EF6CB58E7CF6AADB1E39D6 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
 		82125EC384E942ADA861A80B4E1C54FD /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
 		83C3DAEA588DA0673D6235CFA7AB31DD /* ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
+		84E86AB4578E186E7B2AFF8851D63295 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
 		8F3DFD80683BE681779D76CDAE7865F6 /* Pods-Paging Data Source Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Paging Data Source Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		8F6BF77F8A02B3EB2ACEEBF494764005 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
+		8FF2B327DE0A1ABB56F6FB6BD0943AD0 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
+		937A886B6CD1DB329E8A2DDD44662F8B /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
 		9DF7D4F51C8ADF9C669161A2E5E51B52 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
 		9F3E8EF1D588217723F3289841A25DF1 /* libILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libILGDynamicObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		AEAA35A1757D39CA138E1FC0BBEDF3B5 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
+		A85A884FD8D4E8C7B655F9D8C004432E /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
+		A9B9A992A9A2B13E8800A5179B03D58E /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
 		B0A5B40A76DE6D548909461D52504BFF /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
 		B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		C8F9681D0E406EBCF9D6C6B260DE1EB7 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
 		D190B8553BD3314394B7A68597ECD513 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
 		D7180FA362DCE0EB5719EE0CC8EEA64B /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
-		DE0BE671BFDF4511100322058B15EBB4 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
 		EBF958E44EC865CFE846FAFF3B9C33B7 /* Pods-Paging Data Source Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-resources.sh"; sourceTree = "<group>"; };
-		EC4A254CA884B5DC094BE95EDD3DDC58 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
 		F323E6A9DF2D511067E494B10BE08C69 /* ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ILGDynamicObjC.xcconfig; sourceTree = "<group>"; };
 		F454A3A24056DB3DCE273346636DE4A9 /* Pods-Paging Data Source Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Paging Data Source Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		F57ADA887B804CAFEFED7C5257EBFDA5 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
 		F9E7156AF0861917A6FC456143B05B90 /* libPods-Paging Data Source Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Paging Data Source Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FAEAF6B7409CBFDCADB7755154F794D0 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
 		FAF001A7E5DACAD78FD59474F63B20FA /* ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
 		FD05FE413330A0F6F2C5A37734C2A6E2 /* Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Vokoder-prefix.pch"; sourceTree = "<group>"; };
 		FD6D489858C816B8AA66D1290CA9634C /* Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Vokoder-dummy.m"; sourceTree = "<group>"; };
-		FDCCD5015CE7D5885031249B2D1A3555 /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -197,6 +199,14 @@
 			path = "Paging Data Source Example/Pods/Target Support Files/Vokoder";
 			sourceTree = "<group>";
 		};
+		20E02BA6F62978C55AD3065F171F63A1 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				8D3610F8B0A61E9B17CB4746C06C4F3A /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
 		2275B10F17A319ACF4E2FCEB6E48B5E8 /* Vokoder */ = {
 			isa = PBXGroup;
 			children = (
@@ -215,6 +225,14 @@
 				B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */,
 			);
 			name = iOS;
+			sourceTree = "<group>";
+		};
+		35B36633B6DC6C4C65E32C17CF208A1D /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				7A283B9D1137B54CD97F1050A5291823 /* VOKCoreDataManagerInternalMacros.h */,
+			);
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		36AE8AFA6A8E7D8CF1828A3C2FAF26AF /* Classes */ = {
@@ -244,7 +262,7 @@
 		5432B40F9F44CDE12CC2BF92C02E6CB4 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				9019D90BE6B2E38E73205C5733895196 /* Pod */,
+				20E02BA6F62978C55AD3065F171F63A1 /* Pod */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -311,12 +329,23 @@
 			path = ILGDynamicObjC;
 			sourceTree = "<group>";
 		};
-		9019D90BE6B2E38E73205C5733895196 /* Pod */ = {
+		8D3610F8B0A61E9B17CB4746C06C4F3A /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				D1DD8B9CA3D52D813C4C9D5117B986AB /* Classes */,
+				80160FDC40EF6CB58E7CF6AADB1E39D6 /* NSManagedObject+VOKManagedObjectAdditions.h */,
+				A85A884FD8D4E8C7B655F9D8C004432E /* NSManagedObject+VOKManagedObjectAdditions.m */,
+				438540CA566C4EC94C19ABC9F30C8F6C /* VOKCoreDataCollectionTypes.h */,
+				5BA03F557966E137F25B95C58B6CAFC6 /* VOKCoreDataManager.h */,
+				A9B9A992A9A2B13E8800A5179B03D58E /* VOKCoreDataManager.m */,
+				6CB43F468D0CE4D041478891A2B0A15D /* VOKManagedObjectMap.h */,
+				8FF2B327DE0A1ABB56F6FB6BD0943AD0 /* VOKManagedObjectMap.m */,
+				84E86AB4578E186E7B2AFF8851D63295 /* VOKManagedObjectMapper.h */,
+				937A886B6CD1DB329E8A2DDD44662F8B /* VOKManagedObjectMapper.m */,
+				C8F9681D0E406EBCF9D6C6B260DE1EB7 /* VOKMappableModel.h */,
+				139657F659FC076EF7C64B990BB09813 /* VOKNullabilityFeatures.h */,
+				35B36633B6DC6C4C65E32C17CF208A1D /* Internal */,
 			);
-			path = Pod;
+			path = Classes;
 			sourceTree = "<group>";
 		};
 		9A1E7C84946C527C604668341A336CE3 /* Products */ = {
@@ -327,14 +356,6 @@
 				4B9635343991A2D67AA3055F69FAF95B /* libVokoder.a */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		9CE249DC838DBB17F43461B8F0C3F112 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				F57ADA887B804CAFEFED7C5257EBFDA5 /* VOKCoreDataManagerInternalMacros.h */,
-			);
-			path = Internal;
 			sourceTree = "<group>";
 		};
 		9D695F033C4A93ADE081DB11508B59AB /* Classes */ = {
@@ -351,24 +372,6 @@
 				715076F02CD6B92542AFCBA3AACC9578 /* Classes */,
 			);
 			path = Pod;
-			sourceTree = "<group>";
-		};
-		D1DD8B9CA3D52D813C4C9D5117B986AB /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				DE0BE671BFDF4511100322058B15EBB4 /* NSManagedObject+VOKManagedObjectAdditions.h */,
-				6EAFE2B5C296F24A3AB441F8EAD38251 /* NSManagedObject+VOKManagedObjectAdditions.m */,
-				18FA22BA364515E8473F2B89F28817D9 /* VOKCoreDataManager.h */,
-				EC4A254CA884B5DC094BE95EDD3DDC58 /* VOKCoreDataManager.m */,
-				FAEAF6B7409CBFDCADB7755154F794D0 /* VOKManagedObjectMap.h */,
-				6A1AA0AB047204DFF94882A01CABDAB0 /* VOKManagedObjectMap.m */,
-				AEAA35A1757D39CA138E1FC0BBEDF3B5 /* VOKManagedObjectMapper.h */,
-				57DFB1A3C95550F22062BC76F9A4CBDB /* VOKManagedObjectMapper.m */,
-				8F6BF77F8A02B3EB2ACEEBF494764005 /* VOKMappableModel.h */,
-				FDCCD5015CE7D5885031249B2D1A3555 /* VOKNullabilityFeatures.h */,
-				9CE249DC838DBB17F43461B8F0C3F112 /* Internal */,
-			);
-			path = Classes;
 			sourceTree = "<group>";
 		};
 		D6D02DF6F13151A872A8858BE6651BE1 /* Pods */ = {
@@ -418,29 +421,30 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		8384EDE1691BF86298B561097DE90805 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3DFB3E4B860665C799BCB893F67BD7A8 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				6B3BBEB7DABFB694ED248639540E4947 /* VOKCollectionDataSource.h in Headers */,
-				D36228D7D54130CBDF34796C0E344A81 /* VOKCoreDataManager.h in Headers */,
-				DE21B421FF8C13F6A08A79004743A88B /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				62CB89BC6D12BB5D82054A6A4EA26F16 /* VOKDefaultPagingAccessory.h in Headers */,
-				CCECE529B32437CBB9152793BCF0E868 /* VOKFetchedResultsDataSource.h in Headers */,
-				26C169BB742D0E35FEC933F545ABA221 /* VOKManagedObjectMap.h in Headers */,
-				B69C59CFA5982774C869CDF168F0CDED /* VOKManagedObjectMapper.h in Headers */,
-				13CF236EF731735CD35B79D962F5E06E /* VOKMappableModel.h in Headers */,
-				8EBEF8CF54C41D440C7E061074868975 /* VOKNullabilityFeatures.h in Headers */,
-				0539AED40B206F78A2B4A6129CC0D437 /* VOKPagingFetchedResultsDataSource.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8F078591045F5F001A3B1395DFDA8320 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				B9079F74D1398C0370ACB47B775CD6A7 /* ILGClasses.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F472E759CAFF04EF2BA64133D16B0BF0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A4BB08ECBCDFB996B1DAB517580C26DE /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				398C60C9357C24E9E7F7F9BEEE4708F6 /* VOKCollectionDataSource.h in Headers */,
+				5549D1D654D66CC8258FB01791AD83CE /* VOKCoreDataCollectionTypes.h in Headers */,
+				804DC530169811990D87E81C7CAF1409 /* VOKCoreDataManager.h in Headers */,
+				C1056734ABFD11CED55A7139256063AE /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				A23E4F9A68F21341A3DB857D801AF835 /* VOKDefaultPagingAccessory.h in Headers */,
+				7A2C65393A0A30B04AD143BEC504652F /* VOKFetchedResultsDataSource.h in Headers */,
+				A45BC990F32B6D3EAF48C6E3BB1DDAC3 /* VOKManagedObjectMap.h in Headers */,
+				08B907036A6BE96FF55211AA1D8D0AA1 /* VOKManagedObjectMapper.h in Headers */,
+				788885E4255D772932135C398E8E1B6A /* VOKMappableModel.h in Headers */,
+				B9DF58D6641F80FFDA63D2869B75B88E /* VOKNullabilityFeatures.h in Headers */,
+				F88A460B9436E4F993A373AE377C063B /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -471,7 +475,7 @@
 			buildPhases = (
 				D85C8614412B58C71F2C9D88BB7D3602 /* Sources */,
 				5930D7213C3482ECEBDD7AE3C20C66E9 /* Frameworks */,
-				8384EDE1691BF86298B561097DE90805 /* Headers */,
+				F472E759CAFF04EF2BA64133D16B0BF0 /* Headers */,
 			);
 			buildRules = (
 			);

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-Paging Data Source Example-Vokoder.xcscheme
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-Paging Data Source Example-Vokoder.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,30 +23,42 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0DAF12DD571E222EE325A08E"
+            BuildableName = "libPods-Paging Data Source Example-Vokoder.a"
+            BlueprintName = "Pods-Paging Data Source Example-Vokoder"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -1,36 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES">
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '3F5F541C22C2FDB206B7100E'
-               BlueprintName = 'Vokoder'
-               ReferencedContainer = 'container:Pods.xcodeproj'
-               BuildableName = 'libVokoder.a'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A2CBEA9D0F7450454FE505AEBBEA9BF9"
+               BuildableName = "libVokoder.a"
+               BlueprintName = "Vokoder"
+               ReferencedContainer = "container:Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -38,17 +41,25 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A2CBEA9D0F7450454FE505AEBBEA9BF9"
+            BuildableName = "libVokoder.a"
+            BlueprintName = "Vokoder"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.h
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.h
@@ -10,10 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSManagedObject (VOKManagedObjectAdditions)
-
 /// A completion block after an asynchronous operation on a temporary context. NSManagedObject's are not threadsafe.
 typedef void(^VOKManagedObjectsReturnBlock)(VOKArrayOfManagedObjects *managedObjects);
+
+@interface NSManagedObject (VOKManagedObjectAdditions)
 
 /**
  Checks for NSNull before seting a value.

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.h
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.h
@@ -5,6 +5,7 @@
 
 #import <CoreData/CoreData.h>
 
+#import "VOKCoreDataCollectionTypes.h"
 #import "VOKNullabilityFeatures.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -12,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSManagedObject (VOKManagedObjectAdditions)
 
 /// A completion block after an asynchronous operation on a temporary context. NSManagedObject's are not threadsafe.
-typedef void(^VOKManagedObjectsReturnBlock)(NSArray *arrayOfManagedObjects);
+typedef void(^VOKManagedObjectsReturnBlock)(VOKArrayOfManagedObjects *managedObjects);
 
 /**
  Checks for NSNull before seting a value.
@@ -26,14 +27,14 @@ typedef void(^VOKManagedObjectsReturnBlock)(NSArray *arrayOfManagedObjects);
  This method does not respect keyPaths. The dictionary is flat.
  @return    An NSDictionary matching the original input dictionary.
  */
-- (NSDictionary *)vok_dictionaryRepresentation;
+- (VOKStringToObjectDictionary *)vok_dictionaryRepresentation;
 
 /**
  Creates a dictionary based on the set mapping. This should round-trip data from dictionaries to core data and back.
  This method respects keyPaths.
  @return    An NSDictionary matching the original input dictionary.
  */
-- (NSDictionary *)vok_dictionaryRepresentationRespectingKeyPaths;
+- (VOKStringToObjectDictionary *)vok_dictionaryRepresentationRespectingKeyPaths;
 
 /**
  Gets the entity name string for the particular NSManagedObject subclass on which the method is called.
@@ -63,8 +64,8 @@ typedef void(^VOKManagedObjectsReturnBlock)(NSArray *arrayOfManagedObjects);
  @param contextOfNil    The managed object context to update and/or insert the objects. If nil, the main context will be used.
  @return                An array of this subclass of NSManagedObject.
  **/
-+ (NSArray *)vok_addWithArray:(NSArray *)inputArray
-      forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
++ (VOKArrayOfManagedObjects *)vok_addWithArray:(VOKArrayOfObjectDictionaries *)inputArray
+                       forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
 
 /*
  Create or update a NSManagedObject, respecting the mapper's overwriteObjectsWithServerChanges and ignoreNullValueOverwrites properties.
@@ -75,7 +76,7 @@ typedef void(^VOKManagedObjectsReturnBlock)(NSArray *arrayOfManagedObjects);
  @param contextOfNil    The managed object context to update and/or insert the object. If nil, the main context will be used.
  @return                An instance of this subclass of NSManagedObject.
  **/
-+ (nullable instancetype)vok_addWithDictionary:(NSDictionary *)inputDict
++ (nullable instancetype)vok_addWithDictionary:(VOKStringToObjectDictionary *)inputDict
                        forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
 
 /*
@@ -86,7 +87,7 @@ typedef void(^VOKManagedObjectsReturnBlock)(NSArray *arrayOfManagedObjects);
  @param inputArray      An array of dictionaries with foreign data to input on a background queue in a temporary context.
  @param completion      Executed after the background operation. The array contains the objects imported/updated. It will be executed on the main queue.
  **/
-+ (void)vok_addWithArrayInBackground:(NSArray *)inputArray
++ (void)vok_addWithArrayInBackground:(VOKArrayOfObjectDictionaries *)inputArray
                           completion:(nullable VOKManagedObjectsReturnBlock)completion;
 
 /*
@@ -117,8 +118,8 @@ typedef void(^VOKManagedObjectsReturnBlock)(NSArray *arrayOfManagedObjects);
  @param contextOrNil    The managed object context to fetch in.  If nil, the main context will be used.
  @return                NSArray full of the instances of the current class.
  */
-+ (NSArray *)vok_fetchAllForPredicate:(nullable NSPredicate *)predicate
-              forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
++ (VOKArrayOfManagedObjects *)vok_fetchAllForPredicate:(nullable NSPredicate *)predicate
+                               forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
 
 /*
  Returns all entites matching the predicate, sorted using the array of sort descriptors.
@@ -127,9 +128,9 @@ typedef void(^VOKManagedObjectsReturnBlock)(NSArray *arrayOfManagedObjects);
  @param contextOrNil    The managed object context to fetch in.  If nil, the main context will be used.
  @return                NSArray full of the instances of the current class.
  */
-+ (NSArray *)vok_fetchAllForPredicate:(nullable NSPredicate *)predicate
-                             sortedBy:(nullable NSArray *)sortDescriptors
-              forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
++ (VOKArrayOfManagedObjects *)vok_fetchAllForPredicate:(nullable NSPredicate *)predicate
+                                              sortedBy:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
+                               forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
 
 /*
  Returns all entites matching the predicate.
@@ -139,10 +140,10 @@ typedef void(^VOKManagedObjectsReturnBlock)(NSArray *arrayOfManagedObjects);
  @param contextOrNil    The managed object context to fetch in.  If nil, the main context will be used.
  @return                NSArray full of the instances of the current class.
  */
-+ (NSArray *)vok_fetchAllForPredicate:(nullable NSPredicate *)predicate
-                          sortedByKey:(NSString *)sortKey
-                            ascending:(BOOL)ascending
-              forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
++ (VOKArrayOfManagedObjects *)vok_fetchAllForPredicate:(nullable NSPredicate *)predicate
+                                           sortedByKey:(NSString *)sortKey
+                                             ascending:(BOOL)ascending
+                               forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
 
 /*
  Returns one entite matching the predicate. Asserts the count is exactly 1. If more objects are returned this method will let you know.

--- a/Pod/Classes/Optional Data Sources/VOKCollectionDataSource.h
+++ b/Pod/Classes/Optional Data Sources/VOKCollectionDataSource.h
@@ -19,14 +19,14 @@ NS_ASSUME_NONNULL_BEGIN
               cacheName:(nullable NSString *)cacheName
          collectionView:(nullable UICollectionView *)collectionView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass;
 
 - (id)initWithPredicate:(nullable NSPredicate *)predicate
               cacheName:(nullable NSString *)cacheName
          collectionView:(nullable UICollectionView *)collectionView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass
               batchSize:(NSInteger)batchSize;
 
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
               cacheName:(nullable NSString *)cacheName
          collectionView:(nullable UICollectionView *)collectionView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass
                delegate:(nullable id <VOKFetchedResultsDataSourceDelegate>)delegate;
 
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
               cacheName:(nullable NSString *)cacheName
          collectionView:(nullable UICollectionView *)collectionView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass
               batchSize:(NSInteger)batchSize
                delegate:(nullable id <VOKFetchedResultsDataSourceDelegate>)delegate;
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
               cacheName:(nullable NSString *)cacheName
          collectionView:(nullable UICollectionView *)collectionView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass
               batchSize:(NSInteger)batchSize
              fetchLimit:(NSInteger)fetchLimit

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) NSInteger fetchLimit;
 
 @property (weak, nonatomic) NSPredicate *predicate;
-@property (weak, nonatomic) NSArray *sortDescriptors;
+@property (weak, nonatomic) VOKArrayOfSortDescriptors *sortDescriptors;
 
 @property (nonatomic) BOOL includesSubentities;
 
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 //you can ignore deprecation warnings in subclasses
 @property (strong, readonly) NSFetchedResultsController *fetchedResultsController;
 
-- (nullable NSArray *)fetchedObjects;
+- (nullable VOKArrayOfManagedObjects *)fetchedObjects;
 
 - (void)reloadData;
 
@@ -52,14 +52,14 @@ NS_ASSUME_NONNULL_BEGIN
               cacheName:(nullable NSString *)cacheName
               tableView:(nullable UITableView *)tableView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass;
 
 - (id)initWithPredicate:(nullable NSPredicate *)predicate
               cacheName:(nullable NSString *)cacheName
               tableView:(nullable UITableView *)tableView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass
               batchSize:(NSInteger)batchSize;
 
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
               cacheName:(nullable NSString *)cacheName
               tableView:(nullable UITableView *)tableView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass
                delegate:(nullable id <VOKFetchedResultsDataSourceDelegate>)delegate;
 
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
               cacheName:(nullable NSString *)cacheName
               tableView:(nullable UITableView *)tableView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass
               batchSize:(NSInteger)batchSize
                delegate:(nullable id <VOKFetchedResultsDataSourceDelegate>)delegate;
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
               cacheName:(nullable NSString *)cacheName
               tableView:(nullable UITableView *)tableView
      sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
-        sortDescriptors:(nullable NSArray *)sortDescriptors
+        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
      managedObjectClass:(Class)managedObjectClass
               batchSize:(NSInteger)batchSize
              fetchLimit:(NSInteger)fetchLimit

--- a/Pod/Classes/VOKCoreDataCollectionTypes.h
+++ b/Pod/Classes/VOKCoreDataCollectionTypes.h
@@ -15,11 +15,10 @@
 @class NSManagedObjectID;
 @class VOKManagedObjectMap;
 
-//include the pointer for this one since the fallback is id
-#define VOKManagedObjectSubclassPtr __kindof NSManagedObject *
+typedef __kindof NSManagedObject VOKManagedObjectSubclass;
 
 // [NSManagedObject]
-typedef NSArray<VOKManagedObjectSubclassPtr> VOKArrayOfManagedObjects;
+typedef NSArray<VOKManagedObjectSubclass *> VOKArrayOfManagedObjects;
 
 // [NSManagedObjectID]
 typedef NSArray<__kindof NSManagedObjectID *> VOKArrayOfManagedObjectIDs;
@@ -45,7 +44,7 @@ typedef NSDictionary<NSString *, NSString *> VOKStringToStringDictionary;
 #else
 //no generic support, fallback to regular NSArray, NSDictionary
 
-#define VOKManagedObjectSubclassPtr id
+#define VOKManagedObjectSubclass NSManagedObject
 #define VOKArrayOfManagedObjects NSArray
 #define VOKArrayOfManagedObjectIDs NSArray
 #define VOKStringToObjectDictionary NSDictionary

--- a/Pod/Classes/VOKCoreDataCollectionTypes.h
+++ b/Pod/Classes/VOKCoreDataCollectionTypes.h
@@ -1,0 +1,61 @@
+//
+//  VOKCoreDataCollectionTypes.h
+//  Pods
+//
+//  Created by Carl Hill-Popper on 10/23/15.
+//
+//
+
+#ifndef VOKCoreDataCollectionTypes_h
+#define VOKCoreDataCollectionTypes_h
+
+#if __has_feature(objc_generics)
+//forward declare classes used here since we don't know where this will be included
+@class NSManagedObject;
+@class NSManagedObjectID;
+@class VOKManagedObjectMap;
+
+//include the pointer for this one since the fallback is id
+#define VOKManagedObjectSubclassPtr __kindof NSManagedObject *
+
+// [NSManagedObject]
+typedef NSArray<VOKManagedObjectSubclassPtr> VOKArrayOfManagedObjects;
+
+// [NSManagedObjectID]
+typedef NSArray<__kindof NSManagedObjectID *> VOKArrayOfManagedObjectIDs;
+
+// [String : AnyObject]
+typedef NSDictionary<NSString *, id> VOKStringToObjectDictionary;
+
+// [String : AnyObject] mutable
+typedef NSMutableDictionary<NSString *, id> VOKStringToObjectMutableDictionary;
+
+// [VOKStringToObjectDictionary]
+typedef NSArray<VOKStringToObjectDictionary *> VOKArrayOfObjectDictionaries;
+
+// [NSSortDescriptor]
+typedef NSArray<NSSortDescriptor *> VOKArrayOfSortDescriptors;
+
+// [VOKManagedObjectMap]
+typedef NSArray<VOKManagedObjectMap *> VOKArrayOfManagedObjectMaps;
+
+// [String : String]
+typedef NSDictionary<NSString *, NSString *> VOKStringToStringDictionary;
+
+#else
+//no generic support, fallback to regular NSArray, NSDictionary
+
+#define VOKManagedObjectSubclassPtr id
+#define VOKArrayOfManagedObjects NSArray
+#define VOKArrayOfManagedObjectIDs NSArray
+#define VOKStringToObjectDictionary NSDictionary
+#define VOKStringToObjectMutableDictionary NSMutableDictionary
+#define VOKArrayOfObjectDictionaries NSArray
+#define VOKArrayOfSortDescriptors NSArray
+
+#define VOKArrayOfManagedObjectMaps NSArray
+#define VOKStringToStringDictionary NSDictionary
+
+#endif
+
+#endif /* VOKGenericCollectionTypes_h */

--- a/Pod/Classes/VOKCoreDataManager.h
+++ b/Pod/Classes/VOKCoreDataManager.h
@@ -217,8 +217,8 @@ typedef void(^VOKObjectIDsReturnBlock)(VOKArrayOfManagedObjectIDs *managedObject
  @param contextOrNil    The managed object context in which fetch instances of the given class. A nil context will use the main context.
  @return                The object matching the uri passed in. If the object doesn't exist nil is returned.
  */
-- (nullable VOKManagedObjectSubclassPtr)existingObjectAtURI:(NSURL *)uri
-                                    forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
+- (nullable VOKManagedObjectSubclass *)existingObjectAtURI:(NSURL *)uri
+                                   forManagedObjectContext:(nullable NSManagedObjectContext *)contextOrNil;
 
 /**
  Deletes a given object in its current context. Uses the object's context. As always, remember to keep NSManagedObjects on one queue.

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -382,7 +382,7 @@ static VOKCoreDataManager *VOK_SharedObject;
     return results;
 }
 
-- (id)existingObjectAtURI:(NSURL *)uri forManagedObjectContext:(NSManagedObjectContext *)contextOrNil
+- (NSManagedObject *)existingObjectAtURI:(NSURL *)uri forManagedObjectContext:(NSManagedObjectContext *)contextOrNil
 {
     NSManagedObjectID *objectID = [self.persistentStoreCoordinator managedObjectIDForURIRepresentation:uri];
     

--- a/Pod/Classes/VOKManagedObjectMap.h
+++ b/Pod/Classes/VOKManagedObjectMap.h
@@ -5,6 +5,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "VOKCoreDataCollectionTypes.h"
 #import "VOKNullabilityFeatures.h"
 
 /**
@@ -86,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param mapDict     Each key is the expected input keyPath and each value is core data key.
  @return            An array of VOKManagedObjectMaps.
  */
-+ (NSArray *)mapsFromDictionary:(NSDictionary *)mapDict;
++ (VOKArrayOfManagedObjectMaps *)mapsFromDictionary:(VOKStringToStringDictionary *)mapDict;
 
 /**
  Default formatter used for date fields. This is the RFC 3339 format, with

--- a/Pod/Classes/VOKManagedObjectMapper.h
+++ b/Pod/Classes/VOKManagedObjectMapper.h
@@ -13,9 +13,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^VOKPostImportBlock)(VOKStringToObjectDictionary *inputDict, NSManagedObject *outputObject);
+typedef void(^VOKPostImportBlock)(VOKStringToObjectDictionary *inputDict, VOKManagedObjectSubclass *outputObject);
 
-typedef void(^VOKPostExportBlock)(VOKStringToObjectMutableDictionary *outputDict, NSManagedObject *inputObject);
+typedef void(^VOKPostExportBlock)(VOKStringToObjectMutableDictionary *outputDict, VOKManagedObjectSubclass *inputObject);
 
 @interface VOKManagedObjectMapper : NSObject
 

--- a/Pod/Classes/VOKManagedObjectMapper.h
+++ b/Pod/Classes/VOKManagedObjectMapper.h
@@ -13,8 +13,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// An completion block to run after importing each foreign dictionary.
 typedef void(^VOKPostImportBlock)(VOKStringToObjectDictionary *inputDict, VOKManagedObjectSubclass *outputObject);
 
+/// A completion block to run after exporting a managed object to a dictionary.
 typedef void(^VOKPostExportBlock)(VOKStringToObjectMutableDictionary *outputDict, VOKManagedObjectSubclass *inputObject);
 
 @interface VOKManagedObjectMapper : NSObject

--- a/Pod/Classes/VOKManagedObjectMapper.h
+++ b/Pod/Classes/VOKManagedObjectMapper.h
@@ -6,15 +6,16 @@
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
 
+#import "VOKCoreDataCollectionTypes.h"
 #import "VOKNullabilityFeatures.h"
 
 #import "VOKManagedObjectMap.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^VOKPostImportBlock)(NSDictionary *inputDict, NSManagedObject *outputObject);
+typedef void(^VOKPostImportBlock)(VOKStringToObjectDictionary *inputDict, NSManagedObject *outputObject);
 
-typedef void(^VOKPostExportBlock)(NSMutableDictionary *outputDict, NSManagedObject *inputObject);
+typedef void(^VOKPostExportBlock)(VOKStringToObjectMutableDictionary *outputDict, NSManagedObject *inputObject);
 
 @interface VOKManagedObjectMapper : NSObject
 
@@ -36,13 +37,13 @@ typedef void(^VOKPostExportBlock)(NSMutableDictionary *outputDict, NSManagedObje
 @property (nonatomic, copy) VOKPostExportBlock __nullable exportCompletionBlock;
 
 /**
- Creates a new map.
+ Creates a new mapper.
  @param comparisonKey   An NSString to uniquely identify local entities. Can be nil to enable duplicates.
  @param mapsArray       An NSArray of VOKManagedObjectMaps to corrdinate input data and the core data model.
  @return                A new mapper with the given unique key and maps.
  */
 + (instancetype)mapperWithUniqueKey:(nullable NSString *)comparisonKey
-                            andMaps:(NSArray *)mapsArray;
+                            andMaps:(VOKArrayOfManagedObjectMaps *)mapsArray;
 /**
  Convenience constructor for default mapper.
  @return    A default mapper wherein the local keys and foreign keys are identical.

--- a/Pod/Classes/VOKMappableModel.h
+++ b/Pod/Classes/VOKMappableModel.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol VOKMappableModel <NSObject>
 
 ///@return an array of VOKManagedObjectMap objects mapping foreign keys to local keys.
-+ (NSArray *)coreDataMaps;
++ (VOKArrayOfManagedObjectMaps *)coreDataMaps;
 
 ///@return the key name to use to uniquely compare two instances of a class.
 + (nullable NSString *)uniqueKey;

--- a/SampleProject/Pods/Headers/Private/Vokoder/VOKCoreDataCollectionTypes.h
+++ b/SampleProject/Pods/Headers/Private/Vokoder/VOKCoreDataCollectionTypes.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/VOKCoreDataCollectionTypes.h

--- a/SampleProject/Pods/Headers/Public/Vokoder/VOKCoreDataCollectionTypes.h
+++ b/SampleProject/Pods/Headers/Public/Vokoder/VOKCoreDataCollectionTypes.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/VOKCoreDataCollectionTypes.h

--- a/SampleProject/Pods/Pods.xcodeproj/project.pbxproj
+++ b/SampleProject/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,33 +7,34 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0C802039BF1FA120174B71B65DDD3303 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 21626EBBD5B012A19F13D97D0FA4598F /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DE394F65D68884B0FA481851F21B327 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 41A112130B5CFCEAA8C96901F9D46DEC /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09D5CFB9E8D9C6E8866FE39D7B5D2D8D /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D56C1F3F66E7ED868EDF4400358F808 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DDD3D3C220B07CFCBA02E337502DEB8 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A6EA8E90AA03A2F8861E0B591E5A0264 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2727F57E74B4A6BC514BD8B860B2F0B9 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FAD3754A05D32E59309613C6D17B88C /* VOKDefaultPagingAccessory.m */; };
-		31A15ABA57F09F4F294123D02908A42D /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 00BB5BDD6235AC3CB56272ECA02F0684 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		2B0A2E5222FFA0A65C1E9FD29FC40B93 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 69D610DA300F18E9CD4B0E3353D13079 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		31A15ABA57F09F4F294123D02908A42D /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D2A1C115A76F4489C8EA2029BFBDB76 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
 		32596DED9F7878DE3781CB209CC2627E /* Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A02F54C47615AD824FAD2388E8B9EF7 /* Vokoder-dummy.m */; };
-		3B42EC7A027A81A26BA35CE4AAC57B81 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D44524F10DF6B68200DC0C32F511C266 /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3838CEFE93E84E0A5538F273ACFD60A0 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 22BD905008F28FF4BC3B92B610F121B3 /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		44158341E167B76B65167E15077F6610 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D190B8553BD3314394B7A68597ECD513 /* CoreData.framework */; };
-		56D098ADF7E2E3AD7D132B920AF979FE /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 861CA4394A7D891F9A8805EB4D67371F /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		619094545C99A18381C3D9D0CDA3A14F /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A7B7E62EED6D096F0D19D867EC59A64C /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		52121EA79E09C6F6AB2B8E4AB2AAC31B /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B42A49F6B5DB7C6B35F1EC34A2C584A6 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63742F21BF732C2FC3A1B9347BA7043B /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = A6AE8D66476D5D6F3E15CE09BAAACE8F /* VOKFetchedResultsDataSource.m */; };
-		6C0E171AB4B16D85050C222CB60AE203 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1716D0C04B1CEE77299F2E79C7305F5B /* VOKCoreDataManager.m */; };
-		73E7F83F3372AA44996B05BDC96144AD /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C7339F9530BAF738D1001C629D7833E /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7D850EBCFC8D5901B5B14FC9C84D8F45 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = CAC9A5CA4D209B442E8F88DC409BC669 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6C0E171AB4B16D85050C222CB60AE203 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DF51F859746AC6AD389F5CE590CFDEB /* VOKCoreDataManager.m */; };
 		841BED808B1493215B855311BB55AD5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
-		933415564DEE0FDE6F57EDCE80209092 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A3A0AE924FF1F4550BC5323475EB7B5 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		93CCF75D620A23706050677E6113522F /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 5898D8E2DEA252F31CE31D2F6279D912 /* VOKManagedObjectMap.m */; };
-		9BB8C57E16CE05589186BAB73FE05E36 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 678A920D7CF5DC1B2123A4F140D321E1 /* VOKManagedObjectMapper.m */; };
+		88DEF95FEC47BC22B277F3488FA18F89 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AB7EB8F1DA2DD4E38CF24287A62D8E97 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93CCF75D620A23706050677E6113522F /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = B6A20DF796560FF4DA99D02C596A987F /* VOKManagedObjectMap.m */; };
+		9BB8C57E16CE05589186BAB73FE05E36 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 04E139BDC6B35156AFDE884F4A572282 /* VOKManagedObjectMapper.m */; };
+		9E12C787EA89ED4611E5770B60D9F1CD /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A3A0AE924FF1F4550BC5323475EB7B5 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F22E6FD52609D2C7572AB037C2AD489 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = F740E70F1953AB02427370435F8F19D8 /* VOKCollectionDataSource.m */; };
 		A02C1B5F7AF6B25FB99C0188200E51DB /* Pods-VOKCoreDataManager-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C1311138A087A8C09DBD9971BA1225E /* Pods-VOKCoreDataManager-dummy.m */; };
-		A8F28C1B198D2D5046D6F1A2A00D56A2 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = C94F74602BFA315E6021239F898D5FA2 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A92BD33C24189CA1F41BD6E11DC3B4AA /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 69D610DA300F18E9CD4B0E3353D13079 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A0D3656557D597F7216FBE8C8EC9C28C /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = CAC9A5CA4D209B442E8F88DC409BC669 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAC36CF5410E482E907CEC8A058667AE /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D44524F10DF6B68200DC0C32F511C266 /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AE27D6F595D455BBB320E3F5D6E3329F /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 78C5B7E35EA648D36A0777837F3058A8 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9079F74D1398C0370ACB47B775CD6A7 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B96552C6D33CE7BB443666B108DFA30 /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD1467C8A69429D6528B94700A874C54 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 46FA8F20B5A840203FDD211588D3E184 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C40DC6DEFE9B313145B4E9B73E5A2E25 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 75560487D681A7A0484C41F71B8365E9 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		C9E13D8EE88D5A633C2F45798A51E4FF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		DA627D87320298F8A3CADC2D9DCCEE4D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		DCC00AE85E693677FFBC6D1F18189B42 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 59FFEC0EBBC7CB50B6C2C443E95A51D6 /* VOKPagingFetchedResultsDataSource.m */; };
-		E1D33249DDAF7AE06DF14520BA2DA67F /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 8650D803E301D92132436E839A6530B3 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD8CD200AF91C55A1C90EF8F778E74A2 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 04B372B7471C542BDFD305B3AC011BED /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F7CABB38F71CFB24FE49B1C2C47AE740 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		F97B8927170A88D3E65B28A1B3678344 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 57235B66D08563B4E0A57B24D8A31EF6 /* Pods-VOKCoreDataManager Tests-dummy.m */; };
 		FAAA12A123BCB7D8A3E0AF3B8E1C0085 /* ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 83C3DAEA588DA0673D6235CFA7AB31DD /* ILGDynamicObjC-dummy.m */; };
@@ -78,46 +79,47 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		00BB5BDD6235AC3CB56272ECA02F0684 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
 		02D613911E97E88389490AFFC486D15D /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		04B372B7471C542BDFD305B3AC011BED /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
+		04E139BDC6B35156AFDE884F4A572282 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
 		0B96552C6D33CE7BB443666B108DFA30 /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
-		1716D0C04B1CEE77299F2E79C7305F5B /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		0D2A1C115A76F4489C8EA2029BFBDB76 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
 		1A02F54C47615AD824FAD2388E8B9EF7 /* Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Vokoder-dummy.m"; sourceTree = "<group>"; };
+		1D56C1F3F66E7ED868EDF4400358F808 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
 		1FAD3754A05D32E59309613C6D17B88C /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
 		21473FEFE99B96337C17F9D41BC02940 /* Pods-VOKCoreDataManager-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-acknowledgements.plist"; sourceTree = "<group>"; };
-		21626EBBD5B012A19F13D97D0FA4598F /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
+		22BD905008F28FF4BC3B92B610F121B3 /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
 		235377919D31864677672149C8E07C0B /* Pods-VOKCoreDataManager Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-frameworks.sh"; sourceTree = "<group>"; };
 		236902F2E4038A5FBE48ABE393C3D603 /* Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Vokoder.xcconfig; sourceTree = "<group>"; };
-		41A112130B5CFCEAA8C96901F9D46DEC /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
+		2DF51F859746AC6AD389F5CE590CFDEB /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
 		452F9F135A375CF610B249778A08B315 /* libVokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libVokoder.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		46FA8F20B5A840203FDD211588D3E184 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
 		4BC4F8FC80DEC6EEA764A3C7071DF4EE /* libPods-VOKCoreDataManager.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E32F53C3DCE401FD8B3944B6A844F76 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		5056AC853385DCFAB9E0B80EE51563D9 /* Pods-VOKCoreDataManager-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-resources.sh"; sourceTree = "<group>"; };
 		5664BF768292E545F148522AF760D3EF /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		57235B66D08563B4E0A57B24D8A31EF6 /* Pods-VOKCoreDataManager Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-dummy.m"; sourceTree = "<group>"; };
-		5898D8E2DEA252F31CE31D2F6279D912 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
 		59FFEC0EBBC7CB50B6C2C443E95A51D6 /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
 		5C1311138A087A8C09DBD9971BA1225E /* Pods-VOKCoreDataManager-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-dummy.m"; sourceTree = "<group>"; };
-		678A920D7CF5DC1B2123A4F140D321E1 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
 		69D610DA300F18E9CD4B0E3353D13079 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
 		6A3A0AE924FF1F4550BC5323475EB7B5 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
 		6FA5ED4CDE4E734606DBA1CC3D4C876F /* Pods-VOKCoreDataManager-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-acknowledgements.markdown"; sourceTree = "<group>"; };
 		7345CE79B1D6636DB38E844BDEEB90DB /* Pods-VOKCoreDataManager Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-resources.sh"; sourceTree = "<group>"; };
 		75560487D681A7A0484C41F71B8365E9 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
+		78C5B7E35EA648D36A0777837F3058A8 /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
 		7CEFE5889C514FCB3CE8095FBEB80837 /* Pods-VOKCoreDataManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.debug.xcconfig"; sourceTree = "<group>"; };
 		82B8A5254EE829157070061D56D87D05 /* Pods-VOKCoreDataManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.release.xcconfig"; sourceTree = "<group>"; };
 		83C3DAEA588DA0673D6235CFA7AB31DD /* ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
-		861CA4394A7D891F9A8805EB4D67371F /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
-		8650D803E301D92132436E839A6530B3 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
-		8C7339F9530BAF738D1001C629D7833E /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
 		97D21B9F83BAE7D5C53CFDEC95BBDBCE /* Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Vokoder-prefix.pch"; sourceTree = "<group>"; };
 		9D04E15D4AA19BDB744A7E4CD686EC03 /* libILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libILGDynamicObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A649AE2B23F489C1A860D95BFF2EBAC8 /* Pods-VOKCoreDataManager-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-frameworks.sh"; sourceTree = "<group>"; };
 		A6AE8D66476D5D6F3E15CE09BAAACE8F /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		A7B7E62EED6D096F0D19D867EC59A64C /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
+		A6EA8E90AA03A2F8861E0B591E5A0264 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
+		AB7EB8F1DA2DD4E38CF24287A62D8E97 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
+		B42A49F6B5DB7C6B35F1EC34A2C584A6 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
+		B6A20DF796560FF4DA99D02C596A987F /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
 		B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		C94F74602BFA315E6021239F898D5FA2 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
 		CAC9A5CA4D209B442E8F88DC409BC669 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
 		CC6FD326BEFE350B9ABEDF10E7A82DE5 /* Pods-VOKCoreDataManager Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.release.xcconfig"; sourceTree = "<group>"; };
 		D190B8553BD3314394B7A68597ECD513 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
@@ -172,14 +174,6 @@
 				75C052C94C34F41693DF3B627BC44EBF /* Pods-VOKCoreDataManager Tests */,
 			);
 			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		0220A9669413978D17E925AE7093FA66 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				A7B7E62EED6D096F0D19D867EC59A64C /* VOKCoreDataManagerInternalMacros.h */,
-			);
-			path = Internal;
 			sourceTree = "<group>";
 		};
 		1E13786B3199A460EA8B6C586AB8BD9C /* Support Files */ = {
@@ -285,6 +279,22 @@
 			name = FetchedResults;
 			sourceTree = "<group>";
 		};
+		5FBFFE95CFC8E6DDC36CE348FA53E03E /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				1D56C1F3F66E7ED868EDF4400358F808 /* VOKCoreDataManagerInternalMacros.h */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		6523028176EC99D7B14D4B5A47C0CA8C /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				BBA217E8D39F540476657964FC8DBC2C /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
 		67A7443CA17EF31D82DE1AD53BE982CF /* DataSources */ = {
 			isa = PBXGroup;
 			children = (
@@ -361,7 +371,7 @@
 		9AB37BE62D4B3EBF410BE4015B6E0EE4 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				D47EA8495D972AA0204E6B991019FE1E /* Pod */,
+				6523028176EC99D7B14D4B5A47C0CA8C /* Pod */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -383,6 +393,25 @@
 				59FFEC0EBBC7CB50B6C2C443E95A51D6 /* VOKPagingFetchedResultsDataSource.m */,
 			);
 			path = "Optional Data Sources";
+			sourceTree = "<group>";
+		};
+		BBA217E8D39F540476657964FC8DBC2C /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				AB7EB8F1DA2DD4E38CF24287A62D8E97 /* NSManagedObject+VOKManagedObjectAdditions.h */,
+				0D2A1C115A76F4489C8EA2029BFBDB76 /* NSManagedObject+VOKManagedObjectAdditions.m */,
+				78C5B7E35EA648D36A0777837F3058A8 /* VOKCoreDataCollectionTypes.h */,
+				46FA8F20B5A840203FDD211588D3E184 /* VOKCoreDataManager.h */,
+				2DF51F859746AC6AD389F5CE590CFDEB /* VOKCoreDataManager.m */,
+				A6EA8E90AA03A2F8861E0B591E5A0264 /* VOKManagedObjectMap.h */,
+				B6A20DF796560FF4DA99D02C596A987F /* VOKManagedObjectMap.m */,
+				04B372B7471C542BDFD305B3AC011BED /* VOKManagedObjectMapper.h */,
+				04E139BDC6B35156AFDE884F4A572282 /* VOKManagedObjectMapper.m */,
+				B42A49F6B5DB7C6B35F1EC34A2C584A6 /* VOKMappableModel.h */,
+				22BD905008F28FF4BC3B92B610F121B3 /* VOKNullabilityFeatures.h */,
+				5FBFFE95CFC8E6DDC36CE348FA53E03E /* Internal */,
+			);
+			path = Classes;
 			sourceTree = "<group>";
 		};
 		CA0EB5E4151DE05368F7020DC6F75007 /* Products */ = {
@@ -413,14 +442,6 @@
 			name = PagingFetchedResults;
 			sourceTree = "<group>";
 		};
-		D47EA8495D972AA0204E6B991019FE1E /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				F3BF205CEF499C237F4F44E94B6A9168 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
 		D6D02DF6F13151A872A8858BE6651BE1 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -438,24 +459,6 @@
 			name = ILGClasses;
 			sourceTree = "<group>";
 		};
-		F3BF205CEF499C237F4F44E94B6A9168 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				21626EBBD5B012A19F13D97D0FA4598F /* NSManagedObject+VOKManagedObjectAdditions.h */,
-				00BB5BDD6235AC3CB56272ECA02F0684 /* NSManagedObject+VOKManagedObjectAdditions.m */,
-				8C7339F9530BAF738D1001C629D7833E /* VOKCoreDataManager.h */,
-				1716D0C04B1CEE77299F2E79C7305F5B /* VOKCoreDataManager.m */,
-				C94F74602BFA315E6021239F898D5FA2 /* VOKManagedObjectMap.h */,
-				5898D8E2DEA252F31CE31D2F6279D912 /* VOKManagedObjectMap.m */,
-				8650D803E301D92132436E839A6530B3 /* VOKManagedObjectMapper.h */,
-				678A920D7CF5DC1B2123A4F140D321E1 /* VOKManagedObjectMapper.m */,
-				41A112130B5CFCEAA8C96901F9D46DEC /* VOKMappableModel.h */,
-				861CA4394A7D891F9A8805EB4D67371F /* VOKNullabilityFeatures.h */,
-				0220A9669413978D17E925AE7093FA66 /* Internal */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
 		FD0E32E45381295D5FFE246337A5083E /* Classes */ = {
 			isa = PBXGroup;
 			children = (
@@ -467,29 +470,30 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		04FB4A02EB2A6FFED157150CCE772FC5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				88DEF95FEC47BC22B277F3488FA18F89 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				AAC36CF5410E482E907CEC8A058667AE /* VOKCollectionDataSource.h in Headers */,
+				AE27D6F595D455BBB320E3F5D6E3329F /* VOKCoreDataCollectionTypes.h in Headers */,
+				BD1467C8A69429D6528B94700A874C54 /* VOKCoreDataManager.h in Headers */,
+				09D5CFB9E8D9C6E8866FE39D7B5D2D8D /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				A0D3656557D597F7216FBE8C8EC9C28C /* VOKDefaultPagingAccessory.h in Headers */,
+				9E12C787EA89ED4611E5770B60D9F1CD /* VOKFetchedResultsDataSource.h in Headers */,
+				0DDD3D3C220B07CFCBA02E337502DEB8 /* VOKManagedObjectMap.h in Headers */,
+				DD8CD200AF91C55A1C90EF8F778E74A2 /* VOKManagedObjectMapper.h in Headers */,
+				52121EA79E09C6F6AB2B8E4AB2AAC31B /* VOKMappableModel.h in Headers */,
+				3838CEFE93E84E0A5538F273ACFD60A0 /* VOKNullabilityFeatures.h in Headers */,
+				2B0A2E5222FFA0A65C1E9FD29FC40B93 /* VOKPagingFetchedResultsDataSource.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8F078591045F5F001A3B1395DFDA8320 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				B9079F74D1398C0370ACB47B775CD6A7 /* ILGClasses.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B577939C28294901702D62DEB6E338AB /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0C802039BF1FA120174B71B65DDD3303 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				3B42EC7A027A81A26BA35CE4AAC57B81 /* VOKCollectionDataSource.h in Headers */,
-				73E7F83F3372AA44996B05BDC96144AD /* VOKCoreDataManager.h in Headers */,
-				619094545C99A18381C3D9D0CDA3A14F /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				7D850EBCFC8D5901B5B14FC9C84D8F45 /* VOKDefaultPagingAccessory.h in Headers */,
-				933415564DEE0FDE6F57EDCE80209092 /* VOKFetchedResultsDataSource.h in Headers */,
-				A8F28C1B198D2D5046D6F1A2A00D56A2 /* VOKManagedObjectMap.h in Headers */,
-				E1D33249DDAF7AE06DF14520BA2DA67F /* VOKManagedObjectMapper.h in Headers */,
-				0DE394F65D68884B0FA481851F21B327 /* VOKMappableModel.h in Headers */,
-				56D098ADF7E2E3AD7D132B920AF979FE /* VOKNullabilityFeatures.h in Headers */,
-				A92BD33C24189CA1F41BD6E11DC3B4AA /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -520,7 +524,7 @@
 			buildPhases = (
 				84ADF7F63BFE8AE224D7074C35F90020 /* Sources */,
 				480C959A391BCA2042DE2201EC0DE116 /* Frameworks */,
-				B577939C28294901702D62DEB6E338AB /* Headers */,
+				04FB4A02EB2A6FFED157150CCE772FC5 /* Headers */,
 			);
 			buildRules = (
 			);

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'FE27019279D4F66DA2185AB5'
+               BlueprintIdentifier = '69580CFDE5FF949E00F452D5'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libVokoder.a'>

--- a/SampleProject/SampleProject.xcodeproj/project.pbxproj
+++ b/SampleProject/SampleProject.xcodeproj/project.pbxproj
@@ -663,7 +663,7 @@
 				GCC_PREFIX_HEADER = "Supporting Files/VOKCoreDataManager-Prefix.pch";
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/VOKCoreDataManager-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.VOKAL.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Vokal.VOKCoreDataManager;
 				PRODUCT_NAME = VOKCoreDataManager;
 				WRAPPER_EXTENSION = app;
 			};
@@ -679,7 +679,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/VOKCoreDataManager-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.VOKAL.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Vokal.VOKCoreDataManager;
 				PRODUCT_NAME = VOKCoreDataManager;
 				WRAPPER_EXTENSION = app;
 			};

--- a/SampleProject/VOKCoreDataManagerTests/ManagedObjectImportExportTests.m
+++ b/SampleProject/VOKCoreDataManagerTests/ManagedObjectImportExportTests.m
@@ -452,7 +452,8 @@ static NSString *const THING_HAT_COUNT_KEY = @"thing_hats";
     person = nil;
     [[[VOKCoreDataManager sharedInstance] managedObjectContext] reset];
 
-    VIPerson *personFromURI = [[VOKCoreDataManager sharedInstance] existingObjectAtURI:uri forManagedObjectContext:nil];
+    VIPerson *personFromURI = (VIPerson *)[[VOKCoreDataManager sharedInstance] existingObjectAtURI:uri
+                                                                           forManagedObjectContext:nil];
     XCTAssertTrue(personFromURI, @"failed to get existing person object from URI");
     XCTAssertTrue([personFromURI isKindOfClass:[VIPerson class]], @"existing person object was not correct class");
 }
@@ -460,7 +461,8 @@ static NSString *const THING_HAT_COUNT_KEY = @"thing_hats";
 - (void)testFetchWithMalformedURI
 {
     NSURL *uri = [NSURL URLWithString:@"x-coredata://1C8D8740-06E2-4B79-A739-94071E03CD74/VIPerson/p99"];
-    VIPerson *personFromURI = [[VOKCoreDataManager sharedInstance] existingObjectAtURI:uri forManagedObjectContext:nil];
+    VIPerson *personFromURI = (VIPerson *)[[VOKCoreDataManager sharedInstance] existingObjectAtURI:uri
+                                                                           forManagedObjectContext:nil];
     XCTAssertNil(personFromURI, @"existingObjectAtURI did not fail correctly. returned non nil value for malformed URI");
 }
 


### PR DESCRIPTION
Added Obj-C generic decorations to method declarations.  

I `typedef`d named specialized collection types with fallbacks to unspecialized/undecorated types for earlier versions of Xcode.

@vokal/ios-developers, @seanwolter, code review?

For versioning, this can also be a part of 1.4.0 from #55 since it will still compile under older versions of Xcode.