### PR TITLE
CTA train, station, and stop models and maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,7 @@ matrix:
         - xcode_workspace: Paging Data Source Example/Paging Data Source Example.xcworkspace
           xcode_scheme: Paging Data Source Example
           xcode_sdk: iphonesimulator
+        - xcode_workspace: SwiftSampleProject/SwiftSampleProject.xcworkspace
+          xcode_scheme: SwiftyVokoder
+          xcode_sdk: iphonesimulator
 

--- a/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -1,36 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES">
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '9F19A1867D815562541CD5AF'
-               BlueprintName = 'Vokoder'
-               ReferencedContainer = 'container:Pods.xcodeproj'
-               BuildableName = 'Vokoder.framework'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BEEA8FB525D7395FD5A281D489154CF1"
+               BuildableName = "Vokoder.framework"
+               BlueprintName = "Vokoder"
+               ReferencedContainer = "container:Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -38,17 +41,25 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BEEA8FB525D7395FD5A281D489154CF1"
+            BuildableName = "Vokoder.framework"
+            BlueprintName = "Vokoder"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/SwiftSampleProject/SwiftSampleProject.xcodeproj/project.pbxproj
+++ b/SwiftSampleProject/SwiftSampleProject.xcodeproj/project.pbxproj
@@ -9,12 +9,20 @@
 /* Begin PBXBuildFile section */
 		BD933D600CBF86542442FDE0 /* Pods_SwiftyVokoderTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F035F26C14E954FD3C335BA8 /* Pods_SwiftyVokoderTests.framework */; };
 		CA56478011E7DB3E3CB84257 /* Pods_SwiftyVokoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8CF07AC8DBE4283D739347E6 /* Pods_SwiftyVokoder.framework */; };
+		DE8EA1021BF6797D002FDF6A /* Stop+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8EA0FC1BF6797D002FDF6A /* Stop+CoreDataProperties.swift */; };
+		DE8EA1031BF6797D002FDF6A /* Stop.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8EA0FD1BF6797D002FDF6A /* Stop.swift */; };
+		DE8EA1041BF6797D002FDF6A /* TrainLine+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8EA0FE1BF6797D002FDF6A /* TrainLine+CoreDataProperties.swift */; };
+		DE8EA1051BF6797D002FDF6A /* TrainLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8EA0FF1BF6797D002FDF6A /* TrainLine.swift */; };
+		DE8EA1061BF6797D002FDF6A /* Station+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8EA1001BF6797D002FDF6A /* Station+CoreDataProperties.swift */; };
+		DE8EA1071BF6797D002FDF6A /* Station.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8EA1011BF6797D002FDF6A /* Station.swift */; };
+		DE8EA1091BF67D91002FDF6A /* VOKManagedObjectMap+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8EA1081BF67D91002FDF6A /* VOKManagedObjectMap+Swift.swift */; };
 		DEAD7AA91BEBCACD004FE281 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAD7AA81BEBCACD004FE281 /* AppDelegate.swift */; };
 		DEAD7AAB1BEBCACD004FE281 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAD7AAA1BEBCACD004FE281 /* ViewController.swift */; };
 		DEAD7AAE1BEBCACD004FE281 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEAD7AAC1BEBCACD004FE281 /* Main.storyboard */; };
 		DEAD7AB01BEBCACD004FE281 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEAD7AAF1BEBCACD004FE281 /* Assets.xcassets */; };
 		DEAD7AB31BEBCACD004FE281 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEAD7AB11BEBCACD004FE281 /* LaunchScreen.storyboard */; };
 		DEAD7ABE1BEBCACE004FE281 /* SwiftyVokoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAD7ABD1BEBCACE004FE281 /* SwiftyVokoderTests.swift */; };
+		DEAD7ACB1BEBDC2A004FE281 /* CoreDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = DEAD7AC91BEBDC2A004FE281 /* CoreDataModel.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,6 +40,13 @@
 		52DD5325250D7C4A94E1C893 /* Pods-SwiftyVokoder.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftyVokoder.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftyVokoder/Pods-SwiftyVokoder.release.xcconfig"; sourceTree = "<group>"; };
 		81F2BDA431493805F246D4DD /* Pods-SwiftyVokoderTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftyVokoderTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftyVokoderTests/Pods-SwiftyVokoderTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8CF07AC8DBE4283D739347E6 /* Pods_SwiftyVokoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftyVokoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE8EA0FC1BF6797D002FDF6A /* Stop+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Stop+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		DE8EA0FD1BF6797D002FDF6A /* Stop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stop.swift; sourceTree = "<group>"; };
+		DE8EA0FE1BF6797D002FDF6A /* TrainLine+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TrainLine+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		DE8EA0FF1BF6797D002FDF6A /* TrainLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrainLine.swift; sourceTree = "<group>"; };
+		DE8EA1001BF6797D002FDF6A /* Station+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Station+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		DE8EA1011BF6797D002FDF6A /* Station.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Station.swift; sourceTree = "<group>"; };
+		DE8EA1081BF67D91002FDF6A /* VOKManagedObjectMap+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VOKManagedObjectMap+Swift.swift"; sourceTree = "<group>"; };
 		DEAD7AA51BEBCACD004FE281 /* SwiftyVokoder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftyVokoder.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEAD7AA81BEBCACD004FE281 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DEAD7AAA1BEBCACD004FE281 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -42,6 +57,7 @@
 		DEAD7AB91BEBCACE004FE281 /* SwiftyVokoderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftyVokoderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEAD7ABD1BEBCACE004FE281 /* SwiftyVokoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftyVokoderTests.swift; sourceTree = "<group>"; };
 		DEAD7ABF1BEBCACE004FE281 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DEAD7ACA1BEBDC2A004FE281 /* CoreDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = CoreDataModel.xcdatamodel; sourceTree = "<group>"; };
 		E28B7B252364A9E1F69945D4 /* Pods-SwiftyVokoderTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftyVokoderTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftyVokoderTests/Pods-SwiftyVokoderTests.release.xcconfig"; sourceTree = "<group>"; };
 		F035F26C14E954FD3C335BA8 /* Pods_SwiftyVokoderTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftyVokoderTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -111,10 +127,10 @@
 			children = (
 				DEAD7AA81BEBCACD004FE281 /* AppDelegate.swift */,
 				DEAD7AAA1BEBCACD004FE281 /* ViewController.swift */,
+				DE8EA1081BF67D91002FDF6A /* VOKManagedObjectMap+Swift.swift */,
 				DEAD7AAC1BEBCACD004FE281 /* Main.storyboard */,
-				DEAD7AAF1BEBCACD004FE281 /* Assets.xcassets */,
-				DEAD7AB11BEBCACD004FE281 /* LaunchScreen.storyboard */,
-				DEAD7AB41BEBCACD004FE281 /* Info.plist */,
+				DEAD7AC81BEBDC05004FE281 /* Models */,
+				DEAD7AC71BEBDBA8004FE281 /* Resources */,
 			);
 			path = SwiftyVokoder;
 			sourceTree = "<group>";
@@ -126,6 +142,30 @@
 				DEAD7ABF1BEBCACE004FE281 /* Info.plist */,
 			);
 			path = SwiftyVokoderTests;
+			sourceTree = "<group>";
+		};
+		DEAD7AC71BEBDBA8004FE281 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				DEAD7AAF1BEBCACD004FE281 /* Assets.xcassets */,
+				DEAD7AB41BEBCACD004FE281 /* Info.plist */,
+				DEAD7AB11BEBCACD004FE281 /* LaunchScreen.storyboard */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		DEAD7AC81BEBDC05004FE281 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				DE8EA1011BF6797D002FDF6A /* Station.swift */,
+				DE8EA0FD1BF6797D002FDF6A /* Stop.swift */,
+				DE8EA0FF1BF6797D002FDF6A /* TrainLine.swift */,
+				DE8EA1001BF6797D002FDF6A /* Station+CoreDataProperties.swift */,
+				DE8EA0FC1BF6797D002FDF6A /* Stop+CoreDataProperties.swift */,
+				DE8EA0FE1BF6797D002FDF6A /* TrainLine+CoreDataProperties.swift */,
+				DEAD7AC91BEBDC2A004FE281 /* CoreDataModel.xcdatamodeld */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -180,6 +220,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0710;
+				ORGANIZATIONNAME = Vokal;
 				TargetAttributes = {
 					DEAD7AA41BEBCACD004FE281 = {
 						CreatedOnToolsVersion = 7.1;
@@ -327,8 +368,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DE8EA1041BF6797D002FDF6A /* TrainLine+CoreDataProperties.swift in Sources */,
+				DE8EA1021BF6797D002FDF6A /* Stop+CoreDataProperties.swift in Sources */,
+				DE8EA1031BF6797D002FDF6A /* Stop.swift in Sources */,
 				DEAD7AAB1BEBCACD004FE281 /* ViewController.swift in Sources */,
+				DE8EA1071BF6797D002FDF6A /* Station.swift in Sources */,
+				DE8EA1091BF67D91002FDF6A /* VOKManagedObjectMap+Swift.swift in Sources */,
 				DEAD7AA91BEBCACD004FE281 /* AppDelegate.swift in Sources */,
+				DE8EA1061BF6797D002FDF6A /* Station+CoreDataProperties.swift in Sources */,
+				DEAD7ACB1BEBDC2A004FE281 /* CoreDataModel.xcdatamodeld in Sources */,
+				DE8EA1051BF6797D002FDF6A /* TrainLine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,6 +422,8 @@
 		DEAD7A9F1BEBCA7D004FE281 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -600,6 +651,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		DEAD7AC91BEBDC2A004FE281 /* CoreDataModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				DEAD7ACA1BEBDC2A004FE281 /* CoreDataModel.xcdatamodel */,
+			);
+			currentVersion = DEAD7ACA1BEBDC2A004FE281 /* CoreDataModel.xcdatamodel */;
+			path = CoreDataModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = DEAD7A9B1BEBCA7D004FE281 /* Project object */;
 }

--- a/SwiftSampleProject/SwiftSampleProject.xcodeproj/xcshareddata/xcschemes/SwiftyVokoder.xcscheme
+++ b/SwiftSampleProject/SwiftSampleProject.xcodeproj/xcshareddata/xcschemes/SwiftyVokoder.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:SwiftSampleProject.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DEAD7AB81BEBCACE004FE281"
+               BuildableName = "SwiftyVokoderTests.xctest"
+               BlueprintName = "SwiftyVokoderTests"
+               ReferencedContainer = "container:SwiftSampleProject.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/SwiftSampleProject/SwiftyVokoder/Models/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/SwiftSampleProject/SwiftyVokoder/Models/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="15B42" minimumToolsVersion="Xcode 7.0">
+    <entity name="Station" representedClassName="Station" syncable="YES">
+        <attribute name="accessible" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="descriptiveName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="identifier" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="latitude" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="locationString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="longitude" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="stops" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Stop" inverseName="station" inverseEntity="Stop" syncable="YES"/>
+    </entity>
+    <entity name="Stop" representedClassName="Stop" syncable="YES">
+        <attribute name="directionString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="identifier" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="station" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Station" inverseName="stops" inverseEntity="Station" syncable="YES"/>
+        <relationship name="trainLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TrainLine" inverseName="stops" inverseEntity="TrainLine" syncable="YES"/>
+    </entity>
+    <entity name="TrainLine" representedClassName="TrainLine" syncable="YES">
+        <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="stops" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Stop" inverseName="trainLine" inverseEntity="Stop" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Station" positionX="-63" positionY="45" width="128" height="165"/>
+        <element name="TrainLine" positionX="-54" positionY="90" width="128" height="90"/>
+        <element name="Stop" positionX="-36" positionY="117" width="128" height="120"/>
+    </elements>
+</model>

--- a/SwiftSampleProject/SwiftyVokoder/Models/Station+CoreDataProperties.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/Station+CoreDataProperties.swift
@@ -1,6 +1,6 @@
 //
 //  Station+CoreDataProperties.swift
-//  
+//  SwiftyVokoder
 //
 //  Created by Carl Hill-Popper on 11/13/15.
 //  Copyright © 2015 Vokal.

--- a/SwiftSampleProject/SwiftyVokoder/Models/Station+CoreDataProperties.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/Station+CoreDataProperties.swift
@@ -1,0 +1,26 @@
+//
+//  Station+CoreDataProperties.swift
+//  
+//
+//  Created by Carl Hill-Popper on 11/13/15.
+//  Copyright © 2015 Vokal.
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+import Foundation
+import CoreData
+
+extension Station {
+
+    @NSManaged var name: String?
+    @NSManaged var identifier: NSNumber?
+    @NSManaged var locationString: String?
+    @NSManaged var latitude: NSNumber?
+    @NSManaged var longitude: NSNumber?
+    @NSManaged var descriptiveName: String?
+    @NSManaged var accessible: NSNumber?
+    @NSManaged var stops: NSSet?
+
+}

--- a/SwiftSampleProject/SwiftyVokoder/Models/Station.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/Station.swift
@@ -1,6 +1,6 @@
 //
 //  Station.swift
-//  
+//  SwiftyVokoder
 //
 //  Created by Carl Hill-Popper on 11/13/15.
 //  Copyright © 2015 Vokal.
@@ -24,7 +24,6 @@ enum StationAttributes: String {
 
 @objc(Station)
 class Station: NSManagedObject {
-
     lazy private(set) var coordinate: CLLocationCoordinate2D = {
         CLLocationCoordinate2D(latitude: Double(self.latitude ?? 0),
             longitude: Double(self.longitude ?? 0))
@@ -52,6 +51,8 @@ extension Station: VOKMappableModel {
     }
     
     static func importCompletionBlock() -> VOKPostImportBlock {
+        //we aren't using the first param so use the underscore symbol
+        //explicit typing for clarity
         return { (_, inputObject: NSManagedObject) in
             guard let
                 station = inputObject as? Station,

--- a/SwiftSampleProject/SwiftyVokoder/Models/Station.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/Station.swift
@@ -1,0 +1,71 @@
+//
+//  Station.swift
+//  
+//
+//  Created by Carl Hill-Popper on 11/13/15.
+//  Copyright © 2015 Vokal.
+//
+
+import Foundation
+import CoreData
+import CoreLocation
+import Vokoder
+
+//lets pretend we're using mogenerator to create attribute constants
+enum StationAttributes: String {
+    case name
+    case longitude
+    case locationString
+    case latitude
+    case identifier
+    case descriptiveName
+    case accessible
+}
+
+@objc(Station)
+class Station: NSManagedObject {
+
+    lazy private(set) var coordinate: CLLocationCoordinate2D = {
+        CLLocationCoordinate2D(latitude: Double(self.latitude ?? 0),
+            longitude: Double(self.longitude ?? 0))
+    }()
+}
+
+extension Station: VOKMappableModel {
+    static func coreDataMaps() -> [VOKManagedObjectMap] {
+        return [
+            VOKManagedObjectMap(foreignKeyPath: "MAP_ID",
+                coreDataKeyEnum: StationAttributes.identifier),
+            VOKManagedObjectMap(foreignKeyPath: "STATION_NAME",
+                coreDataKeyEnum: StationAttributes.name),
+            VOKManagedObjectMap(foreignKeyPath: "STATION_DESCRIPTIVE_NAME",
+                coreDataKeyEnum: StationAttributes.descriptiveName),
+            VOKManagedObjectMap(foreignKeyPath: "ADA",
+                coreDataKeyEnum: StationAttributes.accessible),
+            VOKManagedObjectMap(foreignKeyPath: "Location",
+                coreDataKeyEnum: StationAttributes.locationString),
+        ]
+    }
+    
+    static func uniqueKey() -> String? {
+        return StationAttributes.identifier.rawValue
+    }
+    
+    static func importCompletionBlock() -> VOKPostImportBlock {
+        return { (_, inputObject: NSManagedObject) in
+            guard let
+                station = inputObject as? Station,
+                locationString = station.locationString else {
+                return
+            }
+            
+            //example locationString: "(41.875478, -87.688436)"
+            //convert parentheses to curly braces to be usable by CGPointFromString
+            var pointString = locationString.stringByReplacingOccurrencesOfString("(", withString: "{")
+            pointString = pointString.stringByReplacingOccurrencesOfString(")", withString: "}")
+            let point = CGPointFromString(pointString)
+            station.latitude = point.x
+            station.longitude = point.y
+        }
+    }
+}

--- a/SwiftSampleProject/SwiftyVokoder/Models/Stop+CoreDataProperties.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/Stop+CoreDataProperties.swift
@@ -1,6 +1,6 @@
 //
 //  Stop+CoreDataProperties.swift
-//  
+//  SwiftyVokoder
 //
 //  Created by Carl Hill-Popper on 11/13/15.
 //  Copyright © 2015 Vokal.

--- a/SwiftSampleProject/SwiftyVokoder/Models/Stop+CoreDataProperties.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/Stop+CoreDataProperties.swift
@@ -1,0 +1,23 @@
+//
+//  Stop+CoreDataProperties.swift
+//  
+//
+//  Created by Carl Hill-Popper on 11/13/15.
+//  Copyright © 2015 Vokal.
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+import Foundation
+import CoreData
+
+extension Stop {
+
+    @NSManaged var identifier: NSNumber?
+    @NSManaged var name: String?
+    @NSManaged var directionString: String?
+    @NSManaged var station: Station?
+    @NSManaged var trainLine: TrainLine?
+
+}

--- a/SwiftSampleProject/SwiftyVokoder/Models/Stop.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/Stop.swift
@@ -1,0 +1,100 @@
+//
+//  Stop.swift
+//  
+//
+//  Created by Carl Hill-Popper on 11/13/15.
+//  Copyright © 2015 Vokal.
+//
+
+import Foundation
+import CoreData
+import Vokoder
+
+//lets pretend we're using mogenerator to create attribute constants
+enum StopAttributes: String {
+    case directionString
+    case identifier
+    case name
+}
+
+@objc(Stop)
+class Stop: NSManagedObject {
+    
+    enum Direction: String {
+        case North = "N"
+        case South = "S"
+        case East = "E"
+        case West = "W"
+        case Unknown
+        
+        init(value: String?) {
+            if let
+                value = value,
+                knownDirection = Direction(rawValue: value) {
+                    self = knownDirection
+            } else {
+                self = .Unknown
+            }
+        }
+    }
+    
+    lazy private(set) var direction: Direction = {
+        Direction(value: self.directionString)
+    }()
+}
+
+extension Stop: VOKMappableModel {
+    /*
+    Example JSON input:
+    {
+        "STOP_ID":30096,
+        "DIRECTION_ID":"S",
+        "STOP_NAME":"Grand/Milwaukee (Forest Pk-bound)",
+        "STATION_NAME":"Grand",
+        "STATION_DESCRIPTIVE_NAME":"Grand (Blue Line)",
+        "MAP_ID":40490,
+        "ADA":false,
+        "RED":false,
+        "BLUE":true,
+        "G":false,
+        "BRN":false,
+        "P":false,
+        "Pexp":false,
+        "Y":false,
+        "Pnk":false,
+        "O":false,
+        "Location":"(41.891189, -87.647578)"
+    },
+    */
+    static func coreDataMaps() -> [VOKManagedObjectMap] {
+        return [
+            VOKManagedObjectMap(foreignKeyPath: "STOP_ID",
+                coreDataKeyEnum: StopAttributes.identifier),
+            VOKManagedObjectMap(foreignKeyPath: "STOP_NAME",
+                coreDataKeyEnum: StopAttributes.name),
+            VOKManagedObjectMap(foreignKeyPath: "DIRECTION_ID",
+                coreDataKeyEnum: StopAttributes.directionString),
+        ]
+    }
+    
+    static func uniqueKey() -> String? {
+        return StopAttributes.identifier.rawValue
+    }
+
+    static func importCompletionBlock() -> VOKPostImportBlock {
+        //explicit typing for clarity
+        return { (inputDict: [String: AnyObject], inputObject: NSManagedObject) in
+            guard let stop = inputObject as? Stop else {
+                return
+            }
+         
+            //NOTE: the input JSON is denormalized so we can pass in the inputDict to create stations
+            stop.station = Station.vok_addWithDictionary(inputDict,
+                forManagedObjectContext: stop.managedObjectContext)
+            
+            //train lines are mapped manually because CTA data is strange
+            stop.trainLine = TrainLine.trainLineFromStopDictionary(inputDict,
+                forManagedObjectContext: stop.managedObjectContext)
+        }
+    }
+}

--- a/SwiftSampleProject/SwiftyVokoder/Models/Stop.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/Stop.swift
@@ -1,6 +1,6 @@
 //
 //  Stop.swift
-//  
+//  SwiftyVokoder
 //
 //  Created by Carl Hill-Popper on 11/13/15.
 //  Copyright © 2015 Vokal.

--- a/SwiftSampleProject/SwiftyVokoder/Models/TrainLine+CoreDataProperties.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/TrainLine+CoreDataProperties.swift
@@ -1,6 +1,6 @@
 //
 //  TrainLine+CoreDataProperties.swift
-//  
+//  SwiftyVokoder
 //
 //  Created by Carl Hill-Popper on 11/13/15.
 //  Copyright © 2015 Vokal.

--- a/SwiftSampleProject/SwiftyVokoder/Models/TrainLine+CoreDataProperties.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/TrainLine+CoreDataProperties.swift
@@ -1,0 +1,21 @@
+//
+//  TrainLine+CoreDataProperties.swift
+//  
+//
+//  Created by Carl Hill-Popper on 11/13/15.
+//  Copyright © 2015 Vokal.
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+import Foundation
+import CoreData
+
+extension TrainLine {
+
+    @NSManaged var identifier: String?
+    @NSManaged var name: String?
+    @NSManaged var stops: NSSet?
+
+}

--- a/SwiftSampleProject/SwiftyVokoder/Models/TrainLine.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/TrainLine.swift
@@ -1,6 +1,6 @@
 //
 //  TrainLine.swift
-//  
+//  SwiftyVokoder
 //
 //  Created by Carl Hill-Popper on 11/13/15.
 //  Copyright © 2015 Vokal.

--- a/SwiftSampleProject/SwiftyVokoder/Models/TrainLine.swift
+++ b/SwiftSampleProject/SwiftyVokoder/Models/TrainLine.swift
@@ -1,0 +1,118 @@
+//
+//  TrainLine.swift
+//  
+//
+//  Created by Carl Hill-Popper on 11/13/15.
+//  Copyright © 2015 Vokal.
+//
+
+import Foundation
+import CoreData
+import Vokoder
+
+//lets pretend we're using mogenerator to create attribute constants
+enum TrainLineAttributes: String {
+    case identifier
+    case name
+}
+
+@objc(TrainLine)
+class TrainLine: NSManagedObject {
+ 
+    enum CTAIdentifier: String {
+        case Blue = "BLUE"
+        case Brown = "BRN"
+        case Green = "G"
+        case Orange = "O"
+        case Pink = "Pnk"
+        case Purple = "P"
+        case PurpleExpress = "Pexp"
+        case Red = "RED"
+        case Yellow = "Y"
+        
+        var name: String {
+            switch self {
+            case .Blue:
+                return "Blue Line"
+            case .Brown:
+                return "Brown Line"
+            case .Green:
+                return "Green Line"
+            case .Orange:
+                return "Orange Line"
+            case .Pink:
+                return "Pink Line"
+            case .Purple:
+                return "Purple Line"
+            case .PurpleExpress:
+                return "Purple Line Express"
+            case .Red:
+                return "Red Line"
+            case .Yellow:
+                return "Yellow Line"
+            }
+        }
+    }
+
+    /**
+     Create or fetch the train line referenced by the input dictionary.
+     The dictionary is assumed to contain keys for each train line identifier
+     with boolean values that determine which train line is referenced.
+     Example: a dictionary that contains the following indicates a Blue line train:
+     
+     [
+         "RED":false,
+         "BLUE":true,
+         "G":false,
+         "BRN":false,
+         "P":false,
+         "Pexp":false,
+         "Y":false,
+         "Pnk":false,
+         "O":false,
+     ]
+     */
+    static func trainLineFromStopDictionary(inputDict: [String: AnyObject],
+        forManagedObjectContext context: NSManagedObjectContext?) -> TrainLine? {
+        
+        let allIdentifiers: [CTAIdentifier] = [
+            .Blue,
+            .Brown,
+            .Green,
+            .Orange,
+            .Pink,
+            .Purple,
+            .PurpleExpress,
+            .Red,
+            .Yellow,
+        ]
+        
+        for identifier in allIdentifiers {
+            if (inputDict[identifier.rawValue] as? Bool) == true {
+                return self.trainLine(ctaIdentifier: identifier, forManagedObjectContext: context)
+            }
+        }
+        
+        return nil
+    }
+    
+    /**
+     Fetch existing or create a new TrainLine with a given CTATrainLineIdentifier in the given context.
+     */
+    static func trainLine(ctaIdentifier identifier: CTAIdentifier,
+        forManagedObjectContext context: NSManagedObjectContext?) -> TrainLine {
+            let predicate = NSPredicate(format: "%K == %@",
+                TrainLineAttributes.identifier.rawValue,
+                identifier.rawValue)
+            if let trainLine = TrainLine.vok_fetchAllForPredicate(predicate,
+                forManagedObjectContext: context).first as? TrainLine {
+                    return trainLine
+            } else {
+                let trainLine = TrainLine.vok_newInstanceWithContext(context)
+                trainLine.identifier = identifier.rawValue
+                trainLine.name = identifier.name
+                
+                return trainLine
+            }
+    }
+}

--- a/SwiftSampleProject/SwiftyVokoder/VOKManagedObjectMap+Swift.swift
+++ b/SwiftSampleProject/SwiftyVokoder/VOKManagedObjectMap+Swift.swift
@@ -1,0 +1,20 @@
+//
+//  VOKManagedObjectMap+Swift.swift
+//  SwiftSampleProject
+//
+//  Created by Carl Hill-Popper on 11/13/15.
+//  Copyright © 2015 Vokal.
+//
+
+import Vokoder
+
+extension VOKManagedObjectMap {
+
+    /**
+     Creates a managed object map from a foreign key and String-based enum case
+     */
+    convenience init<StringEnum: RawRepresentable where StringEnum.RawValue == String>
+        (foreignKeyPath: String, coreDataKeyEnum: StringEnum) {
+            self.init(foreignKeyPath: foreignKeyPath, coreDataKey: coreDataKeyEnum.rawValue)
+    }
+}

--- a/SwiftSampleProject/SwiftyVokoderTests/SwiftyVokoderTests.swift
+++ b/SwiftSampleProject/SwiftyVokoderTests/SwiftyVokoderTests.swift
@@ -58,8 +58,8 @@ class SwiftyVokoderTests: XCTestCase {
         XCTAssertEqual(station.identifier, 40490)
         XCTAssertEqual(station.descriptiveName, "Grand (Blue Line)")
         XCTAssertEqual(station.locationString, "(41.891189, -87.647578)")
-        XCTAssertEqualWithAccuracy(station.coordinate.latitude, 41.891189, accuracy: 1e-6)
-        XCTAssertEqualWithAccuracy(station.coordinate.longitude, -87.647578, accuracy: 1e-6)
+        XCTAssertEqualWithAccuracy(station.coordinate.latitude, 41.891189, accuracy: 1e-5)
+        XCTAssertEqualWithAccuracy(station.coordinate.longitude, -87.647578, accuracy: 1e-5)
         
         XCTAssertEqual(trainLine.name, "Blue Line")
         XCTAssertEqual(trainLine.identifier, "BLUE")

--- a/SwiftSampleProject/SwiftyVokoderTests/SwiftyVokoderTests.swift
+++ b/SwiftSampleProject/SwiftyVokoderTests/SwiftyVokoderTests.swift
@@ -57,6 +57,7 @@ class SwiftyVokoderTests: XCTestCase {
         XCTAssertEqual(station.name, "Grand")
         XCTAssertEqual(station.identifier, 40490)
         XCTAssertEqual(station.descriptiveName, "Grand (Blue Line)")
+        XCTAssertEqual(station.accessible, false)
         XCTAssertEqual(station.locationString, "(41.891189, -87.647578)")
         XCTAssertEqualWithAccuracy(station.coordinate.latitude, 41.891189, accuracy: 1e-5)
         XCTAssertEqualWithAccuracy(station.coordinate.longitude, -87.647578, accuracy: 1e-5)

--- a/SwiftSampleProject/SwiftyVokoderTests/SwiftyVokoderTests.swift
+++ b/SwiftSampleProject/SwiftyVokoderTests/SwiftyVokoderTests.swift
@@ -11,8 +11,57 @@ import XCTest
 
 class SwiftyVokoderTests: XCTestCase {
     
-    func testExample() {
-        XCTFail("Write some tests!")
+    func exampleBlueLineStopDictionary() -> [String: AnyObject] {
+        return [
+            "STOP_ID":30096,
+            "DIRECTION_ID":"S",
+            "STOP_NAME":"Grand/Milwaukee (Forest Pk-bound)",
+            "STATION_NAME":"Grand",
+            "STATION_DESCRIPTIVE_NAME":"Grand (Blue Line)",
+            "MAP_ID":40490,
+            "ADA":false,
+            "RED":false,
+            "BLUE":true,
+            "G":false,
+            "BRN":false,
+            "P":false,
+            "Pexp":false,
+            "Y":false,
+            "Pnk":false,
+            "O":false,
+            "Location":"(41.891189, -87.647578)"
+        ]
     }
     
+    func testCreateTrainLineFromIdentifier() {
+        let redLine = TrainLine.trainLine(ctaIdentifier: .Red, forManagedObjectContext: nil)
+        XCTAssertEqual(redLine.identifier, TrainLine.CTAIdentifier.Red.rawValue)
+        XCTAssertEqual(redLine.name, TrainLine.CTAIdentifier.Red.name)
+    }
+ 
+    func testImport() {
+        let inputDictionary = self.exampleBlueLineStopDictionary()
+        guard let stop = Stop.vok_addWithDictionary(inputDictionary, forManagedObjectContext: nil) else {
+            XCTFail("Could not load Stop from dictionary")
+            return
+        }
+        XCTAssertEqual(stop.name, "Grand/Milwaukee (Forest Pk-bound)")
+        XCTAssertEqual(stop.identifier, 30096)
+        XCTAssertEqual(stop.directionString, "S")
+        XCTAssertEqual(stop.direction, Stop.Direction.South)
+
+        guard let station = stop.station, trainLine = stop.trainLine else {
+            XCTFail("Could not load station or train from dictionary")
+            return
+        }
+        XCTAssertEqual(station.name, "Grand")
+        XCTAssertEqual(station.identifier, 40490)
+        XCTAssertEqual(station.descriptiveName, "Grand (Blue Line)")
+        XCTAssertEqual(station.locationString, "(41.891189, -87.647578)")
+        XCTAssertEqualWithAccuracy(station.coordinate.latitude, 41.891189, accuracy: 1e-6)
+        XCTAssertEqualWithAccuracy(station.coordinate.longitude, -87.647578, accuracy: 1e-6)
+        
+        XCTAssertEqual(trainLine.name, "Blue Line")
+        XCTAssertEqual(trainLine.identifier, "BLUE")
+    }
 }


### PR DESCRIPTION
I chose Chicago CTA train stop data as the example data model.  This adds model definitions, mapping, and minimal unit tests to support that.

The complete [dataset](https://data.cityofchicago.org/Transportation/CTA-System-Information-List-of-L-Stops/8pix-ypme) is ~5700 lines of JSON. I left it out of this PR and will add it later.