### PR TITLE
Fix vok_entityName for the non-MOGenerator case

### DIFF
--- a/Paging Data Source Example/Podfile.lock
+++ b/Paging Data Source Example/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (1.4.0):
-    - Vokoder/Core (= 1.4.0)
-    - Vokoder/DataSources (= 1.4.0)
-  - Vokoder/Core (1.4.0):
+  - Vokoder (1.4.1):
+    - Vokoder/Core (= 1.4.1)
+    - Vokoder/DataSources (= 1.4.1)
+  - Vokoder/Core (1.4.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (1.4.0):
+  - Vokoder/DataSources (1.4.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 1.4.0)
-    - Vokoder/DataSources/FetchedResults (= 1.4.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 1.4.0)
-  - Vokoder/DataSources/Collection (1.4.0):
+    - Vokoder/DataSources/Collection (= 1.4.1)
+    - Vokoder/DataSources/FetchedResults (= 1.4.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 1.4.1)
+  - Vokoder/DataSources/Collection (1.4.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (1.4.0):
+  - Vokoder/DataSources/FetchedResults (1.4.1):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (1.4.0):
+  - Vokoder/DataSources/PagingFetchedResults (1.4.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -28,6 +28,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 1762f4c5bf26c3b1f7e3f730dabc59147bb2f130
+  Vokoder: 6bb77e5a4417b6d7e75ef17eb231e7af01f35db1
 
 COCOAPODS: 0.39.0

--- a/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "1.4.0"
+    "tag": "1.4.1"
   },
   "platforms": {
     "ios": "7.0"

--- a/Paging Data Source Example/Pods/Manifest.lock
+++ b/Paging Data Source Example/Pods/Manifest.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (1.4.0):
-    - Vokoder/Core (= 1.4.0)
-    - Vokoder/DataSources (= 1.4.0)
-  - Vokoder/Core (1.4.0):
+  - Vokoder (1.4.1):
+    - Vokoder/Core (= 1.4.1)
+    - Vokoder/DataSources (= 1.4.1)
+  - Vokoder/Core (1.4.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (1.4.0):
+  - Vokoder/DataSources (1.4.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 1.4.0)
-    - Vokoder/DataSources/FetchedResults (= 1.4.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 1.4.0)
-  - Vokoder/DataSources/Collection (1.4.0):
+    - Vokoder/DataSources/Collection (= 1.4.1)
+    - Vokoder/DataSources/FetchedResults (= 1.4.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 1.4.1)
+  - Vokoder/DataSources/Collection (1.4.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (1.4.0):
+  - Vokoder/DataSources/FetchedResults (1.4.1):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (1.4.0):
+  - Vokoder/DataSources/PagingFetchedResults (1.4.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -28,6 +28,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 1762f4c5bf26c3b1f7e3f730dabc59147bb2f130
+  Vokoder: 6bb77e5a4417b6d7e75ef17eb231e7af01f35db1
 
 COCOAPODS: 0.39.0

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -1,39 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForArchiving = "YES">
             <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A2CBEA9D0F7450454FE505AEBBEA9BF9"
-               BuildableName = "libVokoder.a"
-               BlueprintName = "Vokoder"
-               ReferencedContainer = "container:Pods.xcodeproj">
+               BuildableIdentifier = 'primary'
+               BlueprintIdentifier = '58DDE66BBCC55BF33C7E6F56'
+               BlueprintName = 'Vokoder'
+               ReferencedContainer = 'container:Pods.xcodeproj'
+               BuildableName = 'libVokoder.a'>
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -41,25 +38,17 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A2CBEA9D0F7450454FE505AEBBEA9BF9"
-            BuildableName = "libVokoder.a"
-            BlueprintName = "Vokoder"
-            ReferencedContainer = "container:Pods.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "YES"
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
@@ -51,9 +51,10 @@
             // Start with the class we are...
             Class workingClass = self;
             do {
+                NSString *workingClassName = NSStringFromClass(workingClass);
                 // ... check for a matching entity in the model...
                 for (NSEntityDescription *description in model.entities) {
-                    if ([workingClass class] == [NSClassFromString(description.managedObjectClassName) class]) {
+                    if ([workingClassName isEqualToString:description.managedObjectClassName]) {
                         vok_entityName = description.name;
                         break;
                     }

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
@@ -59,7 +59,7 @@
                     }
                 }
                 // ... and walk up the superclass chain...
-                workingClass = class_getSuperclass(workingClass);
+                workingClass = [workingClass superclass];
                 // ... until we get Nil or find a matching entity (as long as we have a superclass to test and haven't found the entity name).
             } while (workingClass && !vok_entityName);
         }

--- a/SampleProject/Models/VICoreDataModel.xcdatamodeld/VICoreDataModel.xcdatamodel/contents
+++ b/SampleProject/Models/VICoreDataModel.xcdatamodeld/VICoreDataModel.xcdatamodel/contents
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6751" systemVersion="13F1096" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15C50" minimumToolsVersion="Xcode 4.3">
+    <entity name="EntityA" representedClassName="VOKEntityA" isAbstract="YES" syncable="YES"/>
+    <entity name="EntityB" representedClassName="VOKEntityB" parentEntity="EntityA" syncable="YES"/>
+    <entity name="EntityC" representedClassName="VOKEntityC" parentEntity="EntityA" syncable="YES"/>
     <entity name="VIMappablePerson" representedClassName="VIMappablePerson" parentEntity="VIPerson" syncable="YES"/>
     <entity name="VIPerson" representedClassName="VIPerson" syncable="YES">
         <attribute name="birthDay" optional="YES" attributeType="Date" syncable="YES"/>
@@ -15,8 +18,11 @@
         <relationship name="person" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="VIPerson" inverseName="thing" inverseEntity="VIPerson" syncable="YES"/>
     </entity>
     <elements>
+        <element name="VIMappablePerson" positionX="180" positionY="225" width="128" height="45"/>
         <element name="VIPerson" positionX="160" positionY="192" width="128" height="133"/>
         <element name="VIThing" positionX="162" positionY="234" width="128" height="88"/>
-        <element name="VIMappablePerson" positionX="180" positionY="225" width="128" height="45"/>
+        <element name="EntityA" positionX="162" positionY="243" width="128" height="45"/>
+        <element name="EntityB" positionX="171" positionY="252" width="128" height="45"/>
+        <element name="EntityC" positionX="180" positionY="261" width="128" height="45"/>
     </elements>
 </model>

--- a/SampleProject/Models/VOKEntityA.h
+++ b/SampleProject/Models/VOKEntityA.h
@@ -1,0 +1,18 @@
+//
+//  VOKEntityA.h
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VOKEntityA : NSManagedObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleProject/Models/VOKEntityA.m
+++ b/SampleProject/Models/VOKEntityA.m
@@ -1,0 +1,13 @@
+//
+//  VOKEntityA.m
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import "VOKEntityA.h"
+
+@implementation VOKEntityA
+
+@end

--- a/SampleProject/Models/VOKEntityB.h
+++ b/SampleProject/Models/VOKEntityB.h
@@ -1,0 +1,18 @@
+//
+//  VOKEntityB.h
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "VOKEntityA.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VOKEntityB : VOKEntityA
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleProject/Models/VOKEntityB.m
+++ b/SampleProject/Models/VOKEntityB.m
@@ -1,0 +1,13 @@
+//
+//  VOKEntityB.m
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import "VOKEntityB.h"
+
+@implementation VOKEntityB
+
+@end

--- a/SampleProject/Models/VOKEntityC.h
+++ b/SampleProject/Models/VOKEntityC.h
@@ -1,0 +1,18 @@
+//
+//  VOKEntityC.h
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "VOKEntityA.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VOKEntityC : VOKEntityA
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleProject/Models/VOKEntityC.m
+++ b/SampleProject/Models/VOKEntityC.m
@@ -1,0 +1,13 @@
+//
+//  VOKEntityC.m
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import "VOKEntityC.h"
+
+@implementation VOKEntityC
+
+@end

--- a/SampleProject/Podfile.lock
+++ b/SampleProject/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (1.4.0):
-    - Vokoder/Core (= 1.4.0)
-    - Vokoder/DataSources (= 1.4.0)
-  - Vokoder/Core (1.4.0):
+  - Vokoder (1.4.1):
+    - Vokoder/Core (= 1.4.1)
+    - Vokoder/DataSources (= 1.4.1)
+  - Vokoder/Core (1.4.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (1.4.0):
+  - Vokoder/DataSources (1.4.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 1.4.0)
-    - Vokoder/DataSources/FetchedResults (= 1.4.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 1.4.0)
-  - Vokoder/DataSources/Collection (1.4.0):
+    - Vokoder/DataSources/Collection (= 1.4.1)
+    - Vokoder/DataSources/FetchedResults (= 1.4.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 1.4.1)
+  - Vokoder/DataSources/Collection (1.4.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (1.4.0):
+  - Vokoder/DataSources/FetchedResults (1.4.1):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (1.4.0):
+  - Vokoder/DataSources/PagingFetchedResults (1.4.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -28,6 +28,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 1762f4c5bf26c3b1f7e3f730dabc59147bb2f130
+  Vokoder: 6bb77e5a4417b6d7e75ef17eb231e7af01f35db1
 
 COCOAPODS: 0.39.0

--- a/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "1.4.0"
+    "tag": "1.4.1"
   },
   "platforms": {
     "ios": "7.0"

--- a/SampleProject/Pods/Manifest.lock
+++ b/SampleProject/Pods/Manifest.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (1.4.0):
-    - Vokoder/Core (= 1.4.0)
-    - Vokoder/DataSources (= 1.4.0)
-  - Vokoder/Core (1.4.0):
+  - Vokoder (1.4.1):
+    - Vokoder/Core (= 1.4.1)
+    - Vokoder/DataSources (= 1.4.1)
+  - Vokoder/Core (1.4.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (1.4.0):
+  - Vokoder/DataSources (1.4.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 1.4.0)
-    - Vokoder/DataSources/FetchedResults (= 1.4.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 1.4.0)
-  - Vokoder/DataSources/Collection (1.4.0):
+    - Vokoder/DataSources/Collection (= 1.4.1)
+    - Vokoder/DataSources/FetchedResults (= 1.4.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 1.4.1)
+  - Vokoder/DataSources/Collection (1.4.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (1.4.0):
+  - Vokoder/DataSources/FetchedResults (1.4.1):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (1.4.0):
+  - Vokoder/DataSources/PagingFetchedResults (1.4.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -28,6 +28,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 1762f4c5bf26c3b1f7e3f730dabc59147bb2f130
+  Vokoder: 6bb77e5a4417b6d7e75ef17eb231e7af01f35db1
 
 COCOAPODS: 0.39.0

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '69580CFDE5FF949E00F452D5'
+               BlueprintIdentifier = '7A6654919A5EB7E53D22971F'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libVokoder.a'>

--- a/SampleProject/SampleProject.xcodeproj/project.pbxproj
+++ b/SampleProject/SampleProject.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		3D40DE3E180729A10048D5EE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA5F19A615C196500089AA44 /* Foundation.framework */; };
 		3D40DE3F180729A10048D5EE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA5F19A415C196500089AA44 /* UIKit.framework */; };
 		487ADC79AEB21F0C4A5B6963 /* libPods-VOKCoreDataManager Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A15387FCC51E8AC46390CE29 /* libPods-VOKCoreDataManager Tests.a */; };
+		71041E531C5A9328003B4809 /* VOKEntityB.m in Sources */ = {isa = PBXBuildFile; fileRef = 71041E491C5A9328003B4809 /* VOKEntityB.m */; };
+		71041E551C5A9328003B4809 /* VOKEntityC.m in Sources */ = {isa = PBXBuildFile; fileRef = 71041E4D1C5A9328003B4809 /* VOKEntityC.m */; };
+		71041E571C5A9328003B4809 /* VOKEntityA.m in Sources */ = {isa = PBXBuildFile; fileRef = 71041E511C5A9328003B4809 /* VOKEntityA.m */; };
 		718462C21B9505D000015274 /* VIMappablePerson.m in Sources */ = {isa = PBXBuildFile; fileRef = 718462C11B9505D000015274 /* VIMappablePerson.m */; };
 		71E1AAE21A53408D004311E5 /* VIPersonDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E1AAE11A53408D004311E5 /* VIPersonDataSource.m */; };
 		71E1AAEA1A5340A1004311E5 /* VICoreDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 71E1AAE41A5340A1004311E5 /* VICoreDataModel.xcdatamodeld */; };
@@ -50,6 +53,12 @@
 		3D40DE34180728BF0048D5EE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		3D40DE3C180729A10048D5EE /* VOKCoreDataManager Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "VOKCoreDataManager Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F92780151AFBE02160324DF /* Pods-VOKCoreDataManager Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VOKCoreDataManager Tests/Pods-VOKCoreDataManager Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		71041E481C5A9328003B4809 /* VOKEntityB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VOKEntityB.h; sourceTree = "<group>"; };
+		71041E491C5A9328003B4809 /* VOKEntityB.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VOKEntityB.m; sourceTree = "<group>"; };
+		71041E4C1C5A9328003B4809 /* VOKEntityC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VOKEntityC.h; sourceTree = "<group>"; };
+		71041E4D1C5A9328003B4809 /* VOKEntityC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VOKEntityC.m; sourceTree = "<group>"; };
+		71041E501C5A9328003B4809 /* VOKEntityA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VOKEntityA.h; sourceTree = "<group>"; };
+		71041E511C5A9328003B4809 /* VOKEntityA.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VOKEntityA.m; sourceTree = "<group>"; };
 		7172B5031B8E82D400589204 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		7172B5041B8E82D400589204 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		7172B5051B8E82D400589204 /* Vokoder.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = Vokoder.podspec; path = ../Vokoder.podspec; sourceTree = "<group>"; };
@@ -167,6 +176,12 @@
 				71E1AAE71A5340A1004311E5 /* VIPerson.m */,
 				71E1AAE81A5340A1004311E5 /* VIThing.h */,
 				71E1AAE91A5340A1004311E5 /* VIThing.m */,
+				71041E501C5A9328003B4809 /* VOKEntityA.h */,
+				71041E511C5A9328003B4809 /* VOKEntityA.m */,
+				71041E481C5A9328003B4809 /* VOKEntityB.h */,
+				71041E491C5A9328003B4809 /* VOKEntityB.m */,
+				71041E4C1C5A9328003B4809 /* VOKEntityC.h */,
+				71041E4D1C5A9328003B4809 /* VOKEntityC.m */,
 			);
 			path = Models;
 			sourceTree = SOURCE_ROOT;
@@ -469,10 +484,13 @@
 				71E1AB041A534221004311E5 /* VIViewController.m in Sources */,
 				71E1AAEC1A5340A1004311E5 /* VIThing.m in Sources */,
 				71E1AAEA1A5340A1004311E5 /* VICoreDataModel.xcdatamodeld in Sources */,
+				71041E531C5A9328003B4809 /* VOKEntityB.m in Sources */,
 				71E1AB031A534221004311E5 /* VIAppDelegate.m in Sources */,
 				718462C21B9505D000015274 /* VIMappablePerson.m in Sources */,
 				71E1AAF31A5340CE004311E5 /* main.m in Sources */,
+				71041E571C5A9328003B4809 /* VOKEntityA.m in Sources */,
 				71E1AAEB1A5340A1004311E5 /* VIPerson.m in Sources */,
+				71041E551C5A9328003B4809 /* VOKEntityC.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleProject/VOKCoreDataManagerTests/VOKManagedObjectAdditions.m
+++ b/SampleProject/VOKCoreDataManagerTests/VOKManagedObjectAdditions.m
@@ -13,8 +13,16 @@
 #import <NSManagedObject+VOKManagedObjectAdditions.h>
 #import "VIThing.h"
 
+#import "VOKEntityA.h"
+#import "VOKEntityB.h"
+#import "VOKEntityC.h"
+
 static const NSUInteger BasicTestDataStartPoint = 0;
 static const NSUInteger BasicTestDataSize = 5;
+
+@interface VOKManagedObjectForTestGettingEntityName : NSManagedObject @end
+
+@implementation VOKManagedObjectForTestGettingEntityName @end
 
 @interface VOKManagedObjectAdditionTests : XCTestCase
 
@@ -222,6 +230,19 @@ static const NSUInteger BasicTestDataSize = 5;
     
     XCTAssertEqual([[results firstObject] numberOfHats].intValue, BasicTestDataStartPoint + BasicTestDataSize-1);
     XCTAssertEqual([[results lastObject] numberOfHats].intValue, BasicTestDataStartPoint);
+}
+
+#pragma mark - Test getting entity name
+
+- (void)testGettingEntityName
+{
+    XCTAssertEqualObjects([VOKEntityA vok_entityName], @"EntityA");
+    XCTAssertEqualObjects([VOKEntityB vok_entityName], @"EntityB");
+    XCTAssertEqualObjects([VOKEntityC vok_entityName], @"EntityC");
+    XCTAssertEqualObjects([VIThing vok_entityName], @"VIThing");
+    XCTAssertThrows([NSManagedObject vok_entityName]);
+    XCTAssertThrows([VOKManagedObjectForTestGettingEntityName vok_entityName]);
+    XCTAssertThrows([[NSString class] vok_entityName]);
 }
 
 @end

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "1.4.0"
+  s.version          = "1.4.1"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
Actual change is in 75bdca4; 2eec4d7 is running pod install on both sample projects.

Way back in 2014, Vokoder (actually, its predecessor) assumed that entity names were the same as class names.  I tended to name my entities without the project prefix, so that didn't work for me.  In changing it, I leveraged MOGenerator's `entityName` method (or anyone else's, really) if it exists, but otherwise went to look up the entity name in the managed object model.

Except that I did it wrong.  It returned the entity name of the first class that was the same or a superclass of the target class, going through an alphabetical list.  This PR fixes the way entity names are looked up against the model, looking for the entity name for the exact class, then if no match was found, trying the superclass, and going up the superclass chain until it finds an entity or fails.  This'll find the closest ancestor entity name, which is what we want.

I'm applying this to 1.4.0 to make 1.4.1 in this PR.  I'll open a separate PR to apply this to the latest 2.x release, too.

@vokal/ios-developers @seanwolter Code review please?