### PR TITLE
Bring 1.4.1 fix to 2.x line

### DIFF
--- a/Paging Data Source Example/Podfile.lock
+++ b/Paging Data Source Example/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (2.0.0):
-    - Vokoder/Core (= 2.0.0)
-    - Vokoder/DataSources (= 2.0.0)
-  - Vokoder/Core (2.0.0):
+  - Vokoder (2.1.2):
+    - Vokoder/Core (= 2.1.2)
+    - Vokoder/DataSources (= 2.1.2)
+  - Vokoder/Core (2.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (2.0.0):
+  - Vokoder/DataSources (2.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.0.0)
-    - Vokoder/DataSources/FetchedResults (= 2.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.0.0)
-  - Vokoder/DataSources/Collection (2.0.0):
+    - Vokoder/DataSources/Collection (= 2.1.2)
+    - Vokoder/DataSources/FetchedResults (= 2.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.1.2)
+  - Vokoder/DataSources/Collection (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.0.0):
+  - Vokoder/DataSources/FetchedResults (2.1.2):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.0.0):
+  - Vokoder/DataSources/PagingFetchedResults (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -24,10 +24,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Vokoder:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 0cf148e24eab7f54ca735b78275ed0dde1af88fc
+  Vokoder: 3a78a4bdf2a224502e2d83f07bbf2361257d07aa
 
 COCOAPODS: 0.39.0

--- a/Paging Data Source Example/Pods/Headers/Private/Vokoder/Vokoder.h
+++ b/Paging Data Source Example/Pods/Headers/Private/Vokoder/Vokoder.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/Vokoder.h

--- a/Paging Data Source Example/Pods/Headers/Public/Vokoder/Vokoder.h
+++ b/Paging Data Source Example/Pods/Headers/Public/Vokoder/Vokoder.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/Vokoder.h

--- a/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,12 +12,16 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "2.0.0"
+    "tag": "2.1.2"
   },
   "platforms": {
     "ios": "7.0"
   },
   "requires_arc": true,
+  "default_subspecs": [
+    "Core",
+    "DataSources"
+  ],
   "subspecs": [
     {
       "name": "Core",
@@ -70,6 +74,20 @@
             ]
           }
         }
+      ]
+    },
+    {
+      "name": "Swift",
+      "platforms": {
+        "ios": "8.0"
+      },
+      "dependencies": {
+        "Vokoder/DataSources": [
+
+        ]
+      },
+      "source_files": [
+        "Pod/Classes/Swift/*.swift"
       ]
     }
   ]

--- a/Paging Data Source Example/Pods/Manifest.lock
+++ b/Paging Data Source Example/Pods/Manifest.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (2.0.0):
-    - Vokoder/Core (= 2.0.0)
-    - Vokoder/DataSources (= 2.0.0)
-  - Vokoder/Core (2.0.0):
+  - Vokoder (2.1.2):
+    - Vokoder/Core (= 2.1.2)
+    - Vokoder/DataSources (= 2.1.2)
+  - Vokoder/Core (2.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (2.0.0):
+  - Vokoder/DataSources (2.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.0.0)
-    - Vokoder/DataSources/FetchedResults (= 2.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.0.0)
-  - Vokoder/DataSources/Collection (2.0.0):
+    - Vokoder/DataSources/Collection (= 2.1.2)
+    - Vokoder/DataSources/FetchedResults (= 2.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.1.2)
+  - Vokoder/DataSources/Collection (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.0.0):
+  - Vokoder/DataSources/FetchedResults (2.1.2):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.0.0):
+  - Vokoder/DataSources/PagingFetchedResults (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -24,10 +24,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Vokoder:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 0cf148e24eab7f54ca735b78275ed0dde1af88fc
+  Vokoder: 3a78a4bdf2a224502e2d83f07bbf2361257d07aa
 
 COCOAPODS: 0.39.0

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,32 +7,33 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		03C857F433EBADC560BF858311161C6D /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FF2B327DE0A1ABB56F6FB6BD0943AD0 /* VOKManagedObjectMap.m */; };
-		08B907036A6BE96FF55211AA1D8D0AA1 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 84E86AB4578E186E7B2AFF8851D63295 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1109C1788E320524CAC366CCA1FDD141 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A9B9A992A9A2B13E8800A5179B03D58E /* VOKCoreDataManager.m */; };
+		03C857F433EBADC560BF858311161C6D /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 25F57660D162B2F5E7A650A28154F71F /* VOKManagedObjectMap.m */; };
+		0C6657749BBD26BE8ED5F910C2F9D596 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C5662E9562AB6CBE6C1045374615629F /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1109C1788E320524CAC366CCA1FDD141 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1047692D0FAD0B395AE1FB4975A21B34 /* VOKCoreDataManager.m */; };
 		196F157AEBC9B59D29D521F7E076D439 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 770C74B6DCFCEB4BE6325A9388C41FC0 /* VOKFetchedResultsDataSource.m */; };
-		398C60C9357C24E9E7F7F9BEEE4708F6 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 01661146324EA0DA76527EB7035572C1 /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5549D1D654D66CC8258FB01791AD83CE /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 438540CA566C4EC94C19ABC9F30C8F6C /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		788885E4255D772932135C398E8E1B6A /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = C8F9681D0E406EBCF9D6C6B260DE1EB7 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7A2C65393A0A30B04AD143BEC504652F /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF7D4F51C8ADF9C669161A2E5E51B52 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1FCBB7193C81F8350AB9D540B066C6D9 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = BAA58F8304D7238A1CA7540BC6A9A1AE /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		379BD2B5C7A1A27A1241B87487C855ED /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 83772560B116ED564CFF0649CDE14EA3 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5BEA137F2C58267BD0B8E3884B9F37A0 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 3858F65DFCDE502A805CFA44E6D05981 /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77E6CCF43EB60E4DD9F13FD43BF135D9 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E99A40F34551EBBA2BBE82D38E376E8 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B9A068C1DF7F9839504FABB4BE8BDF6 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = B0A5B40A76DE6D548909461D52504BFF /* VOKDefaultPagingAccessory.m */; };
-		804739B1ED5B5D3712A2997F191A165E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A85A884FD8D4E8C7B655F9D8C004432E /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		804DC530169811990D87E81C7CAF1409 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BA03F557966E137F25B95C58B6CAFC6 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		804739B1ED5B5D3712A2997F191A165E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D65F000A660B78BD9DDE36B46F67F4B /* NSManagedObject+VOKManagedObjectAdditions.m */; };
 		812DFB7D099D2206F9D6926D475575EE /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 82125EC384E942ADA861A80B4E1C54FD /* VOKPagingFetchedResultsDataSource.m */; };
-		A23E4F9A68F21341A3DB857D801AF835 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = D7180FA362DCE0EB5719EE0CC8EEA64B /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A45BC990F32B6D3EAF48C6E3BB1DDAC3 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CB43F468D0CE4D041478891A2B0A15D /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A4BB08ECBCDFB996B1DAB517580C26DE /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 80160FDC40EF6CB58E7CF6AADB1E39D6 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9108E2CF44D4C21011487C392C560946 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 244CC8F2727BB290083A3B5500DF8544 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ACA893ABD7E4F7DF2A0DE0EB147B8BE4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		B18C159AD70F20FFE918BDF286F40E6E /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 249D8F839D9397A93D6F37F9786BC499 /* VOKCollectionDataSource.m */; };
+		B3815EBDDBEA29441F383E5E67F3B82C /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = D7180FA362DCE0EB5719EE0CC8EEA64B /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B807E5F3FC8281B31C20BDBF49205492 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 01661146324EA0DA76527EB7035572C1 /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9079F74D1398C0370ACB47B775CD6A7 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B96552C6D33CE7BB443666B108DFA30 /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9822FC1C15B548E4B2A3631ED370F0E /* Pods-Paging Data Source Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 76FCE337C61B99F634ADD203BD4589AD /* Pods-Paging Data Source Example-dummy.m */; };
-		B9DF58D6641F80FFDA63D2869B75B88E /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 139657F659FC076EF7C64B990BB09813 /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C1056734ABFD11CED55A7139256063AE /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A283B9D1137B54CD97F1050A5291823 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C40DC6DEFE9B313145B4E9B73E5A2E25 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 75560487D681A7A0484C41F71B8365E9 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C63E5EBD8C9FF3B43E78E087CBAE6C22 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 937A886B6CD1DB329E8A2DDD44662F8B /* VOKManagedObjectMapper.m */; };
+		C63E5EBD8C9FF3B43E78E087CBAE6C22 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = BC7AA9C44C19A1FB8C096620A94B6015 /* VOKManagedObjectMapper.m */; };
+		CA4073AE95D0815841A7E5EB6F2A0534 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 796E31FFAAA5C778719167532C35D781 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D95AD1B08EBB57B4F6BB0F2F00F3A925 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E9348E2AD5EB10B22EBB742F98EAE4A3 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E22659CF2B63BC78FE81616505F48620 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 799D0DC509FE60CBDC3AFA01FC4E18EE /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED25BE59A1DE84216F3FDECFBED32BDD /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D190B8553BD3314394B7A68597ECD513 /* CoreData.framework */; };
+		F42DC9BEF8B411522879ED4B2E3E5997 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF7D4F51C8ADF9C669161A2E5E51B52 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4D035540EC08CD382635BA5ECFB0D66 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7AD1CC69B0CF82225E01723A98EDF2 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F7CABB38F71CFB24FE49B1C2C47AE740 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
-		F88A460B9436E4F993A373AE377C063B /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 799D0DC509FE60CBDC3AFA01FC4E18EE /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAAA12A123BCB7D8A3E0AF3B8E1C0085 /* ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 83C3DAEA588DA0673D6235CFA7AB31DD /* ILGDynamicObjC-dummy.m */; };
 		FEF747F0B0D8BC3455963BC5AF8604A8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		FFAFBCBF77EC3D261F43F846291787E5 /* Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FD6D489858C816B8AA66D1290CA9634C /* Vokoder-dummy.m */; };
@@ -65,38 +66,39 @@
 /* Begin PBXFileReference section */
 		01661146324EA0DA76527EB7035572C1 /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
 		0B96552C6D33CE7BB443666B108DFA30 /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
-		139657F659FC076EF7C64B990BB09813 /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
+		1047692D0FAD0B395AE1FB4975A21B34 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		244CC8F2727BB290083A3B5500DF8544 /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
 		249D8F839D9397A93D6F37F9786BC499 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
+		25F57660D162B2F5E7A650A28154F71F /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
+		3858F65DFCDE502A805CFA44E6D05981 /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
 		393E4BCB6B84CF48111C6A05EBFFBF46 /* Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Vokoder.xcconfig; sourceTree = "<group>"; };
-		438540CA566C4EC94C19ABC9F30C8F6C /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
+		3D65F000A660B78BD9DDE36B46F67F4B /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
 		4B9635343991A2D67AA3055F69FAF95B /* libVokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libVokoder.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		560ADA6B376E62F39B3220D7E9DB5ECE /* Pods-Paging Data Source Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.debug.xcconfig"; sourceTree = "<group>"; };
-		5BA03F557966E137F25B95C58B6CAFC6 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
 		65900821EAD1DDD584635E06C1BD834F /* Pods-Paging Data Source Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.release.xcconfig"; sourceTree = "<group>"; };
 		6A8EAA421133B6B09336773AA3C0F738 /* Pods-Paging Data Source Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-frameworks.sh"; sourceTree = "<group>"; };
-		6CB43F468D0CE4D041478891A2B0A15D /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
 		75560487D681A7A0484C41F71B8365E9 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
 		76FCE337C61B99F634ADD203BD4589AD /* Pods-Paging Data Source Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-dummy.m"; sourceTree = "<group>"; };
 		770C74B6DCFCEB4BE6325A9388C41FC0 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		796E31FFAAA5C778719167532C35D781 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
 		799D0DC509FE60CBDC3AFA01FC4E18EE /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
-		7A283B9D1137B54CD97F1050A5291823 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
-		80160FDC40EF6CB58E7CF6AADB1E39D6 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
 		82125EC384E942ADA861A80B4E1C54FD /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		83772560B116ED564CFF0649CDE14EA3 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
 		83C3DAEA588DA0673D6235CFA7AB31DD /* ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
-		84E86AB4578E186E7B2AFF8851D63295 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
+		8E99A40F34551EBBA2BBE82D38E376E8 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
 		8F3DFD80683BE681779D76CDAE7865F6 /* Pods-Paging Data Source Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Paging Data Source Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		8FF2B327DE0A1ABB56F6FB6BD0943AD0 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
-		937A886B6CD1DB329E8A2DDD44662F8B /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
 		9DF7D4F51C8ADF9C669161A2E5E51B52 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
 		9F3E8EF1D588217723F3289841A25DF1 /* libILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libILGDynamicObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		A85A884FD8D4E8C7B655F9D8C004432E /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
-		A9B9A992A9A2B13E8800A5179B03D58E /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		AA7AD1CC69B0CF82225E01723A98EDF2 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
 		B0A5B40A76DE6D548909461D52504BFF /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
 		B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		C8F9681D0E406EBCF9D6C6B260DE1EB7 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
+		BAA58F8304D7238A1CA7540BC6A9A1AE /* Vokoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Vokoder.h; sourceTree = "<group>"; };
+		BC7AA9C44C19A1FB8C096620A94B6015 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
+		C5662E9562AB6CBE6C1045374615629F /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
 		D190B8553BD3314394B7A68597ECD513 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
 		D7180FA362DCE0EB5719EE0CC8EEA64B /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
+		E9348E2AD5EB10B22EBB742F98EAE4A3 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
 		EBF958E44EC865CFE846FAFF3B9C33B7 /* Pods-Paging Data Source Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-resources.sh"; sourceTree = "<group>"; };
 		F323E6A9DF2D511067E494B10BE08C69 /* ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ILGDynamicObjC.xcconfig; sourceTree = "<group>"; };
 		F454A3A24056DB3DCE273346636DE4A9 /* Pods-Paging Data Source Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Paging Data Source Example-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -135,6 +137,26 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0259127E947AE6FB131112C4BB3648CF /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				C5662E9562AB6CBE6C1045374615629F /* NSManagedObject+VOKManagedObjectAdditions.h */,
+				3D65F000A660B78BD9DDE36B46F67F4B /* NSManagedObject+VOKManagedObjectAdditions.m */,
+				244CC8F2727BB290083A3B5500DF8544 /* VOKCoreDataCollectionTypes.h */,
+				AA7AD1CC69B0CF82225E01723A98EDF2 /* VOKCoreDataManager.h */,
+				1047692D0FAD0B395AE1FB4975A21B34 /* VOKCoreDataManager.m */,
+				E9348E2AD5EB10B22EBB742F98EAE4A3 /* VOKManagedObjectMap.h */,
+				25F57660D162B2F5E7A650A28154F71F /* VOKManagedObjectMap.m */,
+				83772560B116ED564CFF0649CDE14EA3 /* VOKManagedObjectMapper.h */,
+				BC7AA9C44C19A1FB8C096620A94B6015 /* VOKManagedObjectMapper.m */,
+				8E99A40F34551EBBA2BBE82D38E376E8 /* VOKMappableModel.h */,
+				3858F65DFCDE502A805CFA44E6D05981 /* VOKNullabilityFeatures.h */,
+				BAA58F8304D7238A1CA7540BC6A9A1AE /* Vokoder.h */,
+				6359E2A4F7B264638CB5D808324877C7 /* Internal */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
 		088CF97B779ED2E9832E738B6568EE34 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -199,14 +221,6 @@
 			path = "Paging Data Source Example/Pods/Target Support Files/Vokoder";
 			sourceTree = "<group>";
 		};
-		20E02BA6F62978C55AD3065F171F63A1 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				8D3610F8B0A61E9B17CB4746C06C4F3A /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
 		2275B10F17A319ACF4E2FCEB6E48B5E8 /* Vokoder */ = {
 			isa = PBXGroup;
 			children = (
@@ -225,14 +239,6 @@
 				B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */,
 			);
 			name = iOS;
-			sourceTree = "<group>";
-		};
-		35B36633B6DC6C4C65E32C17CF208A1D /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				7A283B9D1137B54CD97F1050A5291823 /* VOKCoreDataManagerInternalMacros.h */,
-			);
-			path = Internal;
 			sourceTree = "<group>";
 		};
 		36AE8AFA6A8E7D8CF1828A3C2FAF26AF /* Classes */ = {
@@ -262,7 +268,7 @@
 		5432B40F9F44CDE12CC2BF92C02E6CB4 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				20E02BA6F62978C55AD3065F171F63A1 /* Pod */,
+				EFD8F312ED980734451FC7E9E71D9762 /* Pod */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -273,6 +279,14 @@
 				9D695F033C4A93ADE081DB11508B59AB /* Classes */,
 			);
 			path = Pod;
+			sourceTree = "<group>";
+		};
+		6359E2A4F7B264638CB5D808324877C7 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				796E31FFAAA5C778719167532C35D781 /* VOKCoreDataManagerInternalMacros.h */,
+			);
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		715076F02CD6B92542AFCBA3AACC9578 /* Classes */ = {
@@ -327,25 +341,6 @@
 				1E13786B3199A460EA8B6C586AB8BD9C /* Support Files */,
 			);
 			path = ILGDynamicObjC;
-			sourceTree = "<group>";
-		};
-		8D3610F8B0A61E9B17CB4746C06C4F3A /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				80160FDC40EF6CB58E7CF6AADB1E39D6 /* NSManagedObject+VOKManagedObjectAdditions.h */,
-				A85A884FD8D4E8C7B655F9D8C004432E /* NSManagedObject+VOKManagedObjectAdditions.m */,
-				438540CA566C4EC94C19ABC9F30C8F6C /* VOKCoreDataCollectionTypes.h */,
-				5BA03F557966E137F25B95C58B6CAFC6 /* VOKCoreDataManager.h */,
-				A9B9A992A9A2B13E8800A5179B03D58E /* VOKCoreDataManager.m */,
-				6CB43F468D0CE4D041478891A2B0A15D /* VOKManagedObjectMap.h */,
-				8FF2B327DE0A1ABB56F6FB6BD0943AD0 /* VOKManagedObjectMap.m */,
-				84E86AB4578E186E7B2AFF8851D63295 /* VOKManagedObjectMapper.h */,
-				937A886B6CD1DB329E8A2DDD44662F8B /* VOKManagedObjectMapper.m */,
-				C8F9681D0E406EBCF9D6C6B260DE1EB7 /* VOKMappableModel.h */,
-				139657F659FC076EF7C64B990BB09813 /* VOKNullabilityFeatures.h */,
-				35B36633B6DC6C4C65E32C17CF208A1D /* Internal */,
-			);
-			path = Classes;
 			sourceTree = "<group>";
 		};
 		9A1E7C84946C527C604668341A336CE3 /* Products */ = {
@@ -410,6 +405,14 @@
 			name = Collection;
 			sourceTree = "<group>";
 		};
+		EFD8F312ED980734451FC7E9E71D9762 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				0259127E947AE6FB131112C4BB3648CF /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
 		F6213BDD5CC647BDDA0C0D66AF0AAE8A /* Pod */ = {
 			isa = PBXGroup;
 			children = (
@@ -421,30 +424,31 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		31061623F7AE0C94152CEEFCDBF4FD9B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0C6657749BBD26BE8ED5F910C2F9D596 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				B807E5F3FC8281B31C20BDBF49205492 /* VOKCollectionDataSource.h in Headers */,
+				9108E2CF44D4C21011487C392C560946 /* VOKCoreDataCollectionTypes.h in Headers */,
+				F4D035540EC08CD382635BA5ECFB0D66 /* VOKCoreDataManager.h in Headers */,
+				CA4073AE95D0815841A7E5EB6F2A0534 /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				B3815EBDDBEA29441F383E5E67F3B82C /* VOKDefaultPagingAccessory.h in Headers */,
+				F42DC9BEF8B411522879ED4B2E3E5997 /* VOKFetchedResultsDataSource.h in Headers */,
+				D95AD1B08EBB57B4F6BB0F2F00F3A925 /* VOKManagedObjectMap.h in Headers */,
+				379BD2B5C7A1A27A1241B87487C855ED /* VOKManagedObjectMapper.h in Headers */,
+				77E6CCF43EB60E4DD9F13FD43BF135D9 /* VOKMappableModel.h in Headers */,
+				5BEA137F2C58267BD0B8E3884B9F37A0 /* VOKNullabilityFeatures.h in Headers */,
+				1FCBB7193C81F8350AB9D540B066C6D9 /* Vokoder.h in Headers */,
+				E22659CF2B63BC78FE81616505F48620 /* VOKPagingFetchedResultsDataSource.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8F078591045F5F001A3B1395DFDA8320 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				B9079F74D1398C0370ACB47B775CD6A7 /* ILGClasses.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F472E759CAFF04EF2BA64133D16B0BF0 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A4BB08ECBCDFB996B1DAB517580C26DE /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				398C60C9357C24E9E7F7F9BEEE4708F6 /* VOKCollectionDataSource.h in Headers */,
-				5549D1D654D66CC8258FB01791AD83CE /* VOKCoreDataCollectionTypes.h in Headers */,
-				804DC530169811990D87E81C7CAF1409 /* VOKCoreDataManager.h in Headers */,
-				C1056734ABFD11CED55A7139256063AE /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				A23E4F9A68F21341A3DB857D801AF835 /* VOKDefaultPagingAccessory.h in Headers */,
-				7A2C65393A0A30B04AD143BEC504652F /* VOKFetchedResultsDataSource.h in Headers */,
-				A45BC990F32B6D3EAF48C6E3BB1DDAC3 /* VOKManagedObjectMap.h in Headers */,
-				08B907036A6BE96FF55211AA1D8D0AA1 /* VOKManagedObjectMapper.h in Headers */,
-				788885E4255D772932135C398E8E1B6A /* VOKMappableModel.h in Headers */,
-				B9DF58D6641F80FFDA63D2869B75B88E /* VOKNullabilityFeatures.h in Headers */,
-				F88A460B9436E4F993A373AE377C063B /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -475,7 +479,7 @@
 			buildPhases = (
 				D85C8614412B58C71F2C9D88BB7D3602 /* Sources */,
 				5930D7213C3482ECEBDD7AE3C20C66E9 /* Frameworks */,
-				F472E759CAFF04EF2BA64133D16B0BF0 /* Headers */,
+				31061623F7AE0C94152CEEFCDBF4FD9B /* Headers */,
 			);
 			buildRules = (
 			);

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -1,39 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForArchiving = "YES">
             <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A2CBEA9D0F7450454FE505AEBBEA9BF9"
-               BuildableName = "libVokoder.a"
-               BlueprintName = "Vokoder"
-               ReferencedContainer = "container:Pods.xcodeproj">
+               BuildableIdentifier = 'primary'
+               BlueprintIdentifier = '6F2E94CE44D5285CD39EC17E'
+               BlueprintName = 'Vokoder'
+               ReferencedContainer = 'container:Pods.xcodeproj'
+               BuildableName = 'libVokoder.a'>
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -41,25 +38,17 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A2CBEA9D0F7450454FE505AEBBEA9BF9"
-            BuildableName = "libVokoder.a"
-            BlueprintName = "Vokoder"
-            ReferencedContainer = "container:Pods.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "YES"
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Paging Data Source Example/Pods/Target Support Files/Pods-Paging Data Source Example/Pods-Paging Data Source Example-acknowledgements.markdown
+++ b/Paging Data Source Example/Pods/Target Support Files/Pods-Paging Data Source Example/Pods-Paging Data Source Example-acknowledgements.markdown
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ## Vokoder
 
-https://tldrlegal.com/license/mit-license
+The MIT License (MIT)
 
 Copyright (c) 2012-2015 Vokal
 

--- a/Paging Data Source Example/Pods/Target Support Files/Pods-Paging Data Source Example/Pods-Paging Data Source Example-acknowledgements.plist
+++ b/Paging Data Source Example/Pods/Target Support Files/Pods-Paging Data Source Example/Pods-Paging Data Source Example-acknowledgements.plist
@@ -41,7 +41,7 @@ THE SOFTWARE.
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>https://tldrlegal.com/license/mit-license
+			<string>The MIT License (MIT)
 
 Copyright (c) 2012-2015 Vokal
 

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
@@ -49,12 +49,22 @@
             
             // Since we don't have an entityName class method, look up the entity name in the managed object model.
             NSManagedObjectModel *model = [[VOKCoreDataManager sharedInstance] managedObjectModel];
-            for (NSEntityDescription *description in model.entities) {
-                if ([self isSubclassOfClass:NSClassFromString(description.managedObjectClassName)]) {
-                    vok_entityName = description.name;
-                    break;
+            
+            // Start with the class we are...
+            Class workingClass = self;
+            do {
+                NSString *workingClassName = NSStringFromClass(workingClass);
+                // ... check for a matching entity in the model...
+                for (NSEntityDescription *description in model.entities) {
+                    if ([workingClassName isEqualToString:description.managedObjectClassName]) {
+                        vok_entityName = description.name;
+                        break;
+                    }
                 }
-            }
+                // ... and walk up the superclass chain...
+                workingClass = [workingClass superclass];
+                // ... until we get Nil or find a matching entity (as long as we have a superclass to test and haven't found the entity name).
+            } while (workingClass && !vok_entityName);
         }
         NSAssert(vok_entityName, @"no entity found that uses %@ as its class", NSStringFromClass(self));
         // Save the determined entity name as an associated value.

--- a/SampleProject/Models/VOKCoreDataModel.xcdatamodeld/VOKCoreDataModel.xcdatamodel/contents
+++ b/SampleProject/Models/VOKCoreDataModel.xcdatamodeld/VOKCoreDataModel.xcdatamodel/contents
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="14F1021" minimumToolsVersion="Xcode 4.3">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15C50" minimumToolsVersion="Xcode 4.3">
+    <entity name="EntityA" representedClassName="VOKEntityA" isAbstract="YES" syncable="YES"/>
+    <entity name="EntityB" representedClassName="VOKEntityB" parentEntity="EntityA" syncable="YES"/>
+    <entity name="EntityC" representedClassName="VOKEntityC" parentEntity="EntityA" syncable="YES"/>
     <entity name="VOKMappablePerson" representedClassName="VOKMappablePerson" parentEntity="VOKPerson" syncable="YES"/>
     <entity name="VOKPerson" representedClassName="VOKPerson" syncable="YES">
         <attribute name="birthDay" optional="YES" attributeType="Date" syncable="YES"/>
@@ -18,5 +21,8 @@
         <element name="VOKMappablePerson" positionX="0" positionY="0" width="0" height="0"/>
         <element name="VOKPerson" positionX="0" positionY="0" width="0" height="0"/>
         <element name="VOKThing" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="EntityA" positionX="162" positionY="243" width="128" height="45"/>
+        <element name="EntityB" positionX="171" positionY="252" width="128" height="45"/>
+        <element name="EntityC" positionX="180" positionY="261" width="128" height="45"/>
     </elements>
 </model>

--- a/SampleProject/Models/VOKEntityA.h
+++ b/SampleProject/Models/VOKEntityA.h
@@ -1,0 +1,18 @@
+//
+//  VOKEntityA.h
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VOKEntityA : NSManagedObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleProject/Models/VOKEntityA.m
+++ b/SampleProject/Models/VOKEntityA.m
@@ -1,0 +1,13 @@
+//
+//  VOKEntityA.m
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import "VOKEntityA.h"
+
+@implementation VOKEntityA
+
+@end

--- a/SampleProject/Models/VOKEntityB.h
+++ b/SampleProject/Models/VOKEntityB.h
@@ -1,0 +1,18 @@
+//
+//  VOKEntityB.h
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "VOKEntityA.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VOKEntityB : VOKEntityA
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleProject/Models/VOKEntityB.m
+++ b/SampleProject/Models/VOKEntityB.m
@@ -1,0 +1,13 @@
+//
+//  VOKEntityB.m
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import "VOKEntityB.h"
+
+@implementation VOKEntityB
+
+@end

--- a/SampleProject/Models/VOKEntityC.h
+++ b/SampleProject/Models/VOKEntityC.h
@@ -1,0 +1,18 @@
+//
+//  VOKEntityC.h
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "VOKEntityA.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VOKEntityC : VOKEntityA
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleProject/Models/VOKEntityC.m
+++ b/SampleProject/Models/VOKEntityC.m
@@ -1,0 +1,13 @@
+//
+//  VOKEntityC.m
+//  
+//
+//  Created by Isaac Greenspan on 1/28/16.
+//
+//
+
+#import "VOKEntityC.h"
+
+@implementation VOKEntityC
+
+@end

--- a/SampleProject/Podfile.lock
+++ b/SampleProject/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (2.0.0):
-    - Vokoder/Core (= 2.0.0)
-    - Vokoder/DataSources (= 2.0.0)
-  - Vokoder/Core (2.0.0):
+  - Vokoder (2.1.2):
+    - Vokoder/Core (= 2.1.2)
+    - Vokoder/DataSources (= 2.1.2)
+  - Vokoder/Core (2.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (2.0.0):
+  - Vokoder/DataSources (2.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.0.0)
-    - Vokoder/DataSources/FetchedResults (= 2.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.0.0)
-  - Vokoder/DataSources/Collection (2.0.0):
+    - Vokoder/DataSources/Collection (= 2.1.2)
+    - Vokoder/DataSources/FetchedResults (= 2.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.1.2)
+  - Vokoder/DataSources/Collection (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.0.0):
+  - Vokoder/DataSources/FetchedResults (2.1.2):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.0.0):
+  - Vokoder/DataSources/PagingFetchedResults (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -24,10 +24,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Vokoder:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 0cf148e24eab7f54ca735b78275ed0dde1af88fc
+  Vokoder: 3a78a4bdf2a224502e2d83f07bbf2361257d07aa
 
 COCOAPODS: 0.39.0

--- a/SampleProject/Pods/Headers/Private/Vokoder/Vokoder.h
+++ b/SampleProject/Pods/Headers/Private/Vokoder/Vokoder.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/Vokoder.h

--- a/SampleProject/Pods/Headers/Public/Vokoder/Vokoder.h
+++ b/SampleProject/Pods/Headers/Public/Vokoder/Vokoder.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/Vokoder.h

--- a/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,12 +12,16 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "2.0.0"
+    "tag": "2.1.2"
   },
   "platforms": {
     "ios": "7.0"
   },
   "requires_arc": true,
+  "default_subspecs": [
+    "Core",
+    "DataSources"
+  ],
   "subspecs": [
     {
       "name": "Core",
@@ -70,6 +74,20 @@
             ]
           }
         }
+      ]
+    },
+    {
+      "name": "Swift",
+      "platforms": {
+        "ios": "8.0"
+      },
+      "dependencies": {
+        "Vokoder/DataSources": [
+
+        ]
+      },
+      "source_files": [
+        "Pod/Classes/Swift/*.swift"
       ]
     }
   ]

--- a/SampleProject/Pods/Manifest.lock
+++ b/SampleProject/Pods/Manifest.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (2.0.0):
-    - Vokoder/Core (= 2.0.0)
-    - Vokoder/DataSources (= 2.0.0)
-  - Vokoder/Core (2.0.0):
+  - Vokoder (2.1.2):
+    - Vokoder/Core (= 2.1.2)
+    - Vokoder/DataSources (= 2.1.2)
+  - Vokoder/Core (2.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (2.0.0):
+  - Vokoder/DataSources (2.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.0.0)
-    - Vokoder/DataSources/FetchedResults (= 2.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.0.0)
-  - Vokoder/DataSources/Collection (2.0.0):
+    - Vokoder/DataSources/Collection (= 2.1.2)
+    - Vokoder/DataSources/FetchedResults (= 2.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.1.2)
+  - Vokoder/DataSources/Collection (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.0.0):
+  - Vokoder/DataSources/FetchedResults (2.1.2):
     - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.0.0):
+  - Vokoder/DataSources/PagingFetchedResults (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
 
@@ -24,10 +24,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Vokoder:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 0cf148e24eab7f54ca735b78275ed0dde1af88fc
+  Vokoder: 3a78a4bdf2a224502e2d83f07bbf2361257d07aa
 
 COCOAPODS: 0.39.0

--- a/SampleProject/Pods/Pods.xcodeproj/project.pbxproj
+++ b/SampleProject/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,34 +7,35 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		09D5CFB9E8D9C6E8866FE39D7B5D2D8D /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D56C1F3F66E7ED868EDF4400358F808 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0DDD3D3C220B07CFCBA02E337502DEB8 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A6EA8E90AA03A2F8861E0B591E5A0264 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06BAE41ABE229D199B2661E79D9C682C /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1324E59C45286803F6E047D6670CABA9 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		13CD3A4B0F9488085F75787D3730D591 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 335C848586917589FB83BABA43F60372 /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B6045470092DA0C3FD7B799C8CA18E8 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 44998190EEE27DD808F59C34C1D4581B /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF8EBC0F6D8DDFE41DD0E39BE3C8106 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A0DF5A37E74BE783E9F8F1294C4214D /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D82408513C635F8159CC47EE1F5D537 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A3A0AE924FF1F4550BC5323475EB7B5 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2727F57E74B4A6BC514BD8B860B2F0B9 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FAD3754A05D32E59309613C6D17B88C /* VOKDefaultPagingAccessory.m */; };
-		2B0A2E5222FFA0A65C1E9FD29FC40B93 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 69D610DA300F18E9CD4B0E3353D13079 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		31A15ABA57F09F4F294123D02908A42D /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D2A1C115A76F4489C8EA2029BFBDB76 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		273F3D6FC12C811D0AAD941B75262A17 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B0E39F14692725DB0B44B962A99CA1 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		31A15ABA57F09F4F294123D02908A42D /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B95F38A0D286CF7D5F3A905A9233CC9A /* NSManagedObject+VOKManagedObjectAdditions.m */; };
 		32596DED9F7878DE3781CB209CC2627E /* Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A02F54C47615AD824FAD2388E8B9EF7 /* Vokoder-dummy.m */; };
-		3838CEFE93E84E0A5538F273ACFD60A0 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 22BD905008F28FF4BC3B92B610F121B3 /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		44158341E167B76B65167E15077F6610 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D190B8553BD3314394B7A68597ECD513 /* CoreData.framework */; };
-		52121EA79E09C6F6AB2B8E4AB2AAC31B /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B42A49F6B5DB7C6B35F1EC34A2C584A6 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4BA3B602E15F49F7EC9EC76DC74A5BFB /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 6382745103AFEA44A0C48127BA498AF2 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63742F21BF732C2FC3A1B9347BA7043B /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = A6AE8D66476D5D6F3E15CE09BAAACE8F /* VOKFetchedResultsDataSource.m */; };
-		6C0E171AB4B16D85050C222CB60AE203 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DF51F859746AC6AD389F5CE590CFDEB /* VOKCoreDataManager.m */; };
+		6B7816F5D4C53913BE35CF6AAD521FBB /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 69D610DA300F18E9CD4B0E3353D13079 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6C0E171AB4B16D85050C222CB60AE203 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B42A683F3C35A63A9EFB18E4F1403A6 /* VOKCoreDataManager.m */; };
+		7AA385CBF28446A3B2A096D65940FD0D /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = CAC9A5CA4D209B442E8F88DC409BC669 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8023F655E052F8433D1CCBEF8D079188 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0E30EB24C05932D513858A70DF54AB /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		841BED808B1493215B855311BB55AD5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
-		88DEF95FEC47BC22B277F3488FA18F89 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AB7EB8F1DA2DD4E38CF24287A62D8E97 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		93CCF75D620A23706050677E6113522F /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = B6A20DF796560FF4DA99D02C596A987F /* VOKManagedObjectMap.m */; };
-		9BB8C57E16CE05589186BAB73FE05E36 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 04E139BDC6B35156AFDE884F4A572282 /* VOKManagedObjectMapper.m */; };
-		9E12C787EA89ED4611E5770B60D9F1CD /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A3A0AE924FF1F4550BC5323475EB7B5 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93CCF75D620A23706050677E6113522F /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BA1C6CDB36D7B35085C4230E504F28B /* VOKManagedObjectMap.m */; };
+		9BB8C57E16CE05589186BAB73FE05E36 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = CA5BF2C9AAC5B4A44FA5F27CE7B08FC9 /* VOKManagedObjectMapper.m */; };
 		9F22E6FD52609D2C7572AB037C2AD489 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = F740E70F1953AB02427370435F8F19D8 /* VOKCollectionDataSource.m */; };
 		A02C1B5F7AF6B25FB99C0188200E51DB /* Pods-VOKCoreDataManager-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C1311138A087A8C09DBD9971BA1225E /* Pods-VOKCoreDataManager-dummy.m */; };
-		A0D3656557D597F7216FBE8C8EC9C28C /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = CAC9A5CA4D209B442E8F88DC409BC669 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AAC36CF5410E482E907CEC8A058667AE /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D44524F10DF6B68200DC0C32F511C266 /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AE27D6F595D455BBB320E3F5D6E3329F /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 78C5B7E35EA648D36A0777837F3058A8 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9079F74D1398C0370ACB47B775CD6A7 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B96552C6D33CE7BB443666B108DFA30 /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD1467C8A69429D6528B94700A874C54 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 46FA8F20B5A840203FDD211588D3E184 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3575D20B82D412BC473728D30811C4F /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 910A40241DC3806D702540D9B269A54C /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C40DC6DEFE9B313145B4E9B73E5A2E25 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 75560487D681A7A0484C41F71B8365E9 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		C9E13D8EE88D5A633C2F45798A51E4FF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
+		D0447659E860261EEA9E4865E6BC83E3 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 00597A73D9689358370FDE5EAC674E50 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA627D87320298F8A3CADC2D9DCCEE4D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		DCC00AE85E693677FFBC6D1F18189B42 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 59FFEC0EBBC7CB50B6C2C443E95A51D6 /* VOKPagingFetchedResultsDataSource.m */; };
-		DD8CD200AF91C55A1C90EF8F778E74A2 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 04B372B7471C542BDFD305B3AC011BED /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCF73F704B07A8868CFC4A34B6F788B8 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D44524F10DF6B68200DC0C32F511C266 /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F7CABB38F71CFB24FE49B1C2C47AE740 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */; };
 		F97B8927170A88D3E65B28A1B3678344 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 57235B66D08563B4E0A57B24D8A31EF6 /* Pods-VOKCoreDataManager Tests-dummy.m */; };
 		FAAA12A123BCB7D8A3E0AF3B8E1C0085 /* ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 83C3DAEA588DA0673D6235CFA7AB31DD /* ILGDynamicObjC-dummy.m */; };
@@ -79,21 +80,21 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00597A73D9689358370FDE5EAC674E50 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
 		02D613911E97E88389490AFFC486D15D /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		04B372B7471C542BDFD305B3AC011BED /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
-		04E139BDC6B35156AFDE884F4A572282 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
 		0B96552C6D33CE7BB443666B108DFA30 /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
-		0D2A1C115A76F4489C8EA2029BFBDB76 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
+		1324E59C45286803F6E047D6670CABA9 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
 		1A02F54C47615AD824FAD2388E8B9EF7 /* Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Vokoder-dummy.m"; sourceTree = "<group>"; };
-		1D56C1F3F66E7ED868EDF4400358F808 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
 		1FAD3754A05D32E59309613C6D17B88C /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
 		21473FEFE99B96337C17F9D41BC02940 /* Pods-VOKCoreDataManager-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-acknowledgements.plist"; sourceTree = "<group>"; };
-		22BD905008F28FF4BC3B92B610F121B3 /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
 		235377919D31864677672149C8E07C0B /* Pods-VOKCoreDataManager Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-frameworks.sh"; sourceTree = "<group>"; };
 		236902F2E4038A5FBE48ABE393C3D603 /* Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Vokoder.xcconfig; sourceTree = "<group>"; };
-		2DF51F859746AC6AD389F5CE590CFDEB /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		2A0DF5A37E74BE783E9F8F1294C4214D /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
+		335C848586917589FB83BABA43F60372 /* Vokoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Vokoder.h; sourceTree = "<group>"; };
+		35B0E39F14692725DB0B44B962A99CA1 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
+		44998190EEE27DD808F59C34C1D4581B /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
 		452F9F135A375CF610B249778A08B315 /* libVokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libVokoder.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		46FA8F20B5A840203FDD211588D3E184 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
+		4BA1C6CDB36D7B35085C4230E504F28B /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
 		4BC4F8FC80DEC6EEA764A3C7071DF4EE /* libPods-VOKCoreDataManager.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VOKCoreDataManager.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E32F53C3DCE401FD8B3944B6A844F76 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		5056AC853385DCFAB9E0B80EE51563D9 /* Pods-VOKCoreDataManager-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-resources.sh"; sourceTree = "<group>"; };
@@ -101,29 +102,30 @@
 		57235B66D08563B4E0A57B24D8A31EF6 /* Pods-VOKCoreDataManager Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-dummy.m"; sourceTree = "<group>"; };
 		59FFEC0EBBC7CB50B6C2C443E95A51D6 /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
 		5C1311138A087A8C09DBD9971BA1225E /* Pods-VOKCoreDataManager-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-dummy.m"; sourceTree = "<group>"; };
+		6382745103AFEA44A0C48127BA498AF2 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
 		69D610DA300F18E9CD4B0E3353D13079 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
 		6A3A0AE924FF1F4550BC5323475EB7B5 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
 		6FA5ED4CDE4E734606DBA1CC3D4C876F /* Pods-VOKCoreDataManager-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-acknowledgements.markdown"; sourceTree = "<group>"; };
 		7345CE79B1D6636DB38E844BDEEB90DB /* Pods-VOKCoreDataManager Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-resources.sh"; sourceTree = "<group>"; };
 		75560487D681A7A0484C41F71B8365E9 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
-		78C5B7E35EA648D36A0777837F3058A8 /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
 		7CEFE5889C514FCB3CE8095FBEB80837 /* Pods-VOKCoreDataManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.debug.xcconfig"; sourceTree = "<group>"; };
 		82B8A5254EE829157070061D56D87D05 /* Pods-VOKCoreDataManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.release.xcconfig"; sourceTree = "<group>"; };
 		83C3DAEA588DA0673D6235CFA7AB31DD /* ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
+		8B42A683F3C35A63A9EFB18E4F1403A6 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		910A40241DC3806D702540D9B269A54C /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
 		97D21B9F83BAE7D5C53CFDEC95BBDBCE /* Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Vokoder-prefix.pch"; sourceTree = "<group>"; };
 		9D04E15D4AA19BDB744A7E4CD686EC03 /* libILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libILGDynamicObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A649AE2B23F489C1A860D95BFF2EBAC8 /* Pods-VOKCoreDataManager-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-frameworks.sh"; sourceTree = "<group>"; };
 		A6AE8D66476D5D6F3E15CE09BAAACE8F /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		A6EA8E90AA03A2F8861E0B591E5A0264 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
-		AB7EB8F1DA2DD4E38CF24287A62D8E97 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
-		B42A49F6B5DB7C6B35F1EC34A2C584A6 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
-		B6A20DF796560FF4DA99D02C596A987F /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
 		B8DCF029181227DFB891B1A2658BBCB2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		B95F38A0D286CF7D5F3A905A9233CC9A /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		CA5BF2C9AAC5B4A44FA5F27CE7B08FC9 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
 		CAC9A5CA4D209B442E8F88DC409BC669 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
 		CC6FD326BEFE350B9ABEDF10E7A82DE5 /* Pods-VOKCoreDataManager Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.release.xcconfig"; sourceTree = "<group>"; };
 		D190B8553BD3314394B7A68597ECD513 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
 		D44524F10DF6B68200DC0C32F511C266 /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
+		DA0E30EB24C05932D513858A70DF54AB /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
 		F323E6A9DF2D511067E494B10BE08C69 /* ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ILGDynamicObjC.xcconfig; sourceTree = "<group>"; };
 		F740E70F1953AB02427370435F8F19D8 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
 		FAF001A7E5DACAD78FD59474F63B20FA /* ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
@@ -279,20 +281,12 @@
 			name = FetchedResults;
 			sourceTree = "<group>";
 		};
-		5FBFFE95CFC8E6DDC36CE348FA53E03E /* Internal */ = {
+		567A1E496698FBE4C3BC2F280996D816 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				1D56C1F3F66E7ED868EDF4400358F808 /* VOKCoreDataManagerInternalMacros.h */,
+				6382745103AFEA44A0C48127BA498AF2 /* VOKCoreDataManagerInternalMacros.h */,
 			);
 			path = Internal;
-			sourceTree = "<group>";
-		};
-		6523028176EC99D7B14D4B5A47C0CA8C /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				BBA217E8D39F540476657964FC8DBC2C /* Classes */,
-			);
-			path = Pod;
 			sourceTree = "<group>";
 		};
 		67A7443CA17EF31D82DE1AD53BE982CF /* DataSources */ = {
@@ -371,9 +365,17 @@
 		9AB37BE62D4B3EBF410BE4015B6E0EE4 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				6523028176EC99D7B14D4B5A47C0CA8C /* Pod */,
+				A4406D9824F95F53AE7A952A340B907D /* Pod */,
 			);
 			name = Core;
+			sourceTree = "<group>";
+		};
+		A4406D9824F95F53AE7A952A340B907D /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				C6E4E3C232B443BF0303A2ADB19D9460 /* Classes */,
+			);
+			path = Pod;
 			sourceTree = "<group>";
 		};
 		B54E805850444800B4E192B0CAB39ECE /* Collection */ = {
@@ -395,21 +397,22 @@
 			path = "Optional Data Sources";
 			sourceTree = "<group>";
 		};
-		BBA217E8D39F540476657964FC8DBC2C /* Classes */ = {
+		C6E4E3C232B443BF0303A2ADB19D9460 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				AB7EB8F1DA2DD4E38CF24287A62D8E97 /* NSManagedObject+VOKManagedObjectAdditions.h */,
-				0D2A1C115A76F4489C8EA2029BFBDB76 /* NSManagedObject+VOKManagedObjectAdditions.m */,
-				78C5B7E35EA648D36A0777837F3058A8 /* VOKCoreDataCollectionTypes.h */,
-				46FA8F20B5A840203FDD211588D3E184 /* VOKCoreDataManager.h */,
-				2DF51F859746AC6AD389F5CE590CFDEB /* VOKCoreDataManager.m */,
-				A6EA8E90AA03A2F8861E0B591E5A0264 /* VOKManagedObjectMap.h */,
-				B6A20DF796560FF4DA99D02C596A987F /* VOKManagedObjectMap.m */,
-				04B372B7471C542BDFD305B3AC011BED /* VOKManagedObjectMapper.h */,
-				04E139BDC6B35156AFDE884F4A572282 /* VOKManagedObjectMapper.m */,
-				B42A49F6B5DB7C6B35F1EC34A2C584A6 /* VOKMappableModel.h */,
-				22BD905008F28FF4BC3B92B610F121B3 /* VOKNullabilityFeatures.h */,
-				5FBFFE95CFC8E6DDC36CE348FA53E03E /* Internal */,
+				00597A73D9689358370FDE5EAC674E50 /* NSManagedObject+VOKManagedObjectAdditions.h */,
+				B95F38A0D286CF7D5F3A905A9233CC9A /* NSManagedObject+VOKManagedObjectAdditions.m */,
+				2A0DF5A37E74BE783E9F8F1294C4214D /* VOKCoreDataCollectionTypes.h */,
+				DA0E30EB24C05932D513858A70DF54AB /* VOKCoreDataManager.h */,
+				8B42A683F3C35A63A9EFB18E4F1403A6 /* VOKCoreDataManager.m */,
+				35B0E39F14692725DB0B44B962A99CA1 /* VOKManagedObjectMap.h */,
+				4BA1C6CDB36D7B35085C4230E504F28B /* VOKManagedObjectMap.m */,
+				44998190EEE27DD808F59C34C1D4581B /* VOKManagedObjectMapper.h */,
+				CA5BF2C9AAC5B4A44FA5F27CE7B08FC9 /* VOKManagedObjectMapper.m */,
+				1324E59C45286803F6E047D6670CABA9 /* VOKMappableModel.h */,
+				910A40241DC3806D702540D9B269A54C /* VOKNullabilityFeatures.h */,
+				335C848586917589FB83BABA43F60372 /* Vokoder.h */,
+				567A1E496698FBE4C3BC2F280996D816 /* Internal */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -470,22 +473,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		04FB4A02EB2A6FFED157150CCE772FC5 /* Headers */ = {
+		7081DC3FE919B2C16879CB7A1A0EBDD8 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				88DEF95FEC47BC22B277F3488FA18F89 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				AAC36CF5410E482E907CEC8A058667AE /* VOKCollectionDataSource.h in Headers */,
-				AE27D6F595D455BBB320E3F5D6E3329F /* VOKCoreDataCollectionTypes.h in Headers */,
-				BD1467C8A69429D6528B94700A874C54 /* VOKCoreDataManager.h in Headers */,
-				09D5CFB9E8D9C6E8866FE39D7B5D2D8D /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				A0D3656557D597F7216FBE8C8EC9C28C /* VOKDefaultPagingAccessory.h in Headers */,
-				9E12C787EA89ED4611E5770B60D9F1CD /* VOKFetchedResultsDataSource.h in Headers */,
-				0DDD3D3C220B07CFCBA02E337502DEB8 /* VOKManagedObjectMap.h in Headers */,
-				DD8CD200AF91C55A1C90EF8F778E74A2 /* VOKManagedObjectMapper.h in Headers */,
-				52121EA79E09C6F6AB2B8E4AB2AAC31B /* VOKMappableModel.h in Headers */,
-				3838CEFE93E84E0A5538F273ACFD60A0 /* VOKNullabilityFeatures.h in Headers */,
-				2B0A2E5222FFA0A65C1E9FD29FC40B93 /* VOKPagingFetchedResultsDataSource.h in Headers */,
+				D0447659E860261EEA9E4865E6BC83E3 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				DCF73F704B07A8868CFC4A34B6F788B8 /* VOKCollectionDataSource.h in Headers */,
+				1BF8EBC0F6D8DDFE41DD0E39BE3C8106 /* VOKCoreDataCollectionTypes.h in Headers */,
+				8023F655E052F8433D1CCBEF8D079188 /* VOKCoreDataManager.h in Headers */,
+				4BA3B602E15F49F7EC9EC76DC74A5BFB /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				7AA385CBF28446A3B2A096D65940FD0D /* VOKDefaultPagingAccessory.h in Headers */,
+				1D82408513C635F8159CC47EE1F5D537 /* VOKFetchedResultsDataSource.h in Headers */,
+				273F3D6FC12C811D0AAD941B75262A17 /* VOKManagedObjectMap.h in Headers */,
+				1B6045470092DA0C3FD7B799C8CA18E8 /* VOKManagedObjectMapper.h in Headers */,
+				06BAE41ABE229D199B2661E79D9C682C /* VOKMappableModel.h in Headers */,
+				C3575D20B82D412BC473728D30811C4F /* VOKNullabilityFeatures.h in Headers */,
+				13CD3A4B0F9488085F75787D3730D591 /* Vokoder.h in Headers */,
+				6B7816F5D4C53913BE35CF6AAD521FBB /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -524,7 +528,7 @@
 			buildPhases = (
 				84ADF7F63BFE8AE224D7074C35F90020 /* Sources */,
 				480C959A391BCA2042DE2201EC0DE116 /* Frameworks */,
-				04FB4A02EB2A6FFED157150CCE772FC5 /* Headers */,
+				7081DC3FE919B2C16879CB7A1A0EBDD8 /* Headers */,
 			);
 			buildRules = (
 			);

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '0228C17AC3001DDD7937A8E3'
+               BlueprintIdentifier = 'AFC2C4045646F0FDC5D4B0CF'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libVokoder.a'>

--- a/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager Tests/Pods-VOKCoreDataManager Tests-acknowledgements.markdown
+++ b/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager Tests/Pods-VOKCoreDataManager Tests-acknowledgements.markdown
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ## Vokoder
 
-https://tldrlegal.com/license/mit-license
+The MIT License (MIT)
 
 Copyright (c) 2012-2015 Vokal
 

--- a/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager Tests/Pods-VOKCoreDataManager Tests-acknowledgements.plist
+++ b/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager Tests/Pods-VOKCoreDataManager Tests-acknowledgements.plist
@@ -41,7 +41,7 @@ THE SOFTWARE.
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>https://tldrlegal.com/license/mit-license
+			<string>The MIT License (MIT)
 
 Copyright (c) 2012-2015 Vokal
 

--- a/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager/Pods-VOKCoreDataManager-acknowledgements.markdown
+++ b/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager/Pods-VOKCoreDataManager-acknowledgements.markdown
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ## Vokoder
 
-https://tldrlegal.com/license/mit-license
+The MIT License (MIT)
 
 Copyright (c) 2012-2015 Vokal
 

--- a/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager/Pods-VOKCoreDataManager-acknowledgements.plist
+++ b/SampleProject/Pods/Target Support Files/Pods-VOKCoreDataManager/Pods-VOKCoreDataManager-acknowledgements.plist
@@ -41,7 +41,7 @@ THE SOFTWARE.
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>https://tldrlegal.com/license/mit-license
+			<string>The MIT License (MIT)
 
 Copyright (c) 2012-2015 Vokal
 

--- a/SampleProject/SampleProject.xcodeproj/project.pbxproj
+++ b/SampleProject/SampleProject.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		71E1AAEA1A5340A1004311E5 /* VOKCoreDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 71E1AAE41A5340A1004311E5 /* VOKCoreDataModel.xcdatamodeld */; };
 		71E1AAEB1A5340A1004311E5 /* VOKPerson.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E1AAE71A5340A1004311E5 /* VOKPerson.m */; };
 		71E1AAEC1A5340A1004311E5 /* VOKThing.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E1AAE91A5340A1004311E5 /* VOKThing.m */; };
+		71041E531C5A9328003B4809 /* VOKEntityB.m in Sources */ = {isa = PBXBuildFile; fileRef = 71041E491C5A9328003B4809 /* VOKEntityB.m */; };
+		71041E551C5A9328003B4809 /* VOKEntityC.m in Sources */ = {isa = PBXBuildFile; fileRef = 71041E4D1C5A9328003B4809 /* VOKEntityC.m */; };
+		71041E571C5A9328003B4809 /* VOKEntityA.m in Sources */ = {isa = PBXBuildFile; fileRef = 71041E511C5A9328003B4809 /* VOKEntityA.m */; };
 		71E1AAF21A5340CE004311E5 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 71E1AAEE1A5340CE004311E5 /* Default-568h@2x.png */; };
 		71E1AAF31A5340CE004311E5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E1AAEF1A5340CE004311E5 /* main.m */; };
 		71E1AB031A534221004311E5 /* VOKAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E1AB001A534221004311E5 /* VOKAppDelegate.m */; };
@@ -66,6 +69,12 @@
 		3DBE7F911C2AD77A00FAFA05 /* VOKCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionViewCell.m; sourceTree = "<group>"; };
 		3DBE7F921C2AD77A00FAFA05 /* VOKCollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = VOKCollectionViewCell.xib; sourceTree = "<group>"; };
 		4F92780151AFBE02160324DF /* Pods-VOKCoreDataManager Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VOKCoreDataManager Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VOKCoreDataManager Tests/Pods-VOKCoreDataManager Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		71041E481C5A9328003B4809 /* VOKEntityB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VOKEntityB.h; sourceTree = "<group>"; };
+		71041E491C5A9328003B4809 /* VOKEntityB.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VOKEntityB.m; sourceTree = "<group>"; };
+		71041E4C1C5A9328003B4809 /* VOKEntityC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VOKEntityC.h; sourceTree = "<group>"; };
+		71041E4D1C5A9328003B4809 /* VOKEntityC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VOKEntityC.m; sourceTree = "<group>"; };
+		71041E501C5A9328003B4809 /* VOKEntityA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VOKEntityA.h; sourceTree = "<group>"; };
+		71041E511C5A9328003B4809 /* VOKEntityA.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VOKEntityA.m; sourceTree = "<group>"; };
 		7172B5031B8E82D400589204 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		7172B5041B8E82D400589204 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		7172B5051B8E82D400589204 /* Vokoder.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = Vokoder.podspec; path = ../Vokoder.podspec; sourceTree = "<group>"; };
@@ -206,6 +215,12 @@
 				71E1AAE71A5340A1004311E5 /* VOKPerson.m */,
 				71E1AAE81A5340A1004311E5 /* VOKThing.h */,
 				71E1AAE91A5340A1004311E5 /* VOKThing.m */,
+				71041E501C5A9328003B4809 /* VOKEntityA.h */,
+				71041E511C5A9328003B4809 /* VOKEntityA.m */,
+				71041E481C5A9328003B4809 /* VOKEntityB.h */,
+				71041E491C5A9328003B4809 /* VOKEntityB.m */,
+				71041E4C1C5A9328003B4809 /* VOKEntityC.h */,
+				71041E4D1C5A9328003B4809 /* VOKEntityC.m */,
 			);
 			path = Models;
 			sourceTree = SOURCE_ROOT;
@@ -516,8 +531,11 @@
 				71E1AB031A534221004311E5 /* VOKAppDelegate.m in Sources */,
 				3DBE7F8C1C2AD6EF00FAFA05 /* UIViewController+VOKConvenience.m in Sources */,
 				718462C21B9505D000015274 /* VOKMappablePerson.m in Sources */,
+				71041E531C5A9328003B4809 /* VOKEntityB.m in Sources */,
 				71E1AAF31A5340CE004311E5 /* main.m in Sources */,
 				71E1AAEB1A5340A1004311E5 /* VOKPerson.m in Sources */,
+				71041E571C5A9328003B4809 /* VOKEntityA.m in Sources */,
+				71041E551C5A9328003B4809 /* VOKEntityC.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleProject/VOKCoreDataManagerTests/VOKManagedObjectAdditions.m
+++ b/SampleProject/VOKCoreDataManagerTests/VOKManagedObjectAdditions.m
@@ -13,8 +13,16 @@
 #import <NSManagedObject+VOKManagedObjectAdditions.h>
 #import "VOKThing.h"
 
+#import "VOKEntityA.h"
+#import "VOKEntityB.h"
+#import "VOKEntityC.h"
+
 static const NSUInteger BasicTestDataStartPoint = 0;
 static const NSUInteger BasicTestDataSize = 5;
+
+@interface VOKManagedObjectForTestGettingEntityName : NSManagedObject @end
+
+@implementation VOKManagedObjectForTestGettingEntityName @end
 
 @interface VOKManagedObjectAdditionTests : XCTestCase
 
@@ -222,6 +230,19 @@ static const NSUInteger BasicTestDataSize = 5;
     
     XCTAssertEqual([results.firstObject numberOfHats].intValue, BasicTestDataStartPoint + BasicTestDataSize-1);
     XCTAssertEqual([results.lastObject numberOfHats].intValue, BasicTestDataStartPoint);
+}
+
+#pragma mark - Test getting entity name
+
+- (void)testGettingEntityName
+{
+    XCTAssertEqualObjects([VOKEntityA vok_entityName], @"EntityA");
+    XCTAssertEqualObjects([VOKEntityB vok_entityName], @"EntityB");
+    XCTAssertEqualObjects([VOKEntityC vok_entityName], @"EntityC");
+    XCTAssertEqualObjects([VOKThing vok_entityName], @"VOKThing");
+    XCTAssertThrows([NSManagedObject vok_entityName]);
+    XCTAssertThrows([VOKManagedObjectForTestGettingEntityName vok_entityName]);
+    XCTAssertThrows([[NSString class] vok_entityName]);
 }
 
 @end

--- a/SampleProject/ViewControllers/UIViewController+VOKConvenience.m
+++ b/SampleProject/ViewControllers/UIViewController+VOKConvenience.m
@@ -11,7 +11,8 @@
 
 @implementation UIViewController (VOKConvenience)
 
-- (void)layoutNavBarButtons {
+- (void)layoutNavBarButtons
+{
     UIBarButtonItem *reloadButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh
                                                                                   target:self
                                                                                   action:@selector(reloadData)];
@@ -41,11 +42,13 @@
     [[VOKCoreDataManager sharedInstance] setObjectMapper:mapper forClass:[VOKPerson class]];
 }
 
-- (Class)demoClassToLoad {
+- (Class)demoClassToLoad
+{
     return VOKPerson.class;
 }
 
-- (NSArray *)sortDescriptors {
+- (NSArray *)sortDescriptors
+{
     return @[
              [NSSortDescriptor sortDescriptorWithKey:VOK_CDSELECTOR(numberOfCats) ascending:NO],
              [NSSortDescriptor sortDescriptorWithKey:VOK_CDSELECTOR(lastName) ascending:YES],

--- a/SampleProject/ViewControllers/VOKCollectionViewController.m
+++ b/SampleProject/ViewControllers/VOKCollectionViewController.m
@@ -19,7 +19,8 @@
 
 static NSString *resuseIdentifier;
 
-- (instancetype)init {
+- (instancetype)init
+{
     UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
     layout.itemSize = CGSizeMake(150.0, 50.0);
     return [self initWithCollectionViewLayout:layout];

--- a/SwiftSampleProject/Podfile.lock
+++ b/SwiftSampleProject/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (2.1.0):
+  - Vokoder/Core (2.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (2.1.0):
+  - Vokoder/DataSources (2.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.1.0)
-    - Vokoder/DataSources/FetchedResults (= 2.1.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.1.0)
-  - Vokoder/DataSources/Collection (2.1.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.1.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.1.0):
+    - Vokoder/DataSources/Collection (= 2.1.2)
+    - Vokoder/DataSources/FetchedResults (= 2.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.1.2)
+  - Vokoder/DataSources/Collection (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (2.1.0):
+  - Vokoder/DataSources/FetchedResults (2.1.2):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (2.1.2):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/Swift (2.1.2):
     - Vokoder/DataSources
 
 DEPENDENCIES:
@@ -23,10 +23,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Vokoder:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: a994ccd51213e5d54df5e21b42c9e36be19e1313
+  Vokoder: 3a78a4bdf2a224502e2d83f07bbf2361257d07aa
 
 COCOAPODS: 0.39.0

--- a/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "2.1.0"
+    "tag": "2.1.2"
   },
   "platforms": {
     "ios": "7.0"

--- a/SwiftSampleProject/Pods/Manifest.lock
+++ b/SwiftSampleProject/Pods/Manifest.lock
@@ -1,21 +1,21 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (2.1.0):
+  - Vokoder/Core (2.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
-  - Vokoder/DataSources (2.1.0):
+  - Vokoder/DataSources (2.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.1.0)
-    - Vokoder/DataSources/FetchedResults (= 2.1.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.1.0)
-  - Vokoder/DataSources/Collection (2.1.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.1.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.1.0):
+    - Vokoder/DataSources/Collection (= 2.1.2)
+    - Vokoder/DataSources/FetchedResults (= 2.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.1.2)
+  - Vokoder/DataSources/Collection (2.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (2.1.0):
+  - Vokoder/DataSources/FetchedResults (2.1.2):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (2.1.2):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/Swift (2.1.2):
     - Vokoder/DataSources
 
 DEPENDENCIES:
@@ -23,10 +23,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Vokoder:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: a994ccd51213e5d54df5e21b42c9e36be19e1313
+  Vokoder: 3a78a4bdf2a224502e2d83f07bbf2361257d07aa
 
 COCOAPODS: 0.39.0

--- a/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '1262345DD3D43FD538BFB2D4'
+               BlueprintIdentifier = 'FB66C37F736F27983E059E96'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Vokoder.framework'>

--- a/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
+++ b/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.1.0</string>
+  <string>2.1.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "2.1.1"
+  s.version          = "2.1.2"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
This brings the fix in 1.4.1 (see #70) into the 2.x line and sets the version to 2.1.2.

I also ran `pod install` in all three sample projects.

@vokal/ios-developers @seanwolter Review please?