### PR TITLE
Slight refactoring and finally using iOS 5 methods

### DIFF
--- a/Pod/Classes/VOKCoreDataManager.h
+++ b/Pod/Classes/VOKCoreDataManager.h
@@ -23,9 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM (NSInteger, VOKMigrationFailureOption) {
     /// No handling of a failed migration, will likely cause app instability and crashing when a migration fails.
     VOKMigrationFailureOptionNone,
-    /// Silently delete and recreate the sqlite database file, data will be erased, but instability and crashing will be avoided
+    /// Silently delete and recreate the database file, data will be erased, but instability and crashing will be avoided
     VOKMigrationFailureOptionWipeRecovery,
-    /// Same as VOKMigrationFailureOptionWipeRecoveryAndAlert, but will also notify the user that data has been erased via UIAlertView.
+    /// Same as VOKMigrationFailureOptionWipeRecoveryAndAlert, but will also notify the user that data has been erased via an on screen alert.
     VOKMigrationFailureOptionWipeRecoveryAndAlert,
 };
 

--- a/Pod/Classes/VOKCoreDataManager.h
+++ b/Pod/Classes/VOKCoreDataManager.h
@@ -48,17 +48,11 @@ typedef void(^VOKObjectIDsReturnBlock)(VOKArrayOfManagedObjectIDs *managedObject
  */
 + (VOKCoreDataManager *)sharedInstance;
 
-/**
- The primary managed object context. Only for use on the main queue.
- @return    The main managed object context.
- */
-- (NSManagedObjectContext *)managedObjectContext;
+///The primary managed object context. Only for use on the main queue.
+@property (nonatomic, strong, readonly) NSManagedObjectContext *managedObjectContext;
 
-/**
- The managed object model, based on the resource and database.
- @return    The managed object model
- */
-- (NSManagedObjectModel *)managedObjectModel;
+/// The managed object model, based on the resource and database.
+@property (nonatomic, strong, readonly) NSManagedObjectModel *managedObjectModel;
 
 /**
  Set the name of the managed object model and the name of the SQL lite store on disk. Call this first when you setup the core data stack.

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -159,7 +159,6 @@ static VOKCoreDataManager *VOK_SharedObject;
             {
                 NSString *title = @"Migration Failed";
                 NSString *message = @"Migration has failed, data will be erased to ensure application stability.";
-#undef __IPHONE_8_0
 #ifdef __IPHONE_8_0 //if compiling with an old version of Xcode that doesn't include the iOS 8 SDK, ignore UIAlertController
                 if ([UIAlertController class]) {
                     UIAlertController *alert = [UIAlertController alertControllerWithTitle:title

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -494,7 +494,7 @@ static VOKCoreDataManager *VOK_SharedObject;
     if ([NSOperationQueue mainQueue] == [NSOperationQueue currentQueue]) {
         [self saveContext:self.managedObjectContext];
     } else {
-        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        [self.managedObjectContext performBlock:^{
             [self saveContext:self.managedObjectContext];
         }];
     }
@@ -505,7 +505,7 @@ static VOKCoreDataManager *VOK_SharedObject;
     if ([NSOperationQueue mainQueue] == [NSOperationQueue currentQueue]) {
         [self saveContext:self.managedObjectContext];
     } else {
-        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        [self.managedObjectContext performBlockAndWait:^{
             [self saveContext:self.managedObjectContext];
         }];
     }

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -159,6 +159,8 @@ static VOKCoreDataManager *VOK_SharedObject;
             {
                 NSString *title = @"Migration Failed";
                 NSString *message = @"Migration has failed, data will be erased to ensure application stability.";
+#undef __IPHONE_8_0
+#ifdef __IPHONE_8_0 //if compiling with an old version of Xcode that doesn't include the iOS 8 SDK, ignore UIAlertController
                 if ([UIAlertController class]) {
                     UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
                                                                                    message:message
@@ -167,6 +169,7 @@ static VOKCoreDataManager *VOK_SharedObject;
                                                                                                  animated:YES
                                                                                                completion:nil];
                 } else {
+#endif
                     //TODO: delete UIAlertView once support is dropped for iOS 7
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -176,7 +179,9 @@ static VOKCoreDataManager *VOK_SharedObject;
                                       cancelButtonTitle:@""
                                       otherButtonTitles:nil] show];
 #pragma clang diagnostic pop
+#ifdef __IPHONE_8_0
                 }
+#endif
             }
                 //intentional fallthrough
             case VOKMigrationFailureOptionWipeRecovery:

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -187,12 +187,12 @@ static VOKCoreDataManager *VOK_SharedObject;
                                                                         URL:storeURL
                                                                     options:options
                                                                       error:&error]) {
-                    [NSException raise:@"Vokoder Persistant Store Creation Failure after migration"
+                    [NSException raise:@"Vokoder Persistent Store Creation Failure after migration"
                                 format:@"Unresolved error %@, %@", error, [error userInfo]];
                 }
                 break;
             case VOKMigrationFailureOptionNone:
-                VOK_CDLog(@"Vokoder Persistant Store Creation Failure: %@", error);
+                VOK_CDLog(@"Vokoder Persistent Store Creation Failure: %@", error);
                 break;
         }
     }

--- a/SampleProject/VOKAppDelegate.m
+++ b/SampleProject/VOKAppDelegate.m
@@ -16,6 +16,10 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    if (NSClassFromString(@"XCTestCase")) {
+        //during unit testing, don't set up Vokoder in the example app
+        return YES;
+    }
     [[VOKCoreDataManager sharedInstance] setResource:@"VOKCoreDataModel" database:@"VOKCoreDataModel.sqlite"];
 
     [[VOKCoreDataManager sharedInstance] resetCoreData];

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "2.1.2"
+  s.version          = "2.2.0"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
- use `UIAlertController` if available and eliminate deprecation warning for `UIAlertView`
- eliminate `NSConfinementConcurrencyType` deprecation by using `NSPrivateQueueConcurrencyType` for temp context
- some slight refactoring to combine some methods
- use `performBlock` for managed object context operations (and eliminate the private writing queue)

@vokal/ios-developers, @seanwolter, code review?