### PR TITLE
Remove unneeded modulemap

### DIFF
--- a/Paging Data Source Example/Podfile.lock
+++ b/Paging Data Source Example/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (2.3.0):
-    - Vokoder/Core (= 2.3.0)
-    - Vokoder/DataSources (= 2.3.0)
-    - Vokoder/MapperMacros (= 2.3.0)
-  - Vokoder/Core (2.3.0):
+  - Vokoder (2.3.1):
+    - Vokoder/Core (= 2.3.1)
+    - Vokoder/DataSources (= 2.3.1)
+    - Vokoder/MapperMacros (= 2.3.1)
+  - Vokoder/Core (2.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.8.0)
-  - Vokoder/DataSources (2.3.0):
+  - Vokoder/DataSources (2.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.3.0)
-    - Vokoder/DataSources/FetchedResults (= 2.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.3.0)
-  - Vokoder/DataSources/Collection (2.3.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.3.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.3.0):
+    - Vokoder/DataSources/Collection (= 2.3.1)
+    - Vokoder/DataSources/FetchedResults (= 2.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.3.1)
+  - Vokoder/DataSources/Collection (2.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (2.3.0):
+  - Vokoder/DataSources/FetchedResults (2.3.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (2.3.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (2.3.1):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.8.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 60241b87c4e69de33c77ef0218a96177d0345757
+  Vokoder: fc60909b0d3410d3abdc1af7ba01f7e9b6f1198e
   VOKUtilities: 7d579a7fa5304c2eec17c49d293b2554d6059eaa
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "2.3.0"
+    "tag": "2.3.1"
   },
   "platforms": {
     "ios": "7.0"
@@ -47,8 +47,7 @@
 
         ]
       },
-      "source_files": "Pod/Classes/MapperMacros/*.{h,m}",
-      "module_map": "Pod/Classes/MapperMacros/module.modulemap"
+      "source_files": "Pod/Classes/MapperMacros/*.{h,m}"
     },
     {
       "name": "DataSources",

--- a/Paging Data Source Example/Pods/Manifest.lock
+++ b/Paging Data Source Example/Pods/Manifest.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (2.3.0):
-    - Vokoder/Core (= 2.3.0)
-    - Vokoder/DataSources (= 2.3.0)
-    - Vokoder/MapperMacros (= 2.3.0)
-  - Vokoder/Core (2.3.0):
+  - Vokoder (2.3.1):
+    - Vokoder/Core (= 2.3.1)
+    - Vokoder/DataSources (= 2.3.1)
+    - Vokoder/MapperMacros (= 2.3.1)
+  - Vokoder/Core (2.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.8.0)
-  - Vokoder/DataSources (2.3.0):
+  - Vokoder/DataSources (2.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.3.0)
-    - Vokoder/DataSources/FetchedResults (= 2.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.3.0)
-  - Vokoder/DataSources/Collection (2.3.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.3.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.3.0):
+    - Vokoder/DataSources/Collection (= 2.3.1)
+    - Vokoder/DataSources/FetchedResults (= 2.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.3.1)
+  - Vokoder/DataSources/Collection (2.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (2.3.0):
+  - Vokoder/DataSources/FetchedResults (2.3.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (2.3.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (2.3.1):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.8.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 60241b87c4e69de33c77ef0218a96177d0345757
+  Vokoder: fc60909b0d3410d3abdc1af7ba01f7e9b6f1198e
   VOKUtilities: 7d579a7fa5304c2eec17c49d293b2554d6059eaa
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '404B565FCF293BB15E9CD1AF'
+               BlueprintIdentifier = 'B7B9DAE52540BC49D17B2A06'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libVokoder.a'>

--- a/Pod/Classes/MapperMacros/module.modulemap
+++ b/Pod/Classes/MapperMacros/module.modulemap
@@ -1,6 +1,0 @@
-framework module Vokoder {
-  header "../../../VOKUtilities/VOKKeyPathHelper.h"
-
-  export *
-  module * { export * }
-}

--- a/SampleProject/Podfile.lock
+++ b/SampleProject/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (2.3.0):
-    - Vokoder/Core (= 2.3.0)
-    - Vokoder/DataSources (= 2.3.0)
-    - Vokoder/MapperMacros (= 2.3.0)
-  - Vokoder/Core (2.3.0):
+  - Vokoder (2.3.1):
+    - Vokoder/Core (= 2.3.1)
+    - Vokoder/DataSources (= 2.3.1)
+    - Vokoder/MapperMacros (= 2.3.1)
+  - Vokoder/Core (2.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.8.0)
-  - Vokoder/DataSources (2.3.0):
+  - Vokoder/DataSources (2.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.3.0)
-    - Vokoder/DataSources/FetchedResults (= 2.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.3.0)
-  - Vokoder/DataSources/Collection (2.3.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.3.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.3.0):
+    - Vokoder/DataSources/Collection (= 2.3.1)
+    - Vokoder/DataSources/FetchedResults (= 2.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.3.1)
+  - Vokoder/DataSources/Collection (2.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (2.3.0):
+  - Vokoder/DataSources/FetchedResults (2.3.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (2.3.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (2.3.1):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.8.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 60241b87c4e69de33c77ef0218a96177d0345757
+  Vokoder: fc60909b0d3410d3abdc1af7ba01f7e9b6f1198e
   VOKUtilities: 7d579a7fa5304c2eec17c49d293b2554d6059eaa
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "2.3.0"
+    "tag": "2.3.1"
   },
   "platforms": {
     "ios": "7.0"
@@ -47,8 +47,7 @@
 
         ]
       },
-      "source_files": "Pod/Classes/MapperMacros/*.{h,m}",
-      "module_map": "Pod/Classes/MapperMacros/module.modulemap"
+      "source_files": "Pod/Classes/MapperMacros/*.{h,m}"
     },
     {
       "name": "DataSources",

--- a/SampleProject/Pods/Manifest.lock
+++ b/SampleProject/Pods/Manifest.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (2.3.0):
-    - Vokoder/Core (= 2.3.0)
-    - Vokoder/DataSources (= 2.3.0)
-    - Vokoder/MapperMacros (= 2.3.0)
-  - Vokoder/Core (2.3.0):
+  - Vokoder (2.3.1):
+    - Vokoder/Core (= 2.3.1)
+    - Vokoder/DataSources (= 2.3.1)
+    - Vokoder/MapperMacros (= 2.3.1)
+  - Vokoder/Core (2.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.8.0)
-  - Vokoder/DataSources (2.3.0):
+  - Vokoder/DataSources (2.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.3.0)
-    - Vokoder/DataSources/FetchedResults (= 2.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.3.0)
-  - Vokoder/DataSources/Collection (2.3.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.3.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.3.0):
+    - Vokoder/DataSources/Collection (= 2.3.1)
+    - Vokoder/DataSources/FetchedResults (= 2.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.3.1)
+  - Vokoder/DataSources/Collection (2.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (2.3.0):
+  - Vokoder/DataSources/FetchedResults (2.3.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (2.3.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (2.3.1):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.8.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 60241b87c4e69de33c77ef0218a96177d0345757
+  Vokoder: fc60909b0d3410d3abdc1af7ba01f7e9b6f1198e
   VOKUtilities: 7d579a7fa5304c2eec17c49d293b2554d6059eaa
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '73DBB81B628D40691EC45DD5'
+               BlueprintIdentifier = '6570FD080F181393FFBC505B'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libVokoder.a'>

--- a/SwiftSampleProject/Podfile.lock
+++ b/SwiftSampleProject/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (2.3.0):
+  - Vokoder/Core (2.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.8.0)
-  - Vokoder/DataSources (2.3.0):
+  - Vokoder/DataSources (2.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.3.0)
-    - Vokoder/DataSources/FetchedResults (= 2.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.3.0)
-  - Vokoder/DataSources/Collection (2.3.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.3.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.3.0):
+    - Vokoder/DataSources/Collection (= 2.3.1)
+    - Vokoder/DataSources/FetchedResults (= 2.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.3.1)
+  - Vokoder/DataSources/Collection (2.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (2.3.0):
+  - Vokoder/DataSources/FetchedResults (2.3.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (2.3.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/Swift (2.3.1):
     - Vokoder/DataSources
   - VOKUtilities/VOKKeyPathHelper (0.8.0)
   - xUnique (4.1.2)
@@ -39,7 +39,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 60241b87c4e69de33c77ef0218a96177d0345757
+  Vokoder: fc60909b0d3410d3abdc1af7ba01f7e9b6f1198e
   VOKUtilities: 7d579a7fa5304c2eec17c49d293b2554d6059eaa
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "2.3.0"
+    "tag": "2.3.1"
   },
   "platforms": {
     "ios": "7.0"
@@ -47,8 +47,7 @@
 
         ]
       },
-      "source_files": "Pod/Classes/MapperMacros/*.{h,m}",
-      "module_map": "Pod/Classes/MapperMacros/module.modulemap"
+      "source_files": "Pod/Classes/MapperMacros/*.{h,m}"
     },
     {
       "name": "DataSources",

--- a/SwiftSampleProject/Pods/Manifest.lock
+++ b/SwiftSampleProject/Pods/Manifest.lock
@@ -1,22 +1,22 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (2.3.0):
+  - Vokoder/Core (2.3.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.8.0)
-  - Vokoder/DataSources (2.3.0):
+  - Vokoder/DataSources (2.3.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 2.3.0)
-    - Vokoder/DataSources/FetchedResults (= 2.3.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 2.3.0)
-  - Vokoder/DataSources/Collection (2.3.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (2.3.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (2.3.0):
+    - Vokoder/DataSources/Collection (= 2.3.1)
+    - Vokoder/DataSources/FetchedResults (= 2.3.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 2.3.1)
+  - Vokoder/DataSources/Collection (2.3.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (2.3.0):
+  - Vokoder/DataSources/FetchedResults (2.3.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (2.3.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/Swift (2.3.1):
     - Vokoder/DataSources
   - VOKUtilities/VOKKeyPathHelper (0.8.0)
   - xUnique (4.1.2)
@@ -39,7 +39,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 60241b87c4e69de33c77ef0218a96177d0345757
+  Vokoder: fc60909b0d3410d3abdc1af7ba01f7e9b6f1198e
   VOKUtilities: 7d579a7fa5304c2eec17c49d293b2554d6059eaa
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'FA7A6FD2F7ED554D92320724'
+               BlueprintIdentifier = '38E6BF16090740328A1E3CF8'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Vokoder.framework'>

--- a/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
+++ b/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.3.0</string>
+  <string>2.3.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "2.3.0"
+  s.version          = "2.3.1"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}
@@ -25,7 +25,6 @@ Pod::Spec.new do |s|
   s.subspec 'MapperMacros' do |mm|
     mm.dependency 'Vokoder/Core'
     mm.source_files = 'Pod/Classes/MapperMacros/*.{h,m}'
-    mm.module_map = 'Pod/Classes/MapperMacros/module.modulemap'
   end
 
   s.subspec 'DataSources' do |ss|


### PR DESCRIPTION
Adding a module map to a subspec is invalid with CocoaPods.  Turns out that the module map wasn't needed at all though, so I removed it.

@vokal/ios-developers, @seanwolter, review?