### PR TITLE
Remove default_subspecs on subspec

### DIFF
--- a/Paging Data Source Example/Podfile.lock
+++ b/Paging Data Source Example/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (3.1.1):
-    - Vokoder/Core (= 3.1.1)
-    - Vokoder/DataSources (= 3.1.1)
-    - Vokoder/MapperMacros (= 3.1.1)
-  - Vokoder/Core (3.1.1):
+  - Vokoder (3.1.2):
+    - Vokoder/Core (= 3.1.2)
+    - Vokoder/DataSources (= 3.1.2)
+    - Vokoder/MapperMacros (= 3.1.2)
+  - Vokoder/Core (3.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.1):
+  - Vokoder/DataSources (3.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.1)
-    - Vokoder/DataSources/FetchedResults (= 3.1.1)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.1)
-  - Vokoder/DataSources/Collection (3.1.1):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.1):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.1):
+    - Vokoder/DataSources/Collection (= 3.1.2)
+    - Vokoder/DataSources/FetchedResults (= 3.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
+  - Vokoder/DataSources/Collection (3.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (3.1.1):
+  - Vokoder/DataSources/FetchedResults (3.1.2):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (3.1.2):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 85a7a1b2691270f7a4d2480dd6327c24a0cdc225
+  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "3.1.1"
+    "tag": "3.1.2"
   },
   "platforms": {
     "ios": "7.0",
@@ -62,11 +62,6 @@
         "ios": "7.0",
         "tvos": "9.0"
       },
-      "default_subspecs": [
-        "FetchedResults",
-        "PagingFetchedResults",
-        "Collection"
-      ],
       "subspecs": [
         {
           "name": "FetchedResults",

--- a/Paging Data Source Example/Pods/Manifest.lock
+++ b/Paging Data Source Example/Pods/Manifest.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (3.1.1):
-    - Vokoder/Core (= 3.1.1)
-    - Vokoder/DataSources (= 3.1.1)
-    - Vokoder/MapperMacros (= 3.1.1)
-  - Vokoder/Core (3.1.1):
+  - Vokoder (3.1.2):
+    - Vokoder/Core (= 3.1.2)
+    - Vokoder/DataSources (= 3.1.2)
+    - Vokoder/MapperMacros (= 3.1.2)
+  - Vokoder/Core (3.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.1):
+  - Vokoder/DataSources (3.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.1)
-    - Vokoder/DataSources/FetchedResults (= 3.1.1)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.1)
-  - Vokoder/DataSources/Collection (3.1.1):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.1):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.1):
+    - Vokoder/DataSources/Collection (= 3.1.2)
+    - Vokoder/DataSources/FetchedResults (= 3.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
+  - Vokoder/DataSources/Collection (3.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (3.1.1):
+  - Vokoder/DataSources/FetchedResults (3.1.2):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (3.1.2):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 85a7a1b2691270f7a4d2480dd6327c24a0cdc225
+  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '5311EFCAC5A64B6567C9D048'
+               BlueprintIdentifier = '22F09032DC8E80619E8069D6'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libVokoder.a'>

--- a/SampleProject/Podfile.lock
+++ b/SampleProject/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (3.1.1):
-    - Vokoder/Core (= 3.1.1)
-    - Vokoder/DataSources (= 3.1.1)
-    - Vokoder/MapperMacros (= 3.1.1)
-  - Vokoder/Core (3.1.1):
+  - Vokoder (3.1.2):
+    - Vokoder/Core (= 3.1.2)
+    - Vokoder/DataSources (= 3.1.2)
+    - Vokoder/MapperMacros (= 3.1.2)
+  - Vokoder/Core (3.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.1):
+  - Vokoder/DataSources (3.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.1)
-    - Vokoder/DataSources/FetchedResults (= 3.1.1)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.1)
-  - Vokoder/DataSources/Collection (3.1.1):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.1):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.1):
+    - Vokoder/DataSources/Collection (= 3.1.2)
+    - Vokoder/DataSources/FetchedResults (= 3.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
+  - Vokoder/DataSources/Collection (3.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (3.1.1):
+  - Vokoder/DataSources/FetchedResults (3.1.2):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (3.1.2):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 85a7a1b2691270f7a4d2480dd6327c24a0cdc225
+  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "3.1.1"
+    "tag": "3.1.2"
   },
   "platforms": {
     "ios": "7.0",
@@ -62,11 +62,6 @@
         "ios": "7.0",
         "tvos": "9.0"
       },
-      "default_subspecs": [
-        "FetchedResults",
-        "PagingFetchedResults",
-        "Collection"
-      ],
       "subspecs": [
         {
           "name": "FetchedResults",

--- a/SampleProject/Pods/Manifest.lock
+++ b/SampleProject/Pods/Manifest.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (3.1.1):
-    - Vokoder/Core (= 3.1.1)
-    - Vokoder/DataSources (= 3.1.1)
-    - Vokoder/MapperMacros (= 3.1.1)
-  - Vokoder/Core (3.1.1):
+  - Vokoder (3.1.2):
+    - Vokoder/Core (= 3.1.2)
+    - Vokoder/DataSources (= 3.1.2)
+    - Vokoder/MapperMacros (= 3.1.2)
+  - Vokoder/Core (3.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.1):
+  - Vokoder/DataSources (3.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.1)
-    - Vokoder/DataSources/FetchedResults (= 3.1.1)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.1)
-  - Vokoder/DataSources/Collection (3.1.1):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.1):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.1):
+    - Vokoder/DataSources/Collection (= 3.1.2)
+    - Vokoder/DataSources/FetchedResults (= 3.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
+  - Vokoder/DataSources/Collection (3.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (3.1.1):
+  - Vokoder/DataSources/FetchedResults (3.1.2):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (3.1.2):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 85a7a1b2691270f7a4d2480dd6327c24a0cdc225
+  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager Tests-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager Tests-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'BEC0963D7CF7E1643170E577'
+               BlueprintIdentifier = '7F792792D67C6C4EB38EC2B9'
                BlueprintName = 'Pods-VOKCoreDataManager Tests-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager Tests-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-OSX-VOKCoreDataManagerTests-OSX-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-OSX-VOKCoreDataManagerTests-OSX-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'D007224A388962FA4BA28CBE'
+               BlueprintIdentifier = '6157FC2D090CEED534DD4A90'
                BlueprintName = 'Pods-VOKCoreDataManager-OSX-VOKCoreDataManagerTests-OSX-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-OSX-VOKCoreDataManagerTests-OSX-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-OSX-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-OSX-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'F23BBCD02BB217DB58D01E88'
+               BlueprintIdentifier = 'BA65A820C16A9F807649C526'
                BlueprintName = 'Pods-VOKCoreDataManager-OSX-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-OSX-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'C51319E3B3492768464086A4'
+               BlueprintIdentifier = '0CC48578A69CC11C36EFFFC3'
                BlueprintName = 'Pods-VOKCoreDataManager-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-tvOS-VOKCoreDataManagerTests-tvOS-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-tvOS-VOKCoreDataManagerTests-tvOS-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'BB81EC0C5B24AD55EB3A207A'
+               BlueprintIdentifier = '862A345236FCF5C6D2356577'
                BlueprintName = 'Pods-VOKCoreDataManager-tvOS-VOKCoreDataManagerTests-tvOS-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-tvOS-VOKCoreDataManagerTests-tvOS-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-tvOS-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-tvOS-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '9E2551F58C7F9FB068CEA846'
+               BlueprintIdentifier = 'E286C12154F8ED73C69268C0'
                BlueprintName = 'Pods-VOKCoreDataManager-tvOS-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-tvOS-Vokoder.a'>

--- a/SwiftSampleProject/Podfile.lock
+++ b/SwiftSampleProject/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (3.1.1):
+  - Vokoder/Core (3.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.1):
+  - Vokoder/DataSources (3.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.1)
-    - Vokoder/DataSources/FetchedResults (= 3.1.1)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.1)
-  - Vokoder/DataSources/Collection (3.1.1):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.1):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.1):
+    - Vokoder/DataSources/Collection (= 3.1.2)
+    - Vokoder/DataSources/FetchedResults (= 3.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
+  - Vokoder/DataSources/Collection (3.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (3.1.1):
+  - Vokoder/DataSources/FetchedResults (3.1.2):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/Swift (3.1.2):
     - Vokoder/DataSources
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -39,7 +39,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 85a7a1b2691270f7a4d2480dd6327c24a0cdc225
+  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "3.1.1"
+    "tag": "3.1.2"
   },
   "platforms": {
     "ios": "7.0",
@@ -62,11 +62,6 @@
         "ios": "7.0",
         "tvos": "9.0"
       },
-      "default_subspecs": [
-        "FetchedResults",
-        "PagingFetchedResults",
-        "Collection"
-      ],
       "subspecs": [
         {
           "name": "FetchedResults",

--- a/SwiftSampleProject/Pods/Manifest.lock
+++ b/SwiftSampleProject/Pods/Manifest.lock
@@ -1,22 +1,22 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (3.1.1):
+  - Vokoder/Core (3.1.2):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.1):
+  - Vokoder/DataSources (3.1.2):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.1)
-    - Vokoder/DataSources/FetchedResults (= 3.1.1)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.1)
-  - Vokoder/DataSources/Collection (3.1.1):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.1):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.1):
+    - Vokoder/DataSources/Collection (= 3.1.2)
+    - Vokoder/DataSources/FetchedResults (= 3.1.2)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
+  - Vokoder/DataSources/Collection (3.1.2):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (3.1.1):
+  - Vokoder/DataSources/FetchedResults (3.1.2):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/Swift (3.1.2):
     - Vokoder/DataSources
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -39,7 +39,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 85a7a1b2691270f7a4d2480dd6327c24a0cdc225
+  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'B18FDF20285E9131BF11543B'
+               BlueprintIdentifier = '33E79FE2A6F2900117A550F1'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Vokoder.framework'>

--- a/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
+++ b/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.1.1</string>
+  <string>3.1.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "3.1.1"
+  s.version          = "3.1.2"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}
@@ -33,8 +33,6 @@ Pod::Spec.new do |s|
     ss.dependency 'Vokoder/Core'
     ss.ios.deployment_target = '7.0'
     ss.tvos.deployment_target = '9.0'
-
-    ss.default_subspecs = 'FetchedResults', 'PagingFetchedResults', 'Collection'
 
     ss.subspec 'FetchedResults' do |sss|
       sss.source_files = 'Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.{h,m}'


### PR DESCRIPTION
See https://github.com/CocoaPods/CocoaPods/issues/5228 for context. We can no longer include `default_subspecs` on a subspec, but the good news is, we don't need to. I tested that just adding `Vokoder/DataSources` as a pod will indeed include all the subspecs, which is what it was doing explicitly before anyway.

Most of the changes in here are just updates to the sample projects with the changed podspec.

@vokal/ios-developers can I get a review?