### PR TITLE
Allow no results in vok_fetchForPredicate:forManagedObjectContext:

### DIFF
--- a/Paging Data Source Example/Podfile.lock
+++ b/Paging Data Source Example/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (3.1.2):
-    - Vokoder/Core (= 3.1.2)
-    - Vokoder/DataSources (= 3.1.2)
-    - Vokoder/MapperMacros (= 3.1.2)
-  - Vokoder/Core (3.1.2):
+  - Vokoder (3.1.3):
+    - Vokoder/Core (= 3.1.3)
+    - Vokoder/DataSources (= 3.1.3)
+    - Vokoder/MapperMacros (= 3.1.3)
+  - Vokoder/Core (3.1.3):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.2):
+  - Vokoder/DataSources (3.1.3):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.2)
-    - Vokoder/DataSources/FetchedResults (= 3.1.2)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
-  - Vokoder/DataSources/Collection (3.1.2):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.2):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/DataSources/Collection (= 3.1.3)
+    - Vokoder/DataSources/FetchedResults (= 3.1.3)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.3)
+  - Vokoder/DataSources/Collection (3.1.3):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (3.1.2):
+  - Vokoder/DataSources/FetchedResults (3.1.3):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.3):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (3.1.3):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
+  Vokoder: ea7a319d969e187e8678d7768ce3f9bad66f640f
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "3.1.2"
+    "tag": "3.1.3"
   },
   "platforms": {
     "ios": "7.0",

--- a/Paging Data Source Example/Pods/Manifest.lock
+++ b/Paging Data Source Example/Pods/Manifest.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (3.1.2):
-    - Vokoder/Core (= 3.1.2)
-    - Vokoder/DataSources (= 3.1.2)
-    - Vokoder/MapperMacros (= 3.1.2)
-  - Vokoder/Core (3.1.2):
+  - Vokoder (3.1.3):
+    - Vokoder/Core (= 3.1.3)
+    - Vokoder/DataSources (= 3.1.3)
+    - Vokoder/MapperMacros (= 3.1.3)
+  - Vokoder/Core (3.1.3):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.2):
+  - Vokoder/DataSources (3.1.3):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.2)
-    - Vokoder/DataSources/FetchedResults (= 3.1.2)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
-  - Vokoder/DataSources/Collection (3.1.2):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.2):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/DataSources/Collection (= 3.1.3)
+    - Vokoder/DataSources/FetchedResults (= 3.1.3)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.3)
+  - Vokoder/DataSources/Collection (3.1.3):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (3.1.2):
+  - Vokoder/DataSources/FetchedResults (3.1.3):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.3):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (3.1.3):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
+  Vokoder: ea7a319d969e187e8678d7768ce3f9bad66f640f
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '22F09032DC8E80619E8069D6'
+               BlueprintIdentifier = 'FC4805A7F1007CD121C13C65'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libVokoder.a'>

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
@@ -184,7 +184,7 @@
 {
     NSArray *results = [self vok_fetchAllForPredicate:predicate forManagedObjectContext:contextOrNil];
 
-    NSAssert(results.count == 1, @"Your predicate is returning more than 1 object, but the coredatamanager returns only one.");
+    NSAssert(results.count <= 1, @"Your predicate is returning more than 1 object, but the coredatamanager returns only one.");
     return results.lastObject;
 }
 

--- a/SampleProject/Podfile.lock
+++ b/SampleProject/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (3.1.2):
-    - Vokoder/Core (= 3.1.2)
-    - Vokoder/DataSources (= 3.1.2)
-    - Vokoder/MapperMacros (= 3.1.2)
-  - Vokoder/Core (3.1.2):
+  - Vokoder (3.1.3):
+    - Vokoder/Core (= 3.1.3)
+    - Vokoder/DataSources (= 3.1.3)
+    - Vokoder/MapperMacros (= 3.1.3)
+  - Vokoder/Core (3.1.3):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.2):
+  - Vokoder/DataSources (3.1.3):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.2)
-    - Vokoder/DataSources/FetchedResults (= 3.1.2)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
-  - Vokoder/DataSources/Collection (3.1.2):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.2):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/DataSources/Collection (= 3.1.3)
+    - Vokoder/DataSources/FetchedResults (= 3.1.3)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.3)
+  - Vokoder/DataSources/Collection (3.1.3):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (3.1.2):
+  - Vokoder/DataSources/FetchedResults (3.1.3):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.3):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (3.1.3):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
+  Vokoder: ea7a319d969e187e8678d7768ce3f9bad66f640f
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "3.1.2"
+    "tag": "3.1.3"
   },
   "platforms": {
     "ios": "7.0",

--- a/SampleProject/Pods/Manifest.lock
+++ b/SampleProject/Pods/Manifest.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (3.1.2):
-    - Vokoder/Core (= 3.1.2)
-    - Vokoder/DataSources (= 3.1.2)
-    - Vokoder/MapperMacros (= 3.1.2)
-  - Vokoder/Core (3.1.2):
+  - Vokoder (3.1.3):
+    - Vokoder/Core (= 3.1.3)
+    - Vokoder/DataSources (= 3.1.3)
+    - Vokoder/MapperMacros (= 3.1.3)
+  - Vokoder/Core (3.1.3):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.2):
+  - Vokoder/DataSources (3.1.3):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.2)
-    - Vokoder/DataSources/FetchedResults (= 3.1.2)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
-  - Vokoder/DataSources/Collection (3.1.2):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.2):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/DataSources/Collection (= 3.1.3)
+    - Vokoder/DataSources/FetchedResults (= 3.1.3)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.3)
+  - Vokoder/DataSources/Collection (3.1.3):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (3.1.2):
+  - Vokoder/DataSources/FetchedResults (3.1.3):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.3):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (3.1.3):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
+  Vokoder: ea7a319d969e187e8678d7768ce3f9bad66f640f
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager Tests-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager Tests-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '7F792792D67C6C4EB38EC2B9'
+               BlueprintIdentifier = '503C77E0916EF3982F7A924C'
                BlueprintName = 'Pods-VOKCoreDataManager Tests-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager Tests-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-OSX-VOKCoreDataManagerTests-OSX-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-OSX-VOKCoreDataManagerTests-OSX-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '6157FC2D090CEED534DD4A90'
+               BlueprintIdentifier = '4B7313E6A17F5CFB2FB08086'
                BlueprintName = 'Pods-VOKCoreDataManager-OSX-VOKCoreDataManagerTests-OSX-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-OSX-VOKCoreDataManagerTests-OSX-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-OSX-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-OSX-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'BA65A820C16A9F807649C526'
+               BlueprintIdentifier = '92AF1CF910D80C9E409BEA91'
                BlueprintName = 'Pods-VOKCoreDataManager-OSX-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-OSX-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '0CC48578A69CC11C36EFFFC3'
+               BlueprintIdentifier = 'E0585BBCD4795BC7563F9ED8'
                BlueprintName = 'Pods-VOKCoreDataManager-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-tvOS-VOKCoreDataManagerTests-tvOS-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-tvOS-VOKCoreDataManagerTests-tvOS-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '862A345236FCF5C6D2356577'
+               BlueprintIdentifier = '663D2400AA287DFF3D8BDD70'
                BlueprintName = 'Pods-VOKCoreDataManager-tvOS-VOKCoreDataManagerTests-tvOS-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-tvOS-VOKCoreDataManagerTests-tvOS-Vokoder.a'>

--- a/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-tvOS-Vokoder.xcscheme
+++ b/SampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-VOKCoreDataManager-tvOS-Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'E286C12154F8ED73C69268C0'
+               BlueprintIdentifier = '7E9A2ED995CD23B742D7A6C2'
                BlueprintName = 'Pods-VOKCoreDataManager-tvOS-Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libPods-VOKCoreDataManager-tvOS-Vokoder.a'>

--- a/SwiftSampleProject/Podfile.lock
+++ b/SwiftSampleProject/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (3.1.2):
+  - Vokoder/Core (3.1.3):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.2):
+  - Vokoder/DataSources (3.1.3):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.2)
-    - Vokoder/DataSources/FetchedResults (= 3.1.2)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
-  - Vokoder/DataSources/Collection (3.1.2):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.2):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/DataSources/Collection (= 3.1.3)
+    - Vokoder/DataSources/FetchedResults (= 3.1.3)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.3)
+  - Vokoder/DataSources/Collection (3.1.3):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (3.1.2):
+  - Vokoder/DataSources/FetchedResults (3.1.3):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.3):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/Swift (3.1.3):
     - Vokoder/DataSources
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -39,7 +39,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
+  Vokoder: ea7a319d969e187e8678d7768ce3f9bad66f640f
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "3.1.2"
+    "tag": "3.1.3"
   },
   "platforms": {
     "ios": "7.0",

--- a/SwiftSampleProject/Pods/Manifest.lock
+++ b/SwiftSampleProject/Pods/Manifest.lock
@@ -1,22 +1,22 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (3.1.2):
+  - Vokoder/Core (3.1.3):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.9.0)
-  - Vokoder/DataSources (3.1.2):
+  - Vokoder/DataSources (3.1.3):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 3.1.2)
-    - Vokoder/DataSources/FetchedResults (= 3.1.2)
-    - Vokoder/DataSources/PagingFetchedResults (= 3.1.2)
-  - Vokoder/DataSources/Collection (3.1.2):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (3.1.2):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (3.1.2):
+    - Vokoder/DataSources/Collection (= 3.1.3)
+    - Vokoder/DataSources/FetchedResults (= 3.1.3)
+    - Vokoder/DataSources/PagingFetchedResults (= 3.1.3)
+  - Vokoder/DataSources/Collection (3.1.3):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (3.1.2):
+  - Vokoder/DataSources/FetchedResults (3.1.3):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (3.1.3):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/Swift (3.1.3):
     - Vokoder/DataSources
   - VOKUtilities/VOKKeyPathHelper (0.9.0)
   - xUnique (4.1.2)
@@ -39,7 +39,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: cc8e9e9aa506a89d0f168a4469ffbdee83c23a8d
+  Vokoder: ea7a319d969e187e8678d7768ce3f9bad66f640f
   VOKUtilities: 460869a30db1beed7ec9954895dff24705db6e06
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
+++ b/SwiftSampleProject/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Vokoder.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '33E79FE2A6F2900117A550F1'
+               BlueprintIdentifier = '88DB83702CE83C8F93700D7F'
                BlueprintName = 'Vokoder'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Vokoder.framework'>

--- a/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
+++ b/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.1.2</string>
+  <string>3.1.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "3.1.2"
+  s.version          = "3.1.3"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
This fixes the assertion in `vok_fetchForPredicate:forManagedObjectContext:` to allow an empty result set, and adds tests around it. This regression was introduced in da3bf047da6b180fa265232c9bceb1c2248b4db4.

Most of this diff is just updating the local pod in the sample projects. The only real changes are in these two files:
- Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
- SampleProject/VOKCoreDataManagerTests/VOKManagedObjectAdditions.m

@vokal/ios-developers code review please?