### PR TITLE
Allow unshared instances of the manager

### DIFF
--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.h
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.h
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// A completion block after an asynchronous operation on a temporary context. NSManagedObject's are not threadsafe.
 typedef void(^VOKManagedObjectsReturnBlock)(VOKArrayOfManagedObjects *managedObjects);
 
+/**
+ This category adds conveniece methods to NSManagedObject.  These methods call the underlying methods on VOKCoreDataManager.sharedInstance.
+ */
 @interface NSManagedObject (VOKManagedObjectAdditions)
 
 /**

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
@@ -34,48 +34,7 @@
 
 + (NSString *)vok_entityName
 {
-    static char AssociatedObjectKey;  // The key for the runtime-association.
-    
-    // Get the associated value.
-    NSString *vok_entityName = objc_getAssociatedObject(self, &AssociatedObjectKey);
-    
-    // If we didn't find an associated entity name, determine the entity name.
-    if (!vok_entityName) {
-        // If we already have an entityName class method (e.g., MOGenerator-generated subclasses), use it.
-        // (Note that we have to cast self (a Class) to id to use NSObject's dynamic-selector methods, even though they work.)
-        if ([(id)self respondsToSelector:@selector(entityName)]) {
-            vok_entityName = [(id)self performSelector:@selector(entityName)];
-        }
-        if (!vok_entityName) {
-            // On OS X, NSObject has a private class method called entityName but it may return nil.
-            // https://github.com/rentzsch/mogenerator/issues/196
-            
-            // Since we don't have an entityName class method (or it didn't return a result),
-            // look up the entity name in the managed object model.
-            NSManagedObjectModel *model = [[VOKCoreDataManager sharedInstance] managedObjectModel];
-            
-            // Start with the class we are...
-            Class workingClass = self;
-            do {
-                NSString *workingClassName = NSStringFromClass(workingClass);
-                // ... check for a matching entity in the model...
-                for (NSEntityDescription *description in model.entities) {
-                    if ([workingClassName isEqualToString:description.managedObjectClassName]) {
-                        vok_entityName = description.name;
-                        break;
-                    }
-                }
-                // ... and walk up the superclass chain...
-                workingClass = [workingClass superclass];
-                // ... until we get Nil or find a matching entity (as long as we have a superclass to test and haven't found the entity name).
-            } while (workingClass && !vok_entityName);
-        }
-        NSAssert(vok_entityName, @"no entity found that uses %@ as its class", NSStringFromClass(self));
-        // Save the determined entity name as an associated value.
-        objc_setAssociatedObject(self, &AssociatedObjectKey, vok_entityName, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    }
-    
-    return vok_entityName;
+    return [[VOKCoreDataManager sharedInstance] entityNameForClass:self];
 }
 
 #pragma mark - Create Objects

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
@@ -7,8 +7,6 @@
 
 #import "NSManagedObject+VOKManagedObjectAdditions.h"
 
-#import <objc/runtime.h>
-
 #import "VOKCoreDataManager.h"
 
 @implementation NSManagedObject (VOKManagedObjectAdditions)

--- a/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
+++ b/Pod/Classes/NSManagedObject+VOKManagedObjectAdditions.m
@@ -113,19 +113,20 @@
 
 + (void)vok_addWithArrayInBackground:(NSArray *)inputArray completion:(VOKManagedObjectsReturnBlock)completion
 {
-    [VOKCoreDataManager importArrayInBackground:inputArray
-                                       forClass:[self class]
-                                     completion:^(NSArray *arrayOfManagedObjectIDs) {
-                                         if (completion) {
-                                             // if there is no completion block there's no need to collect the new/updated objects
-                                             NSMutableArray *returnArray = [NSMutableArray arrayWithCapacity:arrayOfManagedObjectIDs.count];
-                                             NSManagedObjectContext *moc = [[VOKCoreDataManager sharedInstance] managedObjectContext];
-                                             for (NSManagedObjectID *objectID in arrayOfManagedObjectIDs) {
-                                                 [returnArray addObject:[moc objectWithID:objectID]];
-                                             }
-                                             completion([returnArray copy]);
-                                         }
-                                     }];
+    VOKCoreDataManager *coreDataManager = VOKCoreDataManager.sharedInstance;
+    [coreDataManager importArrayInBackground:inputArray
+                                    forClass:[self class]
+                                  completion:^(NSArray *arrayOfManagedObjectIDs) {
+                                      if (completion) {
+                                          // if there is no completion block there's no need to collect the new/updated objects
+                                          NSMutableArray *returnArray = [NSMutableArray arrayWithCapacity:arrayOfManagedObjectIDs.count];
+                                          NSManagedObjectContext *moc = [coreDataManager managedObjectContext];
+                                          for (NSManagedObjectID *objectID in arrayOfManagedObjectIDs) {
+                                              [returnArray addObject:[moc objectWithID:objectID]];
+                                          }
+                                          completion([returnArray copy]);
+                                      }
+                                  }];
 }
 
 #pragma mark - Fetching

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
@@ -239,16 +239,16 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return New data source
  */
-- (instancetype)initWithCoreDataManager:(VOKCoreDataManager *)coreDataManager
-                              predicate:(NSPredicate *)predicate
-                              cacheName:(NSString *)cacheName
-                              tableView:(UITableView *)tableView
-                     sectionNameKeyPath:(NSString *)sectionNameKeyPath
-                        sortDescriptors:(NSArray *)sortDescriptors
+- (instancetype)initWithCoreDataManager:(nullable VOKCoreDataManager *)coreDataManager
+                              predicate:(nullable NSPredicate *)predicate
+                              cacheName:(nullable NSString *)cacheName
+                              tableView:(nullable UITableView *)tableView
+                     sectionNameKeyPath:(nullable NSString *)sectionNameKeyPath
+                        sortDescriptors:(nullable VOKArrayOfSortDescriptors *)sortDescriptors
                      managedObjectClass:(Class)managedObjectClass
                               batchSize:(NSInteger)batchSize
                              fetchLimit:(NSInteger)fetchLimit
-                               delegate:(id <VOKFetchedResultsDataSourceDelegate>)delegate;
+                               delegate:(nullable id <VOKFetchedResultsDataSourceDelegate>)delegate;
 
 /**
  Provide a cell for the given index path. The default implementation of this method attempts to

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
@@ -224,6 +224,33 @@ NS_ASSUME_NONNULL_BEGIN
                          delegate:(nullable id <VOKFetchedResultsDataSourceDelegate>)delegate;
 
 /**
+ Setup this data source.
+ 
+ @param coreDataManager    VOKCoreDataManager object to use as the core data manager
+ @param predicate          Predicate used to filter the objects displayed
+ @param cacheName          Name for the fetched results controller cache
+ @param tableView          Table view to display in. The data source and delegate are set to the newly-created data source.
+ @param sectionNameKeyPath Keypath to use to group results in sections
+ @param sortDescriptors    Sort descriptors to sort the objects
+ @param managedObjectClass NSManagedObject subclass to fetch
+ @param batchSize          Batch size to use for the fetch request fetchBatchSize.
+ @param fetchLimit         Fetch limit to use for the fetch request fetchLimit.
+ @param delegate           Delegate to notify of object selection/deselection and whether the fetch has results
+ 
+ @return New data source
+ */
+- (instancetype)initWithCoreDataManager:(VOKCoreDataManager *)coreDataManager
+                              predicate:(NSPredicate *)predicate
+                              cacheName:(NSString *)cacheName
+                              tableView:(UITableView *)tableView
+                     sectionNameKeyPath:(NSString *)sectionNameKeyPath
+                        sortDescriptors:(NSArray *)sortDescriptors
+                     managedObjectClass:(Class)managedObjectClass
+                              batchSize:(NSInteger)batchSize
+                             fetchLimit:(NSInteger)fetchLimit
+                               delegate:(id <VOKFetchedResultsDataSourceDelegate>)delegate;
+
+/**
  Provide a cell for the given index path. The default implementation of this method attempts to
  dequeue a cell with the reuse identifier "CellIdentifier" and returns it without any configuration.
  As such, this method should be overridden in all subclasses.

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.h
@@ -226,7 +226,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Setup this data source.
  
- @param coreDataManager    VOKCoreDataManager object to use as the core data manager
+ @param coreDataManager    VOKCoreDataManager object to use as the core data manager (pass nil to use VOKCoreDataManager.sharedInstance)
  @param predicate          Predicate used to filter the objects displayed
  @param cacheName          Name for the fetched results controller cache
  @param tableView          Table view to display in. The data source and delegate are set to the newly-created data source.

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
@@ -66,7 +66,7 @@
                        fetchLimit:(NSInteger)fetchLimit
                          delegate:(id <VOKFetchedResultsDataSourceDelegate>)delegate
 {
-    return [self initWithCoreDataManager:VOKCoreDataManager.sharedInstance
+    return [self initWithCoreDataManager:nil
                                predicate:predicate
                                cacheName:cacheName
                                tableView:tableView

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
@@ -14,23 +14,27 @@
 @property (nonatomic, copy) NSString *sectionNameKeyPath;
 @property (nonatomic, copy) NSString *cacheName;
 
+@property (nonatomic, strong) VOKCoreDataManager *coreDataManager;
+
 @end
 
 @implementation VOKFetchedResultsDataSource
 
-- (instancetype)initWithPredicate:(NSPredicate *)predicate
-                        cacheName:(NSString *)cacheName
-                        tableView:(UITableView *)tableView
-               sectionNameKeyPath:(NSString *)sectionNameKeyPath
-                  sortDescriptors:(NSArray *)sortDescriptors
-               managedObjectClass:(Class)managedObjectClass
-                        batchSize:(NSInteger)batchSize
-                       fetchLimit:(NSInteger)fetchLimit
-                         delegate:(id <VOKFetchedResultsDataSourceDelegate>)delegate
+- (instancetype)initWithCoreDataManager:(VOKCoreDataManager *)coreDataManager
+                              predicate:(NSPredicate *)predicate
+                              cacheName:(NSString *)cacheName
+                              tableView:(UITableView *)tableView
+                     sectionNameKeyPath:(NSString *)sectionNameKeyPath
+                        sortDescriptors:(NSArray *)sortDescriptors
+                     managedObjectClass:(Class)managedObjectClass
+                              batchSize:(NSInteger)batchSize
+                             fetchLimit:(NSInteger)fetchLimit
+                               delegate:(id <VOKFetchedResultsDataSourceDelegate>)delegate
 {
     self = [super init];
 
     if (self) {
+        _coreDataManager = coreDataManager ?: VOKCoreDataManager.sharedInstance;
         _predicate = predicate;
         _sortDescriptors = sortDescriptors;
         _managedObjectClass = managedObjectClass;
@@ -50,6 +54,28 @@
     }
 
     return self;
+}
+
+- (instancetype)initWithPredicate:(NSPredicate *)predicate
+                        cacheName:(NSString *)cacheName
+                        tableView:(UITableView *)tableView
+               sectionNameKeyPath:(NSString *)sectionNameKeyPath
+                  sortDescriptors:(NSArray *)sortDescriptors
+               managedObjectClass:(Class)managedObjectClass
+                        batchSize:(NSInteger)batchSize
+                       fetchLimit:(NSInteger)fetchLimit
+                         delegate:(id <VOKFetchedResultsDataSourceDelegate>)delegate
+{
+    return [self initWithCoreDataManager:VOKCoreDataManager.sharedInstance
+                               predicate:predicate
+                               cacheName:cacheName
+                               tableView:tableView
+                      sectionNameKeyPath:sectionNameKeyPath
+                         sortDescriptors:sortDescriptors
+                      managedObjectClass:managedObjectClass
+                               batchSize:batchSize
+                              fetchLimit:fetchLimit
+                                delegate:delegate];
 }
 
 - (instancetype)initWithPredicate:(NSPredicate *)predicate
@@ -251,7 +277,7 @@
 
 - (void)initFetchedResultsController
 {
-    NSManagedObjectContext *moc = [[VOKCoreDataManager sharedInstance] managedObjectContext];
+    NSManagedObjectContext *moc = [self.coreDataManager managedObjectContext];
 
     NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
     NSEntityDescription *entity = [NSEntityDescription entityForName:[_managedObjectClass vok_entityName]

--- a/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
+++ b/Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.m
@@ -280,7 +280,7 @@
     NSManagedObjectContext *moc = [self.coreDataManager managedObjectContext];
 
     NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
-    NSEntityDescription *entity = [NSEntityDescription entityForName:[_managedObjectClass vok_entityName]
+    NSEntityDescription *entity = [NSEntityDescription entityForName:[self.coreDataManager entityNameForClass:_managedObjectClass]
                                               inManagedObjectContext:moc];
     fetchRequest.entity = entity;
     

--- a/Pod/Classes/VOKCoreDataManager.h
+++ b/Pod/Classes/VOKCoreDataManager.h
@@ -153,6 +153,13 @@ typedef void(^VOKObjectIDsReturnBlock)(VOKArrayOfManagedObjectIDs *managedObject
                                                          respectKeyPaths:(BOOL)keyPathsEnabled;
 
 /**
+ Get the entity name for a given managed object class.
+ @param managedObjectClass  The target NSManagedObject subclass.
+ @return                    The entity name corresponding to the given managed object class or nil if it cannot be determined.
+ */
+- (nullable NSString *)entityNameForClass:(Class)managedObjectClass;
+
+/**
  Counts every instance of a given class using the main managed object context. Includes subentities.
  NOT threadsafe! Always use a temp context if you are NOT on the main queue, by calling countForClass:forContext: instead
  @param managedObjectClass      The class to count.

--- a/Pod/Classes/VOKCoreDataManager.h
+++ b/Pod/Classes/VOKCoreDataManager.h
@@ -293,7 +293,7 @@ typedef void(^VOKObjectIDsReturnBlock)(VOKArrayOfManagedObjectIDs *managedObject
                         Do not save or merge the context, it will be done for you.
  @prarm completion      Fired on the main queue once the changes have been merged.
  */
-+ (void)writeToTemporaryContext:(VOKWriteBlock)writeBlock
+- (void)writeToTemporaryContext:(VOKWriteBlock)writeBlock
                      completion:(nullable void (^)(void))completion;
 
 /**
@@ -302,7 +302,7 @@ typedef void(^VOKObjectIDsReturnBlock)(VOKArrayOfManagedObjectIDs *managedObject
  @param objectClass     Specifies the class to instantiate or fetch when importing data.
  @param completion      Fired on the main queue once the changes have been merged. It brings an NSArray of permanent NSManagedObjectIDs matching the objects deserialized from the import array.
  */
-+ (void)importArrayInBackground:(VOKArrayOfObjectDictionaries *)inputArray
+- (void)importArrayInBackground:(VOKArrayOfObjectDictionaries *)inputArray
                        forClass:(Class)objectClass
                      completion:(nullable VOKObjectIDsReturnBlock)completion;
 

--- a/Pod/Classes/VOKCoreDataManager.m
+++ b/Pod/Classes/VOKCoreDataManager.m
@@ -44,15 +44,15 @@
     [self sharedInstance];
 }
 
-static VOKCoreDataManager *VOK_SharedObject;
 + (VOKCoreDataManager *)sharedInstance
 {
+    static VOKCoreDataManager *sharedInstance;
     static dispatch_once_t pred;
     dispatch_once(&pred, ^{
-        VOK_SharedObject = [[self alloc] init];
-        [VOK_SharedObject addMappableModelMappers];
+        sharedInstance = [[self alloc] init];
+        [sharedInstance addMappableModelMappers];
     });
-    return VOK_SharedObject;
+    return sharedInstance;
 }
 
 - (instancetype)init

--- a/SampleProject/VOKCoreDataManagerTests/VOKManagedObjectAdditions.m
+++ b/SampleProject/VOKCoreDataManagerTests/VOKManagedObjectAdditions.m
@@ -102,7 +102,7 @@ static const NSUInteger BasicTestDataSize = 5;
     XCTAssertEqual([VOKThing vok_fetchAllForPredicate:nil
                               forManagedObjectContext:nil].count, 0);
     
-    [VOKCoreDataManager writeToTemporaryContext:^(NSManagedObjectContext *tempContext) {
+    [VOKCoreDataManager.sharedInstance writeToTemporaryContext:^(NSManagedObjectContext *tempContext) {
         
         VOKThing *thing = [VOKThing vok_newInstanceWithContext:tempContext];
         [thing setName:@"test-2"];


### PR DESCRIPTION
In order to allow multiple instances of `VOKCoreDataManager` to coexist:
- any instance methods on `VOKCoreDataManager` should use `self` instead of the shared instance
- any class methods that require an instance of `VOKCoreDataManager` should be converted to instance methods (***breaking change***)
- `VOKCoreDataManager` should not use any methods from `NSManagedObject+VOKManagedObjectAdditions` that require a manager instance

The methods in `NSManagedObject+VOKManagedObjectAdditions` that require a manager instance are now all convenience wrappers that call instance methods on the shared manager.  This means that having multiple manager instances means using the manager methods directly rather than the convenience category methods on the managed objects.

@vokal/ios-developers @chillpop Code review please?