### PR TITLE
Updated version requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you intend to use Vokoder in Swift, use the `Swift` subspec instead:
 
     pod "Vokoder/Swift"
 
-Vokoder requires Xcode 5.1 or higher.  The unit tests require features found in Xcode 6 and higher.  The Swift extensions require Swift 2 and Xcode 7.
+Vokoder requires iOS 7, tvOS 9, or macOS 10.9. The Swift extensions require Swift 3 and Xcode 8.
 
 ## Subspecs
 


### PR DESCRIPTION
Of course I noticed this right after pushing 4.0.1 to CocoaPods.

I dropped the bit about the oldest version of Xcode required (I'm sure it's no longer 5.1), and I'm not sure how far back the unit tests will run but don't want to keep making promises there. Instead, I specified earliest OS versions, based on the podspec.

@vokal/ios-developers review?