### PR TITLE
Lint the pod during the regular build, so that lint fails will fail Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
     - SCAN_WORKSPACE="SampleProject/SampleProject.xcworkspace"                           SCAN_SCHEME="VOKCoreDataManager-OSX"     SCAN_SDK="macosx"
     - SCAN_WORKSPACE="SwiftSampleProject/SwiftSampleProject.xcworkspace"                 SCAN_SCHEME="SwiftyVokoder"              SCAN_SDK="iphonesimulator"
     - SCAN_WORKSPACE="Paging Data Source Example/Paging Data Source Example.xcworkspace" SCAN_SCHEME="Paging Data Source Example" SCAN_SDK="iphonesimulator"
-script: bundle exec fastlane scan
-after_script:
+script:
+  - bundle exec fastlane scan
   - bundle exec pod lib lint
 git:
   depth: 10000  # For the auto-incrementing build number script to work, we need to clone with a basically-infinite depth.


### PR DESCRIPTION
I tried this out in #121 to confirm it would indeed fail, and it looks like the impact on build time isn't too significant. This PR only includes the Travis config update, and not the test commit I included in #121 to confirm it would fail.

Fixes #103.

@vokal/ios-developers cool?