### PR TITLE
RM alternate dependency declarations

### DIFF
--- a/Paging Data Source Example/Podfile.lock
+++ b/Paging Data Source Example/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (5.0.0):
-    - Vokoder/Core (= 5.0.0)
-    - Vokoder/DataSources (= 5.0.0)
-    - Vokoder/MapperMacros (= 5.0.0)
-  - Vokoder/Core (5.0.0):
+  - Vokoder (5.0.1):
+    - Vokoder/Core (= 5.0.1)
+    - Vokoder/DataSources (= 5.0.1)
+    - Vokoder/MapperMacros (= 5.0.1)
+  - Vokoder/Core (5.0.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.11.0)
-  - Vokoder/DataSources (5.0.0):
+  - Vokoder/DataSources (5.0.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 5.0.0)
-    - Vokoder/DataSources/FetchedResults (= 5.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 5.0.0)
-  - Vokoder/DataSources/Collection (5.0.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (5.0.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (5.0.0):
+    - Vokoder/DataSources/Collection (= 5.0.1)
+    - Vokoder/DataSources/FetchedResults (= 5.0.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 5.0.1)
+  - Vokoder/DataSources/Collection (5.0.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (5.0.0):
+  - Vokoder/DataSources/FetchedResults (5.0.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (5.0.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (5.0.1):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.11.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 36b3c173b1f8933aebd419ff6e740fece076be06
+  Vokoder: 2e571a4e2290fdf9431d923ae6be2fd094f3ab0f
   VOKUtilities: e831207f9217bd8060467d28f26b5f7a902db63c
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/Paging Data Source Example/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "5.0.0"
+    "tag": "5.0.1"
   },
   "platforms": {
     "ios": "8.0",
@@ -95,10 +95,11 @@
       "name": "Swift",
       "platforms": {
         "ios": "8.0",
-        "tvos": "9.0"
+        "tvos": "9.0",
+        "watchos": "3.0"
       },
       "dependencies": {
-        "Vokoder/DataSources": [
+        "Vokoder/Core": [
 
         ]
       },

--- a/Paging Data Source Example/Pods/Manifest.lock
+++ b/Paging Data Source Example/Pods/Manifest.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (5.0.0):
-    - Vokoder/Core (= 5.0.0)
-    - Vokoder/DataSources (= 5.0.0)
-    - Vokoder/MapperMacros (= 5.0.0)
-  - Vokoder/Core (5.0.0):
+  - Vokoder (5.0.1):
+    - Vokoder/Core (= 5.0.1)
+    - Vokoder/DataSources (= 5.0.1)
+    - Vokoder/MapperMacros (= 5.0.1)
+  - Vokoder/Core (5.0.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.11.0)
-  - Vokoder/DataSources (5.0.0):
+  - Vokoder/DataSources (5.0.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 5.0.0)
-    - Vokoder/DataSources/FetchedResults (= 5.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 5.0.0)
-  - Vokoder/DataSources/Collection (5.0.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (5.0.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (5.0.0):
+    - Vokoder/DataSources/Collection (= 5.0.1)
+    - Vokoder/DataSources/FetchedResults (= 5.0.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 5.0.1)
+  - Vokoder/DataSources/Collection (5.0.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (5.0.0):
+  - Vokoder/DataSources/FetchedResults (5.0.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (5.0.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (5.0.1):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.11.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 36b3c173b1f8933aebd419ff6e740fece076be06
+  Vokoder: 2e571a4e2290fdf9431d923ae6be2fd094f3ab0f
   VOKUtilities: e831207f9217bd8060467d28f26b5f7a902db63c
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/Paging Data Source Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Paging Data Source Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,179 +7,179 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0FBF15D82D6887E4507BAEC5AE7D44A5 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */; };
-		13860E57730CB68C980144C1246E8166 /* VOKUtilities-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 812A6DF58E85CCC1E9280954D46182B9 /* VOKUtilities-dummy.m */; };
-		1523ECABEAC8045673063FA3D6E70899 /* ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 801B9204844DE86EC73A5E7EFC5627E1 /* ILGDynamicObjC-dummy.m */; };
-		191F67BC31A55B010EEDC6CA04C5F797 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */; };
-		1B49270969167C22DCCCF46AD88EB2DB /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1BFB7C298FD5C3D2FD390190D0ECA769 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		235B0187FBBF4AE11D3AE502DA0ECD58 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		23DA4A38A0F5999A47726AD2E3A3CB64 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		24251378DC9175E56D1DBC9CA0A414C4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		266C2EB085F2A07622C62FB075718E2C /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 869B5154502141C012BA472A1C847BDE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		26A5F9C895CB34BF97F17CE571E759A5 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		275AFAF4656AB8170B4E6BD5EABF9505 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */; };
-		2A12A0F766D622588FB6DBE55D841D51 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */; };
-		2C7030DBF426C627A98E271E3996DD9B /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		388C22BC0C6295739569BEFD0E62A532 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */; };
-		421751C8646B1D9437AF8400FDEF78AB /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */; };
-		576AFEB70C4926DF9D90C402F04C1A91 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5FEF85C834ED6D2FD83EDF4EB4C5A288 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		80598BB0FFF71DD997ACBE95F84179EB /* Pods-Paging Data Source Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EDBB3A28D94BF61EEF381177389F13DB /* Pods-Paging Data Source Example-dummy.m */; };
-		845D9724236EF9488DB2D80DF022A1A5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		95B9BB48A25AB5F7D0AEE23B75C52B90 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */; };
-		9B931AD17FA3518651FAB463A8B8D9E1 /* Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 79B1BD8DE394FE1FD0C6D56BEB1B1398 /* Vokoder-dummy.m */; };
-		9DAC5F1FCC91C4B9DA5DE65CD6C06FF9 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A5C22E889A9E7C681C810D7BDE8790D5 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B04C34A5665F815CEE7B9C496B162B1E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		BA01ACF653FD84D67AA2A9F07B7A142E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		CB4A4C09DE45A0847DA2F19BB3614B00 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D36F28073218405C5AC61EFE60512689 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */; };
-		D5D5268A466A625A4B99B43992B3F7BD /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D7811F8401C3BF218D6FFF3403DEF1D2 /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D88DFF6934B408DB7166E3FE6326D411 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E0CEEB884037F2326F94FFD21AA555A5 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */; };
-		E4F0D448B9ACA0588BA05ECBF3C4E4C9 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E63EFB9B228A5DBAA0A19CAF3F531E93 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F0DDF2A2AF18593F10C360BE5443B757 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07B6AF4CD66F19DE73F16B9FC92D8C68 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D0738CD1D7CEA7757D740197C48EF95 /* VOKCollectionDataSource.m */; };
+		2F06156F3BA51E7E4E5F2C445AA2B7E0 /* Pods-Paging Data Source Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 76FCE337C61B99F634ADD203BD4589AD /* Pods-Paging Data Source Example-dummy.m */; };
+		31E7BE2449CED5A01D244BFFAD5379C9 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7155D566D5A064941E35D2E7C10D734D /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35A6F4A9C24E967710598A1C26B31D93 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DE1D527341816F007D01C9B89F211DB7 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B97EDF8DDC55632E69053434378C13E /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 2368D70EAFC8F21DCF0E6806E43C48A5 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		51FEC280F9291A1DFB1A57EDA01B6847 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = C3513E78F8D0B751A02A199A9BC52FA9 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		527315E072F6D5FB7702E07CDEDCBB93 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 1818E50242F41D00F76D30B914CCE65E /* VOKFetchedResultsDataSource.m */; };
+		53316DC21C9788CF466B77B3FDE58485 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F2CDD5CFA737B4733B626801826B90 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55AD5D23DBFF050FE51145FD687FE9B5 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = EF0149E2F696E0470E965BFC18DE9840 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C1F90BCE23204F56623158EAC23392A /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 38883E1232D64CEC9366CAEC8C9395E5 /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D8CC5BB8CAE470C7B2FDAAFDFBBAB0E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF85E5A74BF2C5F729F6419654402FBC /* Foundation.framework */; };
+		5DD4A80F3E44841EFA1C00601FEDF3C6 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 18AFDF4E68EF0C688B4770E0779F89DD /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		656840DA5580BE93DD572FAF0205CDCE /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C7925FE6C2B7EBFC2FB3BB590557B0E /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B0825EECE0A3C720674C46626712C64 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF85E5A74BF2C5F729F6419654402FBC /* Foundation.framework */; };
+		7234CE2D2A7367F8E503A8DD05472D21 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 56C46BC262E57D3C2E20F627216E4169 /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		868003E58080B29EFB2D6D3790441973 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BF4152F27C9C0DCFEE3F92154B676C /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B78A7AED25057F1FE57C3FCF5702025 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 19D25D12F89B23754F4CF8409CDD78F8 /* VOKPagingFetchedResultsDataSource.m */; };
+		A074F219221CFD806AF5196FA3DCFA47 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D9F21FE4F2F2217242EEE8EEDA7DC811 /* VOKManagedObjectMapper.m */; };
+		A225E4B6AB1E363B24C2A8F9C0EDFD05 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EC406103C5D6356E7E1641C322CE3BC /* VOKManagedObjectMap.m */; };
+		B204EA591DB3F9426B1114D0A4B7A2F6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF85E5A74BF2C5F729F6419654402FBC /* Foundation.framework */; };
+		C306FE8A8AB33486C757C9E4EE7FC4FE /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7E84538505F21AD441B87E2C82C53E5 /* CoreData.framework */; };
+		C542B7C464BD4469E2B88C07CCB3065F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF85E5A74BF2C5F729F6419654402FBC /* Foundation.framework */; };
+		D34EED6F4E757257CE35031FE69ABE35 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = BA9924843B153214349674104DE2CB12 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D48F607E0C7B508B713CC0E4BE6173F7 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 85A9E820E6935083D357741816580489 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		D517DD6FFE575B7F4B2028EC248AE99F /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A0BA8286BC5E47F9AB39B4A32947ABB /* VOKKeyPathHelper.m */; };
+		D5D910DB011D4193B52B3781534931B0 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DFC4A4D977A4A09C31EF03CA1710FB9 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DACA210C612AC9DBC16EE93DF9BEB68C /* Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ECE841CABAFB68FD121CCFEE8315539 /* Vokoder-dummy.m */; };
+		DEEDD22C835456A2EAC4C9A1640288A1 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 021C257910025191F41A4D43979BF806 /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E0C7F41F8319CB670F28B27E7AC60784 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EC04304C7E614F58427D9E3334BC1B7 /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E3F320698FC3C13A95D50C999324962E /* VOKUtilities-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 546C3A70128ED9F31BCD5F1DA3906E5C /* VOKUtilities-dummy.m */; };
+		E3F594F70CD4CA9FD8758254055DDFE9 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 27D1AFD5B17FDA2A2A175E83B1275874 /* VOKCoreDataManager.m */; };
+		E8C4FDFF1F577C2B53047A81177B8374 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = E26F92E4B8625F038B4DF8252BCEC98A /* VOKDefaultPagingAccessory.m */; };
+		EF81D0F29CED3566725BC381B7BB46DA /* ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E45006BF2843CDF06D5577882F50178E /* ILGDynamicObjC-dummy.m */; };
+		F87938F5D524D1499F4C7A7A8E60DFA6 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 057FC67101FA35EFE94B64E0A8821D05 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF555B4E3767F382B6FB4A98BA24116A /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C393A2D44B8ABC42C9F78D6221B2343 /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		BAAD07A27454A07F29747B96469992AE /* PBXContainerItemProxy */ = {
+		0852D5DBD351AC595E0D4788EADF2C2C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 69C3F52DD0A5FFBD9C342F59625053AA;
+			remoteGlobalIDString = 1B31289C3C8C09D615F1CCB2E7CEB9B1;
 			remoteInfo = ILGDynamicObjC;
 		};
-		ED52E1F9B8BAB5C3F7D2EB127B326189 /* PBXContainerItemProxy */ = {
+		220FA07538A8AED065D58660DE0DCBA1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7BF6F455B6726E7C85743DC17CAFDD20;
+			remoteGlobalIDString = D8FBCA5BF4CCED24D96FEEFE20B0C031;
 			remoteInfo = VOKUtilities;
 		};
-		9FC710D4649DAC78809D340455BEA9DC /* PBXContainerItemProxy */ = {
+		33B84D5B0FE284839B7C1C922D485F61 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = BA5E2F05EA983D823D3414221069869D;
+			remoteGlobalIDString = 4E4DDD31A3C20692C57F11F1A711541B;
 			remoteInfo = Vokoder;
 		};
-		9E19846C346BFE4CC9BEB3E76B429238 /* PBXContainerItemProxy */ = {
+		703DD5B8297042D8AAC19AE32033EF82 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7BF6F455B6726E7C85743DC17CAFDD20;
+			remoteGlobalIDString = D8FBCA5BF4CCED24D96FEEFE20B0C031;
 			remoteInfo = VOKUtilities;
 		};
-		9E56DCA6B81F481ADEA677BD0C427CE9 /* PBXContainerItemProxy */ = {
+		8FAD4858766994C124CAB046F0120EEB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 69C3F52DD0A5FFBD9C342F59625053AA;
+			remoteGlobalIDString = 1B31289C3C8C09D615F1CCB2E7CEB9B1;
 			remoteInfo = ILGDynamicObjC;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
-		18C54104344AC33572BB25A436C144F8 /* Pods-Paging Data Source Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.release.xcconfig"; sourceTree = "<group>"; };
-		1BA7179BB57D2E39E78D9EF31103070B /* Pods-Paging Data Source Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Paging Data Source Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
-		2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKKeyPathHelper.m; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.m; sourceTree = "<group>"; };
-		311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Vokoder.h; sourceTree = "<group>"; };
-		34CF9C4B25B5F8A784213D7E9738DBDD /* libPods-Paging Data Source Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-Paging Data Source Example.a"; path = "libPods-Paging Data Source Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		42FD299E712A65D222D03FF9FA03010B /* VOKUtilities.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VOKUtilities.xcconfig; sourceTree = "<group>"; };
-		4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
-		4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
-		563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
-		58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
-		5B2171CB97536497AC1DFC99412ED235 /* Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Vokoder-prefix.pch"; sourceTree = "<group>"; };
-		5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
-		5ED4077304AB1720B21D628EFD7A11F4 /* ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ILGDynamicObjC.xcconfig; sourceTree = "<group>"; };
-		63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
-		7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
-		78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		79B1BD8DE394FE1FD0C6D56BEB1B1398 /* Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Vokoder-dummy.m"; sourceTree = "<group>"; };
-		7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
-		7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
-		801B9204844DE86EC73A5E7EFC5627E1 /* ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
-		809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
-		812A6DF58E85CCC1E9280954D46182B9 /* VOKUtilities-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VOKUtilities-dummy.m"; sourceTree = "<group>"; };
-		824A937B5CC4A689193AED27F05DA4B1 /* Pods-Paging Data Source Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-resources.sh"; sourceTree = "<group>"; };
-		869B5154502141C012BA472A1C847BDE /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
-		88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
-		8EBBB96056A220B2BEF1F01EEE84DE2C /* VOKUtilities-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-prefix.pch"; sourceTree = "<group>"; };
-		9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapperMacros.h; sourceTree = "<group>"; };
-		9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		9CAA01EAE9A9BEAD84FD3014FAC597EB /* libILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libILGDynamicObjC.a; path = libILGDynamicObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		A38FF61C71733211E6DDB19385503404 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		ABFD0A01EDA52F8BB58A8A8A0C8AAF80 /* Pods-Paging Data Source Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-frameworks.sh"; sourceTree = "<group>"; };
-		AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
-		C12B1D4858B55AA4DA1FAFD63227B2F3 /* Pods-Paging Data Source Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.debug.xcconfig"; sourceTree = "<group>"; };
-		C4902ACEB6F9D234A1C2BF2DA248D53D /* ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
-		CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
-		CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
-		D8FBDE945FE6490FDF1E79C26690E1D5 /* Pods-Paging Data Source Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Paging Data Source Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		DA9CD9EB3AA7FF3EBC9A08286E12C900 /* libVokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libVokoder.a; path = libVokoder.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		DC30256BDC690C4FDE85E97F341E11E1 /* Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Vokoder.xcconfig; sourceTree = "<group>"; };
-		E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
-		E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
-		E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		EDBB3A28D94BF61EEF381177389F13DB /* Pods-Paging Data Source Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-dummy.m"; sourceTree = "<group>"; };
-		F1F509176F65E2C991E7C9308802DB84 /* libVOKUtilities.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libVOKUtilities.a; path = libVOKUtilities.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
-		F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKKeyPathHelper.h; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.h; sourceTree = "<group>"; };
-		FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		021C257910025191F41A4D43979BF806 /* Vokoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Vokoder.h; sourceTree = "<group>"; };
+		057FC67101FA35EFE94B64E0A8821D05 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
+		1818E50242F41D00F76D30B914CCE65E /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		18AFDF4E68EF0C688B4770E0779F89DD /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
+		19C33B654D94761943C83F7E92583747 /* ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
+		19D25D12F89B23754F4CF8409CDD78F8 /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		1EC04304C7E614F58427D9E3334BC1B7 /* VOKKeyPathHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKKeyPathHelper.h; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.h; sourceTree = "<group>"; };
+		208E55A092EACAC73837C5A644C397C2 /* VOKUtilities-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-prefix.pch"; sourceTree = "<group>"; };
+		2368D70EAFC8F21DCF0E6806E43C48A5 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
+		27D1AFD5B17FDA2A2A175E83B1275874 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		2DFC4A4D977A4A09C31EF03CA1710FB9 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
+		38883E1232D64CEC9366CAEC8C9395E5 /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
+		38F2CDD5CFA737B4733B626801826B90 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
+		4A0BA8286BC5E47F9AB39B4A32947ABB /* VOKKeyPathHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKKeyPathHelper.m; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.m; sourceTree = "<group>"; };
+		4C7925FE6C2B7EBFC2FB3BB590557B0E /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
+		546C3A70128ED9F31BCD5F1DA3906E5C /* VOKUtilities-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VOKUtilities-dummy.m"; sourceTree = "<group>"; };
+		560ADA6B376E62F39B3220D7E9DB5ECE /* Pods-Paging Data Source Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.debug.xcconfig"; sourceTree = "<group>"; };
+		56C46BC262E57D3C2E20F627216E4169 /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
+		56CBEAD7AE66599A3138721A4674FEFE /* VOKUtilities.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VOKUtilities.xcconfig; sourceTree = "<group>"; };
+		5C393A2D44B8ABC42C9F78D6221B2343 /* VOKManagedObjectMapperMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapperMacros.h; sourceTree = "<group>"; };
+		5ECE841CABAFB68FD121CCFEE8315539 /* Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Vokoder-dummy.m"; sourceTree = "<group>"; };
+		65900821EAD1DDD584635E06C1BD834F /* Pods-Paging Data Source Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Paging Data Source Example.release.xcconfig"; sourceTree = "<group>"; };
+		6A8EAA421133B6B09336773AA3C0F738 /* Pods-Paging Data Source Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-frameworks.sh"; sourceTree = "<group>"; };
+		7155D566D5A064941E35D2E7C10D734D /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
+		76FCE337C61B99F634ADD203BD4589AD /* Pods-Paging Data Source Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Paging Data Source Example-dummy.m"; sourceTree = "<group>"; };
+		7D0738CD1D7CEA7757D740197C48EF95 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
+		80C68271DEF89D4BD2DA08130AC3DA47 /* libILGDynamicObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libILGDynamicObjC.a; path = libILGDynamicObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		85A9E820E6935083D357741816580489 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
+		8F3DFD80683BE681779D76CDAE7865F6 /* Pods-Paging Data Source Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Paging Data Source Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		980A80E264EB995EDFF7E8D3DF50AB8C /* Vokoder.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Vokoder.xcconfig; sourceTree = "<group>"; };
+		9EC406103C5D6356E7E1641C322CE3BC /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
+		BA9924843B153214349674104DE2CB12 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
+		C3513E78F8D0B751A02A199A9BC52FA9 /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
+		CE3BB32EC1FDA2C6A8CDDB6AB7233A15 /* libPods-Paging Data Source Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-Paging Data Source Example.a"; path = "libPods-Paging Data Source Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D9F21FE4F2F2217242EEE8EEDA7DC811 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
+		DE1D527341816F007D01C9B89F211DB7 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		DE25C4A5E95721E54AC3C15615E4D3FF /* libVokoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libVokoder.a; path = libVokoder.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE2EA331A670D02F22A9EA83ABEB8D91 /* libVOKUtilities.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libVOKUtilities.a; path = libVOKUtilities.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E26F92E4B8625F038B4DF8252BCEC98A /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
+		E3BF4152F27C9C0DCFEE3F92154B676C /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
+		E45006BF2843CDF06D5577882F50178E /* ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
+		E7E84538505F21AD441B87E2C82C53E5 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		EBF958E44EC865CFE846FAFF3B9C33B7 /* Pods-Paging Data Source Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Paging Data Source Example-resources.sh"; sourceTree = "<group>"; };
+		ECFD1A323A35F81EAAABEFB69D26AEB5 /* Vokoder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Vokoder-prefix.pch"; sourceTree = "<group>"; };
+		EE1CCA35F1E52885C9CD5AC158CB1C71 /* ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ILGDynamicObjC.xcconfig; sourceTree = "<group>"; };
+		EF0149E2F696E0470E965BFC18DE9840 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		F454A3A24056DB3DCE273346636DE4A9 /* Pods-Paging Data Source Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Paging Data Source Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		FF85E5A74BF2C5F729F6419654402FBC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		15141D10078782C4A107A2CC8490502A /* Frameworks */ = {
+		3D8678CBA7454C3F3582BB6789616389 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5FEF85C834ED6D2FD83EDF4EB4C5A288 /* Foundation.framework in Frameworks */,
+				5D8CC5BB8CAE470C7B2FDAAFDFBBAB0E /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8952633548A32679835C87BC28DD5073 /* Frameworks */ = {
+		9010A656E0A3D99D15B93C2982E1A690 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				191F67BC31A55B010EEDC6CA04C5F797 /* CoreData.framework in Frameworks */,
-				24251378DC9175E56D1DBC9CA0A414C4 /* Foundation.framework in Frameworks */,
+				C306FE8A8AB33486C757C9E4EE7FC4FE /* CoreData.framework in Frameworks */,
+				C542B7C464BD4469E2B88C07CCB3065F /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1B080578CDC46257763506AC2A658ADB /* Frameworks */ = {
+		B9F01EC59731F21257BB4F58A9E80D53 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				845D9724236EF9488DB2D80DF022A1A5 /* Foundation.framework in Frameworks */,
+				B204EA591DB3F9426B1114D0A4B7A2F6 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D1E0A78515A425ACB73FFF1E5DED5776 /* Frameworks */ = {
+		F971A66389AAD50F1C555E33BB87FBC2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B04C34A5665F815CEE7B9C496B162B1E /* Foundation.framework in Frameworks */,
+				6B0825EECE0A3C720674C46626712C64 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		27E772C472EE5BD87EA005C1E920FEC6 /* Targets Support Files */ = {
+		088CF97B779ED2E9832E738B6568EE34 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				9A16334436689E328D4AB58E15D37AC6 /* Pods-Paging Data Source Example */,
+				180CD71CD9A70C681D41B1B23FA5A636 /* Pods-Paging Data Source Example */,
 			);
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		73AB5E5F94B4DE5984CD16FDB5EABFD4 /* xUnique */ = {
+		08FC1C11FFA03D2040181A0AB8520A42 /* xUnique */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -187,359 +187,359 @@
 			path = xUnique;
 			sourceTree = "<group>";
 		};
-		050D206B9AEB4DF87D322F72A840A0DE /* MapperMacros */ = {
+		11BDA25FB5605CB74141B5CF00ECE19F /* MapperMacros */ = {
 			isa = PBXGroup;
 			children = (
-				9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */,
+				5C393A2D44B8ABC42C9F78D6221B2343 /* VOKManagedObjectMapperMacros.h */,
 			);
 			name = MapperMacros;
 			path = MapperMacros;
 			sourceTree = "<group>";
 		};
-		D291960F19FD2FE625E66028614C79A8 /* DataSources */ = {
+		12F885C065B0016EC8C6403F5B54BA49 /* DataSources */ = {
 			isa = PBXGroup;
 			children = (
-				62478C4BCC083549B2675083D4CE14F0 /* Collection */,
-				8EB4618C736DD6BDEC8CFC9A74CBE387 /* FetchedResults */,
-				DC922EC5F6A4C858F3D3657B1D19245D /* PagingFetchedResults */,
+				7D9E0FF2D369E5A440547872D410E105 /* Collection */,
+				59CC3702664863EA70C6EF8D15C8B361 /* FetchedResults */,
+				7411776D0D2955862381D41FEA28C209 /* PagingFetchedResults */,
 			);
 			name = DataSources;
 			sourceTree = "<group>";
 		};
-		21C815DB339F7DD825A5E4CB08881309 /* Support Files */ = {
+		164B46FEABD5FACB26D02FA2A504739E /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				79B1BD8DE394FE1FD0C6D56BEB1B1398 /* Vokoder-dummy.m */,
-				5B2171CB97536497AC1DFC99412ED235 /* Vokoder-prefix.pch */,
-				DC30256BDC690C4FDE85E97F341E11E1 /* Vokoder.xcconfig */,
+				980A80E264EB995EDFF7E8D3DF50AB8C /* Vokoder.xcconfig */,
+				5ECE841CABAFB68FD121CCFEE8315539 /* Vokoder-dummy.m */,
+				ECFD1A323A35F81EAAABEFB69D26AEB5 /* Vokoder-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "Paging Data Source Example/Pods/Target Support Files/Vokoder";
 			sourceTree = "<group>";
 		};
-		9A16334436689E328D4AB58E15D37AC6 /* Pods-Paging Data Source Example */ = {
+		180CD71CD9A70C681D41B1B23FA5A636 /* Pods-Paging Data Source Example */ = {
 			isa = PBXGroup;
 			children = (
-				D8FBDE945FE6490FDF1E79C26690E1D5 /* Pods-Paging Data Source Example-acknowledgements.markdown */,
-				1BA7179BB57D2E39E78D9EF31103070B /* Pods-Paging Data Source Example-acknowledgements.plist */,
-				EDBB3A28D94BF61EEF381177389F13DB /* Pods-Paging Data Source Example-dummy.m */,
-				ABFD0A01EDA52F8BB58A8A8A0C8AAF80 /* Pods-Paging Data Source Example-frameworks.sh */,
-				824A937B5CC4A689193AED27F05DA4B1 /* Pods-Paging Data Source Example-resources.sh */,
-				C12B1D4858B55AA4DA1FAFD63227B2F3 /* Pods-Paging Data Source Example.debug.xcconfig */,
-				18C54104344AC33572BB25A436C144F8 /* Pods-Paging Data Source Example.release.xcconfig */,
+				8F3DFD80683BE681779D76CDAE7865F6 /* Pods-Paging Data Source Example-acknowledgements.markdown */,
+				F454A3A24056DB3DCE273346636DE4A9 /* Pods-Paging Data Source Example-acknowledgements.plist */,
+				76FCE337C61B99F634ADD203BD4589AD /* Pods-Paging Data Source Example-dummy.m */,
+				6A8EAA421133B6B09336773AA3C0F738 /* Pods-Paging Data Source Example-frameworks.sh */,
+				EBF958E44EC865CFE846FAFF3B9C33B7 /* Pods-Paging Data Source Example-resources.sh */,
+				560ADA6B376E62F39B3220D7E9DB5ECE /* Pods-Paging Data Source Example.debug.xcconfig */,
+				65900821EAD1DDD584635E06C1BD834F /* Pods-Paging Data Source Example.release.xcconfig */,
 			);
 			name = "Pods-Paging Data Source Example";
 			path = "Target Support Files/Pods-Paging Data Source Example";
 			sourceTree = "<group>";
 		};
-		A82DCA28FABF1F9080B1B2234FFB9045 /* iOS */ = {
+		18C31505F53BCD0CB0F85AB659963013 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */,
-				9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */,
+				E7E84538505F21AD441B87E2C82C53E5 /* CoreData.framework */,
+				FF85E5A74BF2C5F729F6419654402FBC /* Foundation.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		1432AA59D8B53139E350543A9C80D7F8 /* Pods */ = {
+		23A1BCFAF0B252A99191D410D963BB63 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BD69F150A8C2569270FC79BDA1504428 /* ILGDynamicObjC */,
-				0628D34B912C2431236471EF4C7720C0 /* VOKUtilities */,
-				73AB5E5F94B4DE5984CD16FDB5EABFD4 /* xUnique */,
+				278470F3087B980220BFFD720B24B8C9 /* ILGDynamicObjC */,
+				3B5E8C421FE46E1F0E33EA9D8DBA31BA /* VOKUtilities */,
+				08FC1C11FFA03D2040181A0AB8520A42 /* xUnique */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		CA9F64BFACD9A6B9EFC6C13F107B6ABF /* Optional Data Sources */ = {
+		23DF76E159F76DA23AB01D6E8DE44EFE /* Optional Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */,
-				E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */,
+				EF0149E2F696E0470E965BFC18DE9840 /* VOKFetchedResultsDataSource.h */,
+				1818E50242F41D00F76D30B914CCE65E /* VOKFetchedResultsDataSource.m */,
 			);
 			name = "Optional Data Sources";
 			path = "Optional Data Sources";
 			sourceTree = "<group>";
 		};
-		BD69F150A8C2569270FC79BDA1504428 /* ILGDynamicObjC */ = {
+		278470F3087B980220BFFD720B24B8C9 /* ILGDynamicObjC */ = {
 			isa = PBXGroup;
 			children = (
-				C0EADA668804F57D6D9AA862CE8EF321 /* ILGClasses */,
-				F653198251905F2D19DBEA48B7F9A7DC /* Support Files */,
+				78B071F64137B3D3A8C2D8406D61F86F /* ILGClasses */,
+				B15744ACD24BF7D3C0F8E4D3F6831944 /* Support Files */,
 			);
 			name = ILGDynamicObjC;
 			path = ILGDynamicObjC;
 			sourceTree = "<group>";
 		};
-		D1623DACC3E535903FFF1F09759DB50E /* Classes */ = {
+		305E907BDAAD0A2B747115F8EC759173 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				851707713AFD3E95A0F4A2181FE71857 /* Internal */,
-				563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */,
-				28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */,
-				58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */,
-				4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */,
-				7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */,
-				88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */,
-				F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */,
-				0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */,
-				7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */,
-				E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */,
-				7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */,
-				311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */,
+				2DFC4A4D977A4A09C31EF03CA1710FB9 /* NSManagedObject+VOKManagedObjectAdditions.h */,
+				85A9E820E6935083D357741816580489 /* NSManagedObject+VOKManagedObjectAdditions.m */,
+				C3513E78F8D0B751A02A199A9BC52FA9 /* VOKCoreDataCollectionTypes.h */,
+				7155D566D5A064941E35D2E7C10D734D /* VOKCoreDataManager.h */,
+				27D1AFD5B17FDA2A2A175E83B1275874 /* VOKCoreDataManager.m */,
+				4C7925FE6C2B7EBFC2FB3BB590557B0E /* VOKManagedObjectMap.h */,
+				9EC406103C5D6356E7E1641C322CE3BC /* VOKManagedObjectMap.m */,
+				38F2CDD5CFA737B4733B626801826B90 /* VOKManagedObjectMapper.h */,
+				D9F21FE4F2F2217242EEE8EEDA7DC811 /* VOKManagedObjectMapper.m */,
+				BA9924843B153214349674104DE2CB12 /* VOKMappableModel.h */,
+				38883E1232D64CEC9366CAEC8C9395E5 /* VOKNullabilityFeatures.h */,
+				021C257910025191F41A4D43979BF806 /* Vokoder.h */,
+				E9A8A67CF4C33EE106C4748E58F4DE7F /* Internal */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		92AA232EE3E496566240A00B61598355 /* Core */ = {
+		3379A8A40CF7FD9601AD6C418CCE0C61 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				7B6B69F12063310EFEBC024790A2398E /* Pod */,
+				C78FE8F2CFC363943676CC9A2A4445B9 /* Pod */,
 			);
 			name = Core;
 			sourceTree = "<group>";
 		};
-		517BAE0EB2FC6EAB1D352BBA63C2E5FF /* MapperMacros */ = {
+		3A5ADD10C2057887011E042F3D5D404D /* MapperMacros */ = {
 			isa = PBXGroup;
 			children = (
-				B66A8C3BFB903F77BEF8E93ACFB4C101 /* Pod */,
+				3C7CD215A2489F6FC776D0A842B4F95B /* Pod */,
 			);
 			name = MapperMacros;
 			sourceTree = "<group>";
 		};
-		0628D34B912C2431236471EF4C7720C0 /* VOKUtilities */ = {
+		3B5E8C421FE46E1F0E33EA9D8DBA31BA /* VOKUtilities */ = {
 			isa = PBXGroup;
 			children = (
-				FA69128BA538E22FB0AF31EEBAD8D0E8 /* Support Files */,
-				7A433FE6A343961BAD2B564426630D78 /* VOKKeyPathHelper */,
+				C197F38620B9A5B7AD13BD3274305B23 /* Support Files */,
+				9D7BB2BA6115B58F3BAB8172EE53650C /* VOKKeyPathHelper */,
 			);
 			name = VOKUtilities;
 			path = VOKUtilities;
 			sourceTree = "<group>";
 		};
-		B66A8C3BFB903F77BEF8E93ACFB4C101 /* Pod */ = {
+		3C7CD215A2489F6FC776D0A842B4F95B /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				A2E8B182C95CCC90E71CF439B2F7E083 /* Classes */,
+				6C6C16C25D7FDA3C51823DF3C504D8C7 /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		DC48BCE815EC154A59BCA69936CF7135 /* Frameworks */ = {
+		433CD3331B6C3787F473C941B61FC68F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A82DCA28FABF1F9080B1B2234FFB9045 /* iOS */,
+				18C31505F53BCD0CB0F85AB659963013 /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		8EB4618C736DD6BDEC8CFC9A74CBE387 /* FetchedResults */ = {
+		59CC3702664863EA70C6EF8D15C8B361 /* FetchedResults */ = {
 			isa = PBXGroup;
 			children = (
-				478C110C179740FF4A342BF721CA277F /* Pod */,
+				720454545AFB9D694E85438CD02B73D1 /* Pod */,
 			);
 			name = FetchedResults;
 			sourceTree = "<group>";
 		};
-		A2E8B182C95CCC90E71CF439B2F7E083 /* Classes */ = {
+		6C6C16C25D7FDA3C51823DF3C504D8C7 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				050D206B9AEB4DF87D322F72A840A0DE /* MapperMacros */,
+				11BDA25FB5605CB74141B5CF00ECE19F /* MapperMacros */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		6871642A62DD48369704DBF18892621C /* Optional Data Sources */ = {
+		6CECD4D1B2696CA7E7A814C6C0C07C0D /* Optional Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */,
-				CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */,
-				E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */,
-				78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */,
+				057FC67101FA35EFE94B64E0A8821D05 /* VOKDefaultPagingAccessory.h */,
+				E26F92E4B8625F038B4DF8252BCEC98A /* VOKDefaultPagingAccessory.m */,
+				DE1D527341816F007D01C9B89F211DB7 /* VOKPagingFetchedResultsDataSource.h */,
+				19D25D12F89B23754F4CF8409CDD78F8 /* VOKPagingFetchedResultsDataSource.m */,
 			);
 			name = "Optional Data Sources";
 			path = "Optional Data Sources";
 			sourceTree = "<group>";
 		};
-		478C110C179740FF4A342BF721CA277F /* Pod */ = {
+		720454545AFB9D694E85438CD02B73D1 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				0BA6A3697D7736F3A930525826963BB3 /* Classes */,
+				C78E24A3C221781B07C66567CA121523 /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		DC922EC5F6A4C858F3D3657B1D19245D /* PagingFetchedResults */ = {
+		7411776D0D2955862381D41FEA28C209 /* PagingFetchedResults */ = {
 			isa = PBXGroup;
 			children = (
-				2757FE2226489748E1B034F311E8325A /* Pod */,
+				C69B37D94A5AB065E346723178FE5FB1 /* Pod */,
 			);
 			name = PagingFetchedResults;
 			sourceTree = "<group>";
 		};
-		2841E6A5AFA6C5740FA47D68784B43B8 /* Vokoder */ = {
+		7644BAD5589AFB391BDC15F7CC328435 /* Vokoder */ = {
 			isa = PBXGroup;
 			children = (
-				92AA232EE3E496566240A00B61598355 /* Core */,
-				D291960F19FD2FE625E66028614C79A8 /* DataSources */,
-				517BAE0EB2FC6EAB1D352BBA63C2E5FF /* MapperMacros */,
-				21C815DB339F7DD825A5E4CB08881309 /* Support Files */,
+				3379A8A40CF7FD9601AD6C418CCE0C61 /* Core */,
+				12F885C065B0016EC8C6403F5B54BA49 /* DataSources */,
+				3A5ADD10C2057887011E042F3D5D404D /* MapperMacros */,
+				164B46FEABD5FACB26D02FA2A504739E /* Support Files */,
 			);
 			name = Vokoder;
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		C0EADA668804F57D6D9AA862CE8EF321 /* ILGClasses */ = {
+		78B071F64137B3D3A8C2D8406D61F86F /* ILGClasses */ = {
 			isa = PBXGroup;
 			children = (
-				869B5154502141C012BA472A1C847BDE /* ILGClasses.h */,
-				AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */,
+				56C46BC262E57D3C2E20F627216E4169 /* ILGClasses.h */,
+				2368D70EAFC8F21DCF0E6806E43C48A5 /* ILGClasses.m */,
 			);
 			name = ILGClasses;
 			sourceTree = "<group>";
 		};
-		62478C4BCC083549B2675083D4CE14F0 /* Collection */ = {
+		7D9E0FF2D369E5A440547872D410E105 /* Collection */ = {
 			isa = PBXGroup;
 			children = (
-				61BB1467B6A83D6A6A4953981C7A0F3D /* Pod */,
+				90583EAE4B873C596CC2F058001F3D43 /* Pod */,
 			);
 			name = Collection;
 			sourceTree = "<group>";
 		};
-		5DECD2D2DDBCF1DF25E1166EAF85634C = {
+		7DB346D0F39D3F0E887471402A8071AB = {
 			isa = PBXGroup;
 			children = (
-				6D1EB8A38E8CBA4A4B0D3C897A545D0A /* Development Pods */,
-				DC48BCE815EC154A59BCA69936CF7135 /* Frameworks */,
-				A38FF61C71733211E6DDB19385503404 /* Podfile */,
-				1432AA59D8B53139E350543A9C80D7F8 /* Pods */,
-				F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */,
-				27E772C472EE5BD87EA005C1E920FEC6 /* Targets Support Files */,
+				93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */,
+				7E71C6011E315543EE8E3F5A7D6652E5 /* Development Pods */,
+				433CD3331B6C3787F473C941B61FC68F /* Frameworks */,
+				23A1BCFAF0B252A99191D410D963BB63 /* Pods */,
+				90D267E393247B143916E55F57F31D9D /* Products */,
+				088CF97B779ED2E9832E738B6568EE34 /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		6D1EB8A38E8CBA4A4B0D3C897A545D0A /* Development Pods */ = {
+		7E71C6011E315543EE8E3F5A7D6652E5 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2841E6A5AFA6C5740FA47D68784B43B8 /* Vokoder */,
+				7644BAD5589AFB391BDC15F7CC328435 /* Vokoder */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		0D628D92F46B96670EB6FF1B86D31B39 /* Classes */ = {
+		8121C6854DB14C39C5FF177875AE0E96 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				6871642A62DD48369704DBF18892621C /* Optional Data Sources */,
+				6CECD4D1B2696CA7E7A814C6C0C07C0D /* Optional Data Sources */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		61BB1467B6A83D6A6A4953981C7A0F3D /* Pod */ = {
+		90583EAE4B873C596CC2F058001F3D43 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				871C6B29616861FE22F20252EE41CB6B /* Classes */,
+				E4DF510EDE7AF4470C9C7037F59838F7 /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */ = {
+		90D267E393247B143916E55F57F31D9D /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				9CAA01EAE9A9BEAD84FD3014FAC597EB /* libILGDynamicObjC.a */,
-				34CF9C4B25B5F8A784213D7E9738DBDD /* libPods-Paging Data Source Example.a */,
-				F1F509176F65E2C991E7C9308802DB84 /* libVOKUtilities.a */,
-				DA9CD9EB3AA7FF3EBC9A08286E12C900 /* libVokoder.a */,
+				80C68271DEF89D4BD2DA08130AC3DA47 /* libILGDynamicObjC.a */,
+				CE3BB32EC1FDA2C6A8CDDB6AB7233A15 /* libPods-Paging Data Source Example.a */,
+				DE25C4A5E95721E54AC3C15615E4D3FF /* libVokoder.a */,
+				DE2EA331A670D02F22A9EA83ABEB8D91 /* libVOKUtilities.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		7A433FE6A343961BAD2B564426630D78 /* VOKKeyPathHelper */ = {
+		9D7BB2BA6115B58F3BAB8172EE53650C /* VOKKeyPathHelper */ = {
 			isa = PBXGroup;
 			children = (
-				F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */,
-				2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */,
+				1EC04304C7E614F58427D9E3334BC1B7 /* VOKKeyPathHelper.h */,
+				4A0BA8286BC5E47F9AB39B4A32947ABB /* VOKKeyPathHelper.m */,
 			);
 			name = VOKKeyPathHelper;
 			sourceTree = "<group>";
 		};
-		F653198251905F2D19DBEA48B7F9A7DC /* Support Files */ = {
+		B15744ACD24BF7D3C0F8E4D3F6831944 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				801B9204844DE86EC73A5E7EFC5627E1 /* ILGDynamicObjC-dummy.m */,
-				C4902ACEB6F9D234A1C2BF2DA248D53D /* ILGDynamicObjC-prefix.pch */,
-				5ED4077304AB1720B21D628EFD7A11F4 /* ILGDynamicObjC.xcconfig */,
+				EE1CCA35F1E52885C9CD5AC158CB1C71 /* ILGDynamicObjC.xcconfig */,
+				E45006BF2843CDF06D5577882F50178E /* ILGDynamicObjC-dummy.m */,
+				19C33B654D94761943C83F7E92583747 /* ILGDynamicObjC-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/ILGDynamicObjC";
 			sourceTree = "<group>";
 		};
-		6E64A72C77FF954E0048EEA6218BA40E /* Optional Data Sources */ = {
+		B6945C9828D328702E784E17FFBDEF13 /* Optional Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */,
-				809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */,
+				18AFDF4E68EF0C688B4770E0779F89DD /* VOKCollectionDataSource.h */,
+				7D0738CD1D7CEA7757D740197C48EF95 /* VOKCollectionDataSource.m */,
 			);
 			name = "Optional Data Sources";
 			path = "Optional Data Sources";
 			sourceTree = "<group>";
 		};
-		FA69128BA538E22FB0AF31EEBAD8D0E8 /* Support Files */ = {
+		C197F38620B9A5B7AD13BD3274305B23 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				812A6DF58E85CCC1E9280954D46182B9 /* VOKUtilities-dummy.m */,
-				8EBBB96056A220B2BEF1F01EEE84DE2C /* VOKUtilities-prefix.pch */,
-				42FD299E712A65D222D03FF9FA03010B /* VOKUtilities.xcconfig */,
+				56CBEAD7AE66599A3138721A4674FEFE /* VOKUtilities.xcconfig */,
+				546C3A70128ED9F31BCD5F1DA3906E5C /* VOKUtilities-dummy.m */,
+				208E55A092EACAC73837C5A644C397C2 /* VOKUtilities-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/VOKUtilities";
 			sourceTree = "<group>";
 		};
-		2757FE2226489748E1B034F311E8325A /* Pod */ = {
+		C69B37D94A5AB065E346723178FE5FB1 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				0D628D92F46B96670EB6FF1B86D31B39 /* Classes */,
+				8121C6854DB14C39C5FF177875AE0E96 /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		0BA6A3697D7736F3A930525826963BB3 /* Classes */ = {
+		C78E24A3C221781B07C66567CA121523 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				CA9F64BFACD9A6B9EFC6C13F107B6ABF /* Optional Data Sources */,
+				23DF76E159F76DA23AB01D6E8DE44EFE /* Optional Data Sources */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		7B6B69F12063310EFEBC024790A2398E /* Pod */ = {
+		C78FE8F2CFC363943676CC9A2A4445B9 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				D1623DACC3E535903FFF1F09759DB50E /* Classes */,
+				305E907BDAAD0A2B747115F8EC759173 /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		871C6B29616861FE22F20252EE41CB6B /* Classes */ = {
+		E4DF510EDE7AF4470C9C7037F59838F7 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				6E64A72C77FF954E0048EEA6218BA40E /* Optional Data Sources */,
+				B6945C9828D328702E784E17FFBDEF13 /* Optional Data Sources */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		851707713AFD3E95A0F4A2181FE71857 /* Internal */ = {
+		E9A8A67CF4C33EE106C4748E58F4DE7F /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */,
+				E3BF4152F27C9C0DCFEE3F92154B676C /* VOKCoreDataManagerInternalMacros.h */,
 			);
 			name = Internal;
 			path = Internal;
@@ -548,53 +548,53 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		1796AA295D0C21900B10C57B17F2B05E /* Headers */ = {
+		CC75B899D6E3C0EF1AE61BF4BF56378E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A5C22E889A9E7C681C810D7BDE8790D5 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				235B0187FBBF4AE11D3AE502DA0ECD58 /* VOKCollectionDataSource.h in Headers */,
-				576AFEB70C4926DF9D90C402F04C1A91 /* VOKCoreDataCollectionTypes.h in Headers */,
-				26A5F9C895CB34BF97F17CE571E759A5 /* VOKCoreDataManager.h in Headers */,
-				1BFB7C298FD5C3D2FD390190D0ECA769 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				CB4A4C09DE45A0847DA2F19BB3614B00 /* VOKDefaultPagingAccessory.h in Headers */,
-				2C7030DBF426C627A98E271E3996DD9B /* VOKFetchedResultsDataSource.h in Headers */,
-				F0DDF2A2AF18593F10C360BE5443B757 /* VOKManagedObjectMap.h in Headers */,
-				E4F0D448B9ACA0588BA05ECBF3C4E4C9 /* VOKManagedObjectMapper.h in Headers */,
-				D7811F8401C3BF218D6FFF3403DEF1D2 /* VOKManagedObjectMapperMacros.h in Headers */,
-				9DAC5F1FCC91C4B9DA5DE65CD6C06FF9 /* VOKMappableModel.h in Headers */,
-				D88DFF6934B408DB7166E3FE6326D411 /* VOKNullabilityFeatures.h in Headers */,
-				1B49270969167C22DCCCF46AD88EB2DB /* VOKPagingFetchedResultsDataSource.h in Headers */,
-				D5D5268A466A625A4B99B43992B3F7BD /* Vokoder.h in Headers */,
+				D5D910DB011D4193B52B3781534931B0 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				5DD4A80F3E44841EFA1C00601FEDF3C6 /* VOKCollectionDataSource.h in Headers */,
+				51FEC280F9291A1DFB1A57EDA01B6847 /* VOKCoreDataCollectionTypes.h in Headers */,
+				31E7BE2449CED5A01D244BFFAD5379C9 /* VOKCoreDataManager.h in Headers */,
+				868003E58080B29EFB2D6D3790441973 /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				F87938F5D524D1499F4C7A7A8E60DFA6 /* VOKDefaultPagingAccessory.h in Headers */,
+				55AD5D23DBFF050FE51145FD687FE9B5 /* VOKFetchedResultsDataSource.h in Headers */,
+				656840DA5580BE93DD572FAF0205CDCE /* VOKManagedObjectMap.h in Headers */,
+				53316DC21C9788CF466B77B3FDE58485 /* VOKManagedObjectMapper.h in Headers */,
+				FF555B4E3767F382B6FB4A98BA24116A /* VOKManagedObjectMapperMacros.h in Headers */,
+				D34EED6F4E757257CE35031FE69ABE35 /* VOKMappableModel.h in Headers */,
+				5C1F90BCE23204F56623158EAC23392A /* VOKNullabilityFeatures.h in Headers */,
+				DEEDD22C835456A2EAC4C9A1640288A1 /* Vokoder.h in Headers */,
+				35A6F4A9C24E967710598A1C26B31D93 /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D22E50FBE57D326B186A324EF0EAF668 /* Headers */ = {
+		D7BF41AF86BA1F2A15EEDB50CF1A9DE0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E63EFB9B228A5DBAA0A19CAF3F531E93 /* VOKKeyPathHelper.h in Headers */,
+				E0C7F41F8319CB670F28B27E7AC60784 /* VOKKeyPathHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EAFA026208DB7AC9C1EEE9263428BC7D /* Headers */ = {
+		F5065CDB32AB01CC3213136554951510 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				266C2EB085F2A07622C62FB075718E2C /* ILGClasses.h in Headers */,
+				7234CE2D2A7367F8E503A8DD05472D21 /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		69C3F52DD0A5FFBD9C342F59625053AA /* ILGDynamicObjC */ = {
+		1B31289C3C8C09D615F1CCB2E7CEB9B1 /* ILGDynamicObjC */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6D25BA6930540CB15E94ABBAB2C15CF0 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC" */;
+			buildConfigurationList = 843655F1BD17CE6AA3A4B0D0C260E07D /* Build configuration list for PBXNativeTarget "ILGDynamicObjC" */;
 			buildPhases = (
-				E689EC53BCC09E40CBF49B13569C5E18 /* Sources */,
-				15141D10078782C4A107A2CC8490502A /* Frameworks */,
-				EAFA026208DB7AC9C1EEE9263428BC7D /* Headers */,
+				B53A40532506EE128734786971A97702 /* Sources */,
+				3D8678CBA7454C3F3582BB6789616389 /* Frameworks */,
+				F5065CDB32AB01CC3213136554951510 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -602,54 +602,54 @@
 			);
 			name = ILGDynamicObjC;
 			productName = ILGDynamicObjC;
-			productReference = 9CAA01EAE9A9BEAD84FD3014FAC597EB /* libILGDynamicObjC.a */;
+			productReference = 80C68271DEF89D4BD2DA08130AC3DA47 /* libILGDynamicObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		90BFC3EB62262D195CDB4E49D7D0F896 /* Pods-Paging Data Source Example */ = {
+		1B8EA2C5354AF96A5E72CF6E013E7AF8 /* Pods-Paging Data Source Example */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 854C9B6F1E8536F226944DF59A8BF498 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example" */;
+			buildConfigurationList = 338B8614D56FAAABDF1660B1111A61EF /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example" */;
 			buildPhases = (
-				421312D8DF51D4CC05F835904F9BF6B1 /* Sources */,
-				1B080578CDC46257763506AC2A658ADB /* Frameworks */,
+				D8D745B01889F6200FD99BEB585FCDE2 /* Sources */,
+				B9F01EC59731F21257BB4F58A9E80D53 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				31B18520E66DAE635FCC26F85BAB7026 /* PBXTargetDependency */,
-				AABBFEC2FF3F3465ED065C737F0C2474 /* PBXTargetDependency */,
-				282822BC1B5E1E9FEFE5A5A89B03B51D /* PBXTargetDependency */,
+				BD0890E8E8AD434B6951BCEF9C4A5F03 /* PBXTargetDependency */,
+				31E9076D21B3E0DE7EEC924433509DB2 /* PBXTargetDependency */,
+				7168201746A62C0F94B36E315FAA9A41 /* PBXTargetDependency */,
 			);
 			name = "Pods-Paging Data Source Example";
 			productName = "Pods-Paging Data Source Example";
-			productReference = 34CF9C4B25B5F8A784213D7E9738DBDD /* libPods-Paging Data Source Example.a */;
+			productReference = CE3BB32EC1FDA2C6A8CDDB6AB7233A15 /* libPods-Paging Data Source Example.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		BA5E2F05EA983D823D3414221069869D /* Vokoder */ = {
+		4E4DDD31A3C20692C57F11F1A711541B /* Vokoder */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D796A3DA726D8A0C5DFC94A247BDEDEE /* Build configuration list for PBXNativeTarget "Vokoder" */;
+			buildConfigurationList = 5502D28F73ADB71A0C0551D5740DCC16 /* Build configuration list for PBXNativeTarget "Vokoder" */;
 			buildPhases = (
-				48D61696053C90D4304CCE14AD7E6F96 /* Sources */,
-				8952633548A32679835C87BC28DD5073 /* Frameworks */,
-				1796AA295D0C21900B10C57B17F2B05E /* Headers */,
+				C0158FA91399DDCE10D45319142BFB7F /* Sources */,
+				9010A656E0A3D99D15B93C2982E1A690 /* Frameworks */,
+				CC75B899D6E3C0EF1AE61BF4BF56378E /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				C77C5C3C6E92CF56F30CF30BE6CACD4A /* PBXTargetDependency */,
-				14AB4CB86C360F74B3E581E02C31A7EB /* PBXTargetDependency */,
+				62203024C6C9D1C6329545668AAE10D8 /* PBXTargetDependency */,
+				FDBBA52797F4F216C405932356092C01 /* PBXTargetDependency */,
 			);
 			name = Vokoder;
 			productName = Vokoder;
-			productReference = DA9CD9EB3AA7FF3EBC9A08286E12C900 /* libVokoder.a */;
+			productReference = DE25C4A5E95721E54AC3C15615E4D3FF /* libVokoder.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */ = {
+		D8FBCA5BF4CCED24D96FEEFE20B0C031 /* VOKUtilities */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = BFEF623AB493671B39040FD1DBA758AE /* Build configuration list for PBXNativeTarget "VOKUtilities" */;
+			buildConfigurationList = 95A44C00CF7978575913B3DECB1B4CFC /* Build configuration list for PBXNativeTarget "VOKUtilities" */;
 			buildPhases = (
-				530EC35663471E8D1147EC79301EEE0C /* Sources */,
-				D1E0A78515A425ACB73FFF1E5DED5776 /* Frameworks */,
-				D22E50FBE57D326B186A324EF0EAF668 /* Headers */,
+				C20583697F926A405DC3AA18D46A40FE /* Sources */,
+				F971A66389AAD50F1C555E33BB87FBC2 /* Frameworks */,
+				D7BF41AF86BA1F2A15EEDB50CF1A9DE0 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -657,118 +657,118 @@
 			);
 			name = VOKUtilities;
 			productName = VOKUtilities;
-			productReference = F1F509176F65E2C991E7C9308802DB84 /* libVOKUtilities.a */;
+			productReference = DE2EA331A670D02F22A9EA83ABEB8D91 /* libVOKUtilities.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
 			};
-			buildConfigurationList = FC02AE59B0DCC1367E03651BD0868F72 /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 5DECD2D2DDBCF1DF25E1166EAF85634C;
-			productRefGroup = F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */;
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = 90D267E393247B143916E55F57F31D9D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				69C3F52DD0A5FFBD9C342F59625053AA /* ILGDynamicObjC */,
-				90BFC3EB62262D195CDB4E49D7D0F896 /* Pods-Paging Data Source Example */,
-				BA5E2F05EA983D823D3414221069869D /* Vokoder */,
-				7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */,
+				1B31289C3C8C09D615F1CCB2E7CEB9B1 /* ILGDynamicObjC */,
+				1B8EA2C5354AF96A5E72CF6E013E7AF8 /* Pods-Paging Data Source Example */,
+				4E4DDD31A3C20692C57F11F1A711541B /* Vokoder */,
+				D8FBCA5BF4CCED24D96FEEFE20B0C031 /* VOKUtilities */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		E689EC53BCC09E40CBF49B13569C5E18 /* Sources */ = {
+		B53A40532506EE128734786971A97702 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				23DA4A38A0F5999A47726AD2E3A3CB64 /* ILGClasses.m in Sources */,
-				1523ECABEAC8045673063FA3D6E70899 /* ILGDynamicObjC-dummy.m in Sources */,
+				4B97EDF8DDC55632E69053434378C13E /* ILGClasses.m in Sources */,
+				EF81D0F29CED3566725BC381B7BB46DA /* ILGDynamicObjC-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		48D61696053C90D4304CCE14AD7E6F96 /* Sources */ = {
+		C0158FA91399DDCE10D45319142BFB7F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BA01ACF653FD84D67AA2A9F07B7A142E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				95B9BB48A25AB5F7D0AEE23B75C52B90 /* VOKCollectionDataSource.m in Sources */,
-				D36F28073218405C5AC61EFE60512689 /* VOKCoreDataManager.m in Sources */,
-				E0CEEB884037F2326F94FFD21AA555A5 /* VOKDefaultPagingAccessory.m in Sources */,
-				275AFAF4656AB8170B4E6BD5EABF9505 /* VOKFetchedResultsDataSource.m in Sources */,
-				421751C8646B1D9437AF8400FDEF78AB /* VOKManagedObjectMap.m in Sources */,
-				2A12A0F766D622588FB6DBE55D841D51 /* VOKManagedObjectMapper.m in Sources */,
-				0FBF15D82D6887E4507BAEC5AE7D44A5 /* VOKPagingFetchedResultsDataSource.m in Sources */,
-				9B931AD17FA3518651FAB463A8B8D9E1 /* Vokoder-dummy.m in Sources */,
+				D48F607E0C7B508B713CC0E4BE6173F7 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				07B6AF4CD66F19DE73F16B9FC92D8C68 /* VOKCollectionDataSource.m in Sources */,
+				E3F594F70CD4CA9FD8758254055DDFE9 /* VOKCoreDataManager.m in Sources */,
+				E8C4FDFF1F577C2B53047A81177B8374 /* VOKDefaultPagingAccessory.m in Sources */,
+				527315E072F6D5FB7702E07CDEDCBB93 /* VOKFetchedResultsDataSource.m in Sources */,
+				A225E4B6AB1E363B24C2A8F9C0EDFD05 /* VOKManagedObjectMap.m in Sources */,
+				A074F219221CFD806AF5196FA3DCFA47 /* VOKManagedObjectMapper.m in Sources */,
+				DACA210C612AC9DBC16EE93DF9BEB68C /* Vokoder-dummy.m in Sources */,
+				8B78A7AED25057F1FE57C3FCF5702025 /* VOKPagingFetchedResultsDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		530EC35663471E8D1147EC79301EEE0C /* Sources */ = {
+		C20583697F926A405DC3AA18D46A40FE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				388C22BC0C6295739569BEFD0E62A532 /* VOKKeyPathHelper.m in Sources */,
-				13860E57730CB68C980144C1246E8166 /* VOKUtilities-dummy.m in Sources */,
+				D517DD6FFE575B7F4B2028EC248AE99F /* VOKKeyPathHelper.m in Sources */,
+				E3F320698FC3C13A95D50C999324962E /* VOKUtilities-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		421312D8DF51D4CC05F835904F9BF6B1 /* Sources */ = {
+		D8D745B01889F6200FD99BEB585FCDE2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				80598BB0FFF71DD997ACBE95F84179EB /* Pods-Paging Data Source Example-dummy.m in Sources */,
+				2F06156F3BA51E7E4E5F2C445AA2B7E0 /* Pods-Paging Data Source Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		AABBFEC2FF3F3465ED065C737F0C2474 /* PBXTargetDependency */ = {
+		31E9076D21B3E0DE7EEC924433509DB2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = VOKUtilities;
-			target = 7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */;
-			targetProxy = ED52E1F9B8BAB5C3F7D2EB127B326189 /* PBXContainerItemProxy */;
+			target = D8FBCA5BF4CCED24D96FEEFE20B0C031 /* VOKUtilities */;
+			targetProxy = 220FA07538A8AED065D58660DE0DCBA1 /* PBXContainerItemProxy */;
 		};
-		C77C5C3C6E92CF56F30CF30BE6CACD4A /* PBXTargetDependency */ = {
+		62203024C6C9D1C6329545668AAE10D8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ILGDynamicObjC;
-			target = 69C3F52DD0A5FFBD9C342F59625053AA /* ILGDynamicObjC */;
-			targetProxy = BAAD07A27454A07F29747B96469992AE /* PBXContainerItemProxy */;
+			target = 1B31289C3C8C09D615F1CCB2E7CEB9B1 /* ILGDynamicObjC */;
+			targetProxy = 0852D5DBD351AC595E0D4788EADF2C2C /* PBXContainerItemProxy */;
 		};
-		282822BC1B5E1E9FEFE5A5A89B03B51D /* PBXTargetDependency */ = {
+		7168201746A62C0F94B36E315FAA9A41 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Vokoder;
-			target = BA5E2F05EA983D823D3414221069869D /* Vokoder */;
-			targetProxy = 9FC710D4649DAC78809D340455BEA9DC /* PBXContainerItemProxy */;
+			target = 4E4DDD31A3C20692C57F11F1A711541B /* Vokoder */;
+			targetProxy = 33B84D5B0FE284839B7C1C922D485F61 /* PBXContainerItemProxy */;
 		};
-		31B18520E66DAE635FCC26F85BAB7026 /* PBXTargetDependency */ = {
+		BD0890E8E8AD434B6951BCEF9C4A5F03 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ILGDynamicObjC;
-			target = 69C3F52DD0A5FFBD9C342F59625053AA /* ILGDynamicObjC */;
-			targetProxy = 9E56DCA6B81F481ADEA677BD0C427CE9 /* PBXContainerItemProxy */;
+			target = 1B31289C3C8C09D615F1CCB2E7CEB9B1 /* ILGDynamicObjC */;
+			targetProxy = 8FAD4858766994C124CAB046F0120EEB /* PBXContainerItemProxy */;
 		};
-		14AB4CB86C360F74B3E581E02C31A7EB /* PBXTargetDependency */ = {
+		FDBBA52797F4F216C405932356092C01 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = VOKUtilities;
-			target = 7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */;
-			targetProxy = 9E19846C346BFE4CC9BEB3E76B429238 /* PBXContainerItemProxy */;
+			target = D8FBCA5BF4CCED24D96FEEFE20B0C031 /* VOKUtilities */;
+			targetProxy = 703DD5B8297042D8AAC19AE32033EF82 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		78F0498F2AF1B86F8B7B7477CD49552F /* Debug */ = {
+		015A368F878AC3E2CEAE21DDE8026304 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -812,9 +812,9 @@
 			};
 			name = Debug;
 		};
-		53A91932E91666A33E0E28482EF00967 /* Debug */ = {
+		101EFDCC07757C130F0EE55C92D6132F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC30256BDC690C4FDE85E97F341E11E1 /* Vokoder.xcconfig */;
+			baseConfigurationReference = 980A80E264EB995EDFF7E8D3DF50AB8C /* Vokoder.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -835,9 +835,9 @@
 			};
 			name = Debug;
 		};
-		B23C6F35351918F1E9B39A2C809EE826 /* Release */ = {
+		2BEE7E8EFFDB5637470E6850CCF9214E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5ED4077304AB1720B21D628EFD7A11F4 /* ILGDynamicObjC.xcconfig */;
+			baseConfigurationReference = EE1CCA35F1E52885C9CD5AC158CB1C71 /* ILGDynamicObjC.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -858,9 +858,9 @@
 			};
 			name = Release;
 		};
-		D78EF48B0F3173A8EFECFE2C804D4354 /* Debug */ = {
+		337A967EA0D135E56A48196418237922 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 42FD299E712A65D222D03FF9FA03010B /* VOKUtilities.xcconfig */;
+			baseConfigurationReference = 56CBEAD7AE66599A3138721A4674FEFE /* VOKUtilities.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -881,9 +881,9 @@
 			};
 			name = Debug;
 		};
-		0F09218617B76EFF095DF51C162A75C3 /* Debug */ = {
+		365F7147CA099A6B83038CB4A193DEB4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5ED4077304AB1720B21D628EFD7A11F4 /* ILGDynamicObjC.xcconfig */;
+			baseConfigurationReference = EE1CCA35F1E52885C9CD5AC158CB1C71 /* ILGDynamicObjC.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -904,7 +904,7 @@
 			};
 			name = Debug;
 		};
-		29915A707A12A2C46DAA846C396CAB6F /* Release */ = {
+		44CDBB6D11DE06DB64D6268622BDC47E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -944,9 +944,9 @@
 			};
 			name = Release;
 		};
-		F1604B5A420366B3084577C7945FDA8D /* Debug */ = {
+		6664E1DF9B20EFD93DCE04B59A114C1C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C12B1D4858B55AA4DA1FAFD63227B2F3 /* Pods-Paging Data Source Example.debug.xcconfig */;
+			baseConfigurationReference = 560ADA6B376E62F39B3220D7E9DB5ECE /* Pods-Paging Data Source Example.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -967,9 +967,9 @@
 			};
 			name = Debug;
 		};
-		661CE797A8B50E558DA9702A2D0E9E2E /* Release */ = {
+		7B3F8FDF879519CB023EB6DE13C76887 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC30256BDC690C4FDE85E97F341E11E1 /* Vokoder.xcconfig */;
+			baseConfigurationReference = 980A80E264EB995EDFF7E8D3DF50AB8C /* Vokoder.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -990,9 +990,9 @@
 			};
 			name = Release;
 		};
-		B84D6CE021622699F6F2D4FF8F84937C /* Release */ = {
+		AC783633B3024DAB37D52E7B7BED4DA9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 18C54104344AC33572BB25A436C144F8 /* Pods-Paging Data Source Example.release.xcconfig */;
+			baseConfigurationReference = 65900821EAD1DDD584635E06C1BD834F /* Pods-Paging Data Source Example.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1013,9 +1013,9 @@
 			};
 			name = Release;
 		};
-		CA4F131465F9EC80A985ECD3CFF50214 /* Release */ = {
+		D6AC558F4AE48A3EC33E942750E84675 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 42FD299E712A65D222D03FF9FA03010B /* VOKUtilities.xcconfig */;
+			baseConfigurationReference = 56CBEAD7AE66599A3138721A4674FEFE /* VOKUtilities.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1039,52 +1039,52 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		FC02AE59B0DCC1367E03651BD0868F72 /* Build configuration list for PBXProject "Pods" */ = {
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				78F0498F2AF1B86F8B7B7477CD49552F /* Debug */,
-				29915A707A12A2C46DAA846C396CAB6F /* Release */,
+				015A368F878AC3E2CEAE21DDE8026304 /* Debug */,
+				44CDBB6D11DE06DB64D6268622BDC47E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		854C9B6F1E8536F226944DF59A8BF498 /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example" */ = {
+		338B8614D56FAAABDF1660B1111A61EF /* Build configuration list for PBXNativeTarget "Pods-Paging Data Source Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F1604B5A420366B3084577C7945FDA8D /* Debug */,
-				B84D6CE021622699F6F2D4FF8F84937C /* Release */,
+				6664E1DF9B20EFD93DCE04B59A114C1C /* Debug */,
+				AC783633B3024DAB37D52E7B7BED4DA9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D796A3DA726D8A0C5DFC94A247BDEDEE /* Build configuration list for PBXNativeTarget "Vokoder" */ = {
+		5502D28F73ADB71A0C0551D5740DCC16 /* Build configuration list for PBXNativeTarget "Vokoder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				53A91932E91666A33E0E28482EF00967 /* Debug */,
-				661CE797A8B50E558DA9702A2D0E9E2E /* Release */,
+				101EFDCC07757C130F0EE55C92D6132F /* Debug */,
+				7B3F8FDF879519CB023EB6DE13C76887 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6D25BA6930540CB15E94ABBAB2C15CF0 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC" */ = {
+		843655F1BD17CE6AA3A4B0D0C260E07D /* Build configuration list for PBXNativeTarget "ILGDynamicObjC" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0F09218617B76EFF095DF51C162A75C3 /* Debug */,
-				B23C6F35351918F1E9B39A2C809EE826 /* Release */,
+				365F7147CA099A6B83038CB4A193DEB4 /* Debug */,
+				2BEE7E8EFFDB5637470E6850CCF9214E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BFEF623AB493671B39040FD1DBA758AE /* Build configuration list for PBXNativeTarget "VOKUtilities" */ = {
+		95A44C00CF7978575913B3DECB1B4CFC /* Build configuration list for PBXNativeTarget "VOKUtilities" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D78EF48B0F3173A8EFECFE2C804D4354 /* Debug */,
-				CA4F131465F9EC80A985ECD3CFF50214 /* Release */,
+				337A967EA0D135E56A48196418237922 /* Debug */,
+				D6AC558F4AE48A3EC33E942750E84675 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 }

--- a/SampleProject/Podfile.lock
+++ b/SampleProject/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (5.0.0):
-    - Vokoder/Core (= 5.0.0)
-    - Vokoder/DataSources (= 5.0.0)
-    - Vokoder/MapperMacros (= 5.0.0)
-  - Vokoder/Core (5.0.0):
+  - Vokoder (5.0.1):
+    - Vokoder/Core (= 5.0.1)
+    - Vokoder/DataSources (= 5.0.1)
+    - Vokoder/MapperMacros (= 5.0.1)
+  - Vokoder/Core (5.0.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.11.0)
-  - Vokoder/DataSources (5.0.0):
+  - Vokoder/DataSources (5.0.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 5.0.0)
-    - Vokoder/DataSources/FetchedResults (= 5.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 5.0.0)
-  - Vokoder/DataSources/Collection (5.0.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (5.0.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (5.0.0):
+    - Vokoder/DataSources/Collection (= 5.0.1)
+    - Vokoder/DataSources/FetchedResults (= 5.0.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 5.0.1)
+  - Vokoder/DataSources/Collection (5.0.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (5.0.0):
+  - Vokoder/DataSources/FetchedResults (5.0.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (5.0.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (5.0.1):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.11.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 36b3c173b1f8933aebd419ff6e740fece076be06
+  Vokoder: 2e571a4e2290fdf9431d923ae6be2fd094f3ab0f
   VOKUtilities: e831207f9217bd8060467d28f26b5f7a902db63c
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "5.0.0"
+    "tag": "5.0.1"
   },
   "platforms": {
     "ios": "8.0",
@@ -95,10 +95,11 @@
       "name": "Swift",
       "platforms": {
         "ios": "8.0",
-        "tvos": "9.0"
+        "tvos": "9.0",
+        "watchos": "3.0"
       },
       "dependencies": {
-        "Vokoder/DataSources": [
+        "Vokoder/Core": [
 
         ]
       },

--- a/SampleProject/Pods/Manifest.lock
+++ b/SampleProject/Pods/Manifest.lock
@@ -1,26 +1,26 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder (5.0.0):
-    - Vokoder/Core (= 5.0.0)
-    - Vokoder/DataSources (= 5.0.0)
-    - Vokoder/MapperMacros (= 5.0.0)
-  - Vokoder/Core (5.0.0):
+  - Vokoder (5.0.1):
+    - Vokoder/Core (= 5.0.1)
+    - Vokoder/DataSources (= 5.0.1)
+    - Vokoder/MapperMacros (= 5.0.1)
+  - Vokoder/Core (5.0.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.11.0)
-  - Vokoder/DataSources (5.0.0):
+  - Vokoder/DataSources (5.0.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 5.0.0)
-    - Vokoder/DataSources/FetchedResults (= 5.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 5.0.0)
-  - Vokoder/DataSources/Collection (5.0.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (5.0.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (5.0.0):
+    - Vokoder/DataSources/Collection (= 5.0.1)
+    - Vokoder/DataSources/FetchedResults (= 5.0.1)
+    - Vokoder/DataSources/PagingFetchedResults (= 5.0.1)
+  - Vokoder/DataSources/Collection (5.0.1):
     - Vokoder/Core
     - Vokoder/DataSources/FetchedResults
-  - Vokoder/MapperMacros (5.0.0):
+  - Vokoder/DataSources/FetchedResults (5.0.1):
+    - Vokoder/Core
+  - Vokoder/DataSources/PagingFetchedResults (5.0.1):
+    - Vokoder/Core
+    - Vokoder/DataSources/FetchedResults
+  - Vokoder/MapperMacros (5.0.1):
     - Vokoder/Core
   - VOKUtilities/VOKKeyPathHelper (0.11.0)
   - xUnique (4.1.2)
@@ -43,7 +43,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 36b3c173b1f8933aebd419ff6e740fece076be06
+  Vokoder: 2e571a4e2290fdf9431d923ae6be2fd094f3ab0f
   VOKUtilities: e831207f9217bd8060467d28f26b5f7a902db63c
   xUnique: 7f74d3f52c7769f648aa7be8fe614fc27dba2405
 

--- a/SampleProject/Pods/Pods.xcodeproj/project.pbxproj
+++ b/SampleProject/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,741 +7,741 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		015BBE42BFA94926F1821BFC2A834CCB /* VOKUtilities-iOS10.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 11A1254258740229172AFBF17D09766B /* VOKUtilities-iOS10.0-dummy.m */; };
-		02C17E48E81042FF7E0CDC7A0044B8DD /* ILGDynamicObjC-tvOS9.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B508BB2C656A01663ED09C2BD6DBF60D /* ILGDynamicObjC-tvOS9.0-dummy.m */; };
-		0B8E8252A6484F5339CE6F6436FBD788 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0D633BB1E4976903E38F8E0EC784F61C /* VOKUtilities-tvOS9.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B4EFDCF5E3A1C9DE1EF57F56A5E89A9E /* VOKUtilities-tvOS9.0-dummy.m */; };
-		0D6D534E3C9B6A84580A6D6BFEEE81E2 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */; };
-		0DB6A46CE2F6D5966ED8D9DF06BA2B55 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 401D2715E3ECF45767B49F2CC295F881 /* Cocoa.framework */; };
-		102913FD8409E29E0857C47DC3FE6CC6 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		105324934B4128CE7CBC26B7FB46BDE7 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 869B5154502141C012BA472A1C847BDE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		136A13665F8140A0E702D36C3ACE10F0 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		16C1BECEE727060D40104163A5DBA865 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		192827E20FC8446D657674ECE07A2278 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 82172DDFD8E6F88B65EEA9534A3D9C8F /* Pods-VOKCoreDataManager Tests-dummy.m */; };
-		19C6F9213120B51921B2001439610850 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1D1C379F62C74BF3030BF8A98437E23F /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */; };
-		1E8FE3F1ACB7EFA1F57408FA4C8035A4 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */; };
-		1F446BC724AA574735515ABA0A62BD3B /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */; };
-		1FCBC3AD47AD6DA601E7AD4A30B72C4F /* Pods-VOKCoreDataManagerTests-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BAD21DFB02DACBE61BE0CD79929B2470 /* Pods-VOKCoreDataManagerTests-OSX-dummy.m */; };
-		214F4C2D6C242E0E441A192C815B3F3B /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 41449AC4115C95FEE99A662AE575B165 /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m */; };
-		23A3F749BC20D5AAFC7473C690FEC1DB /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		24899E5C7C373E520C5A2A2226B2CEDE /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */; };
-		25A26D9A0D6EFC10694241426DC0340B /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2695889BADE02B8AC583B63359F06683 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		2AC32D5CD6EECA4FDF09E97E71B2E7E3 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2AE16A81FDE3E16BA4D57DC7888E73DE /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		2AFED2B8BD3BE82221630075961A8D76 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */; };
-		300E953DC4BC3AB71E97A7B92966A920 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A822E5E3CDFCC86FEC214C99131A21 /* Foundation.framework */; };
-		30A87AFCB2D8E58514FF3A19FDF2DACD /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		328D82E9C9E74292D46425A8900AA83F /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */; };
-		3527695D7B12A691EC1AEFC11738A11C /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */; };
-		35E439CDE0EA2E8D8CA03208A4322FE6 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3683D33FADF42CDF5DAF4DF8704A65E2 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		368E58C6248101C84FE13EBBE8B6014F /* Pods-VOKCoreDataManager-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C1EAC16934CC93F3643B1C1FEDFF267 /* Pods-VOKCoreDataManager-dummy.m */; };
-		3C27EA94898EEFB47778570C486D5B35 /* Vokoder-43a9e09e-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 82E3E7B746BAE97CD6D2774290142ED7 /* Vokoder-43a9e09e-dummy.m */; };
-		3CEC4C3BC960907305B96B5B2355A869 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */; };
-		3D0F4F8AFA033477C7F49C19EB71A3C1 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */; };
-		3DAFA123AB6A7D1605F576918F8C34A4 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */; };
-		3FC971C123FD795E6A6D3C84F84C09FF /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		404F5F1A6209F7ABC31638636519FDFC /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4239E3D796DBEB48EC3ADFF756E05681 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43340EBBBA56CF713DE87D4A27A70260 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		433EC4F0966D6AF0E2678002DC4DF599 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		450496251A7BA2B3D37F34CD778C15DD /* ILGDynamicObjC-iOS10.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DA0098176104446F883E6B65527B8A0A /* ILGDynamicObjC-iOS10.0-dummy.m */; };
-		47AF74A30219D8E2076AA00A4E56ECF4 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 869B5154502141C012BA472A1C847BDE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49E7BEAE60F1613EF5BABD50C4519B32 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4BA15FD945CC92F7509238BFBC6515C6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A822E5E3CDFCC86FEC214C99131A21 /* Foundation.framework */; };
-		4BB8B30D2384397342319A5697096481 /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4D7C401D667BC2094B0EA7EB3DFAE62D /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		51D9BFAC3685013BA5B9634B41F0F0B1 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		51F1C73A6185E598217E542E7B966858 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		52A56FC44DCDCE5B2608F03C08A550AA /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		54D25B7DEDC9EEDD0E0447751BADCD9D /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		5675C02FADF11EB8E8320E724210568E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		580ABAC13B4E0CEB6442AD966649F566 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5EF2E643525616EC375997F2AEB86E21 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		5F64111A607C3D3BCE72102ECA78A186 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5FA9D810CBA6CB60F9CFF263537BE456 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6082D08DD0989F4878E96EDBAEB58D75 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		63C2DFA4D17315DA6C2F184BBFE01E68 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */; };
-		646185927EEADF2E613EC05CE8427C3C /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		65B1ED16AD8C7AA351BF7A872F698F8C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 401D2715E3ECF45767B49F2CC295F881 /* Cocoa.framework */; };
-		661AA59429E5B2429E31E1F3C8922F62 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6993215C457638263962E17F9A066163 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EFCE4C7258AA749F7C0C8C56D0A0238 /* Foundation.framework */; };
-		6A94241FDA929C3910C83340DBA1FFB7 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6BC44C54E5C93449DCB60B431603D2C3 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6BFB756F3ED0144E84460516CB9F2284 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6C572325A94536A585E7F47782D128D3 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D66700B3B5B4A7EFB769D3E32840214 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D9831C017C990F306AE2D41405A196A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		6F7EA85D6C7B663B30B1A68F13CFBC91 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */; };
-		737E72C5560B397AFE2854856EDE2F00 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */; };
-		73B495A12E1D082D07127884FE661CC0 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		743A42FB1870BBCDE66EA244C6D2B81A /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */; };
-		764C6548E7C26D41B6A1AA84C02E733E /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 869B5154502141C012BA472A1C847BDE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7DA51D377B082021229C4E59AD384750 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7E73528BC9653F858835FC74B8E93063 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		825286991F22E1D3962B06DB2F2BC854 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 401D2715E3ECF45767B49F2CC295F881 /* Cocoa.framework */; };
-		82972C8DF6F0563ABDDB62132CF36A74 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		82CB600A6F80FBF198559733390B7A68 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		87CF3DA899E4ED32C2217846DA0940BC /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */; };
-		88F1AF7CBF905B732BE982C0D9CEB776 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8AB1E0FA4075C8EA532569E104BE907F /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8C3697DC2708F6A9515D10821A9BFD6A /* ILGDynamicObjC-iOS8.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D13E5AD07A409EAF8DC80F587980045 /* ILGDynamicObjC-iOS8.0-dummy.m */; };
-		8CAEDA327441BF6F947A05F997561523 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */; };
-		8CE2D0975555809CBEF58B9A53FBBFEE /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8DC8CFF0376475766C1ACD8FDF349B85 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8DC9917D6046F9F367ED866AA41974F6 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8E2A4AC0207764AF17B9A5A1C780C924 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */; };
-		93B5712DEEAFDA5F6AAD1601B3B573D6 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */; };
-		957A152E45E1CDDB3B74699DD166448A /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 50A3B698A62926F6226DDBBAB560654C /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m */; };
-		97CD56264D4CD533431CCAE366E2D8A5 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		982646390A255AAB33BBCB49BF88037E /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		990EF069A00A89658C3E15A51F6B89BB /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9B1BC00446877E2EBABDAF764C3DD74C /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9D4D7E8EFD7E36D37FCC4752A1FBAF0E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		9F192D20C860B1FA484395CE0837B1A3 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 869B5154502141C012BA472A1C847BDE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A11FD9C14B7FFC323F364B560147150D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 401D2715E3ECF45767B49F2CC295F881 /* Cocoa.framework */; };
-		A336E042B5EC6EF76642EA16D66CC52C /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A627DE01714BC5F9572E3B77355FB1DD /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A66A81E509C40E74D7AA088CCC1FF9FB /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BEF41F9488CF0AD0F1BEAB977EE1344 /* CoreData.framework */; };
-		A6B2315F61D59B21A1D49241A8D822B7 /* Pods-TodayWidget-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F599B152C838E6E92557EDDA9F762C8 /* Pods-TodayWidget-dummy.m */; };
-		A786F7556ADB2F74928A06234C3B0A84 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		AA44657EBC16F5C70D8D07D1462943F1 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */; };
-		AABD791CF6702F076ECD3048EF012B5A /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB7DB2BBA5BE2D21A21BC6E4B8250F57 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AC04F0E852D7B83913B858685460647D /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		AE70C3C7996645F4117D2CEAE4D04C51 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		B13D10AF163463F562D484379EF34F55 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		B1870391FEF30266A0F1F2CD9C29FBA9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		B391D74BB0D53B921FB76F6BEB0BF9D9 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */; };
-		B3DF21D53EC610FE5B6DF93359FDEBCF /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3F141B0753647F2470E96894D689ED6 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */; };
-		B497BC62DCD171CDC0C409B13953DAA6 /* Pods-VOKCoreDataManager-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 15E61F3ED71D4BB874AA0377FFD6913A /* Pods-VOKCoreDataManager-OSX-dummy.m */; };
-		B6A7F88E8EB4CAF611479203471DCCEC /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B880CE05CBF6CB5787D15CC4C1279BED /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC3D524F479824F5723A9C436E28048C /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD4C0158BCDF677CA84DAA2E53A014FB /* ILGDynamicObjC-watchOS3.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E646F53576D2B76A6A6E9AD7DF6C4B29 /* ILGDynamicObjC-watchOS3.0-dummy.m */; };
-		BDD8B57802D9673AD52A1A618EC6CF6F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		BFA780DB964CC6548028BC651EBDBAD7 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */; };
-		BFFC6F2B83E4C3F7EF1C36C2D16963D3 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C10529D65C356EE3CD99FA101CF447F9 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C160E43F9E41DBFA0084624063595E9F /* Vokoder-07029ee6-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE627662872CB24AE24EF8A1B15A39E /* Vokoder-07029ee6-dummy.m */; };
-		C4E230C6A457F5D7E9D9926EA4CFE4AC /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */; };
-		C612D5C5557BEA33C16C7860EAC6D4F1 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */; };
-		C7594F21A0AECD01716AE7F09DD30209 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EFCE4C7258AA749F7C0C8C56D0A0238 /* Foundation.framework */; };
-		C7D068D4C3096A23658D151F27585D53 /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C7F5A068F59705FB447E5800A18B060F /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		CBE797E25E2F634657C2CAAAA417E47B /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		CC8BEC105AB9F9D7E46AC59F3869E9FC /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */; };
-		CDF0D559D34D81876583BE5BFE7A0855 /* ILGDynamicObjC-OSX10.9-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C9E87A90A0263D062114FF0A770907E3 /* ILGDynamicObjC-OSX10.9-dummy.m */; };
-		CF06EAB5B6A9FBA5DA323D9463DA8402 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CF754E7FE7B0B17866101A901249CA5F /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CFD75FEDECEF49045B045B57312E9A39 /* Pods-WatchApp Extension-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B7E1436723B14D27E6BA24BED48AC926 /* Pods-WatchApp Extension-dummy.m */; };
-		D0B168BA95EA50F98E6E19D52907AA11 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */; };
-		D3AA6E8F956F717D5784C2830AFF84CF /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */; };
-		D3E5E5E0698E1423CF8F9362F1A2C29F /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1B58FA45A045846147421FED31002DE /* CoreData.framework */; };
-		D43A99C4866F631713F400CA853E0E38 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D44AF48CA0114A2575C23316F4A3224A /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D5EC9CB32DBB33F12D67FFE4A3CAB139 /* VOKUtilities-OSX10.9-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E58709DA76AFCA54DD99E99F8816216 /* VOKUtilities-OSX10.9-dummy.m */; };
-		D75303B44B7B76E232F84677347B76D0 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */; };
-		D7DE79A214E3100E67063F537318A98A /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */; };
-		DA7F7DC776B03695CC8379939C5650DB /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2906A391168DB65AA73E4991C4B823D /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */; };
-		E357871430EED2E5414653E43C632156 /* Pods-VOKCoreDataManager-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D027326B67067ACEBDBE37DB79F7385 /* Pods-VOKCoreDataManager-tvOS-dummy.m */; };
-		E357EDDBD070B2292E1604F0B471F8BC /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E3979A80852AD1EEFC4E5A7D3C6AA3A7 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E3B3136AFD1DAC359D11181B486F30B9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A822E5E3CDFCC86FEC214C99131A21 /* Foundation.framework */; };
-		E42DD2BCC077F4FF1ABAE9BC8B740D63 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 869B5154502141C012BA472A1C847BDE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E497F680C4A49AE22A92AE5CBC8645F3 /* VOKUtilities-watchOS3.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 26E4FE111178C5C067F328C472B591B8 /* VOKUtilities-watchOS3.0-dummy.m */; };
-		E58204A8205C8159D1F6DA3FE719D2AB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		E5B3BD49B499D9E3E6199D637EFF7951 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E78C5052267BCCFBEB22F27B3A00EA9F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 401D2715E3ECF45767B49F2CC295F881 /* Cocoa.framework */; };
-		E7D998634E2AA6974F94679E1626C875 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EFCE4C7258AA749F7C0C8C56D0A0238 /* Foundation.framework */; };
-		EA8404FBB154BDD8AD3291C091219768 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EB4EF7DBB9AC285B1AFEC184281D3275 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EC7F3ECA4D305DECC73D835A569716A9 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */; };
-		EC7F497C62BBB4BE68D4DEF68E2AD775 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ECE9BEE23769E966643C8CFF01F092A6 /* VOKUtilities-iOS8.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F920122B363EAB2F5D908F0E79FDF3D /* VOKUtilities-iOS8.0-dummy.m */; };
-		EE0F115D4931F05A794E9B3DBB3E887A /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9A34B73FE8744709086EEDE7B8E260E /* CoreData.framework */; };
-		EFAA0FA4E463363BF9693C38FFD0DE01 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
-		F28F423A4D4ABFB740076745484CC9FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EFCE4C7258AA749F7C0C8C56D0A0238 /* Foundation.framework */; };
-		F45762EBBE9E98DAC699E0C2F5990295 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */; };
-		F4678503D054BDFB079984BC0AC40797 /* Vokoder.root-Core-MapperMacros-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BA27034E65288609E599B4DA7D5DFC9 /* Vokoder.root-Core-MapperMacros-OSX-dummy.m */; };
-		F5082391EE2F2C0236D080F3858FD701 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */; };
-		F5F23DA6453D28D95E8A733A85601B1C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A822E5E3CDFCC86FEC214C99131A21 /* Foundation.framework */; };
-		FECC27CF48BAFBF6963E3758318D97B3 /* Vokoder-fdc3d3be-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90FCCF9E010C8FB81278273CB8C6BE /* Vokoder-fdc3d3be-dummy.m */; };
-		FF0BD2F894A5249B34F67C7D74EE3259 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A822E5E3CDFCC86FEC214C99131A21 /* Foundation.framework */; };
+		0043FE7AD08748391DC5DFB5C41D37B3 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C43930A300BDD6E51802E60CCCB0D0BA /* VOKCoreDataManager.m */; };
+		020A36006AD71205E39454FEBD88FC3A /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C43930A300BDD6E51802E60CCCB0D0BA /* VOKCoreDataManager.m */; };
+		045626A337D27B79B5F1DFA71B4E41D0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91DC91E6AC68D30020C930507DB0AA6B /* Foundation.framework */; };
+		055381161947320FF982032C6901FAD2 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D4814650D73EC866488F54A2D67E18 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05903515DA8BF3144444CE0344774AA3 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = D91D5E5463F76934D51AB2FFC59D546C /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0614BE18B71FDC76A97372A209182A8E /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 0722BD137224E95065B72D89C2AFBCFD /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		062132CC3C87B3DF9F0F432E53C6913A /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 83A5210A54A780630BFCCE098510222D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0708A9547A437E1C1DE62A0FC7EEC188 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48DA15F76198935F143046A92BF85D5D /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		075E3DB64E8F1E44279EB9885FA4C4FD /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C80C1AF1B4A51B665AC7646313D71FA /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		087B92FCA40D5EAF5DF821EE4FABB13F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		0915349CC81E429185BE68BD93586F9D /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCC0FF64C3F3E287CEAECA22685202E8 /* CoreData.framework */; };
+		092F5C8938E1FED36CE9F9EE0F700B22 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C43930A300BDD6E51802E60CCCB0D0BA /* VOKCoreDataManager.m */; };
+		0994703F9794794765C0762F51907088 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		09A2D5475AB84629A5759CB402C103DE /* VOKUtilities-OSX10.9-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = ACC93AC3354867D4E1A9EA57B514B986 /* VOKUtilities-OSX10.9-dummy.m */; };
+		0B7E0EF27CD0C885C9E76EF954C0404A /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C482370A22662EBCBDABF143AE65DA1 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0D5E14E5142F40C5A4FA2BE16FAFC1BE /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F16018059E07FFE33BA6CAE4B20A3FE /* CoreData.framework */; };
+		0D99D3E84C86BA048BA1E87D94682495 /* Pods-VOKCoreDataManagerTests-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B35AEEFA32F827F824257B551216CA40 /* Pods-VOKCoreDataManagerTests-OSX-dummy.m */; };
+		0E5FD0E8D0F597F599EEE9927A095A85 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 310E3889F83DDE730396B90732C5C8B0 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F0425993229B187D8C29E97B38404F5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		0F1E4FF3C5CFE7758201499C49DE7353 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C80C1AF1B4A51B665AC7646313D71FA /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F5E25E490B231D230E46DD857414BE4 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D4814650D73EC866488F54A2D67E18 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		102521CC5059C5AAA27EC264AA2DEBF5 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2F5E5AD6B5231F5D7DA2650C39E582 /* VOKPagingFetchedResultsDataSource.m */; };
+		114C8C290140EACA1E13689FE841EB7A /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 0722BD137224E95065B72D89C2AFBCFD /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		152BE1FFA7D8E4E3E33678B5BEEAABDC /* Vokoder.root-Core-MapperMacros-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 02EE4FC2B5A5C8BF8A41098711CFFB96 /* Vokoder.root-Core-MapperMacros-OSX-dummy.m */; };
+		16262B39AA2AA453DCBB2FD9B53678ED /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48DA15F76198935F143046A92BF85D5D /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		181B1103B946F695FEEB82B144459C43 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 0722BD137224E95065B72D89C2AFBCFD /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		185687C1B9E198D61705197900787A55 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = A51D6B1CB24680567D407CAA0F7A1ACE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18FF370C45EB051762823DCA194535E8 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4109FF539D2341CA5287721D8D377E01 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		197758005952E38D8ABD8781B3AA73CB /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 83A5210A54A780630BFCCE098510222D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		19DA9D8F384558D4199EFDE072150B2E /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48DA15F76198935F143046A92BF85D5D /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A0F635AAAF25DAD5ED50BCDFC593017 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2797C5EFB0D6E418F204877116937884 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BDB18C364B819D884ED267A7DB0E154 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		1F91350CA25BCF86BB981C41C563A117 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E11CB0B4AE91356599EC30A92B9972A /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		22044B2E84C5C08AA2B0EEC6739E2CDF /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = BBC4DD83586D3E0AFB4994434004972E /* VOKDefaultPagingAccessory.m */; };
+		22FEFFCBA024BDABCB4A81B643D5E9F0 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 77118E2573E1FBFEB6E82786750837EE /* Pods-VOKCoreDataManager Tests-dummy.m */; };
+		2545C926DC79561CFC8F96C3C3375B35 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = BDDF3ADA1E4AEB030434A241FD4B8B8E /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		262656E6C44D5BF8ED537569C0485A8E /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 039E65118EEA36942D15DABBB9EAACB4 /* VOKManagedObjectMapper.m */; };
+		272BF390524C5F027ED7A56AA4E8AECB /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 039E65118EEA36942D15DABBB9EAACB4 /* VOKManagedObjectMapper.m */; };
+		27ED44F8CB5177E06D40ABEB98DB9344 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2797C5EFB0D6E418F204877116937884 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		283AAF6F553CFEFA0CF98CC97F3FC0A1 /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAB26DA0FB2C2CF6F3E8B966842D337 /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2884EF1D66ADBA9A5E55A302560743F1 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DEE798B4DA83762C29CD7D8D3730B0E /* VOKKeyPathHelper.m */; };
+		28D90A83F48C78266B3D16B6AD7B7D6E /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = D91D5E5463F76934D51AB2FFC59D546C /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A2B5DD963AAA6A719405BE367E273DF /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C43930A300BDD6E51802E60CCCB0D0BA /* VOKCoreDataManager.m */; };
+		2C9B869BC7B4B6354C249A113052AF0E /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 310E3889F83DDE730396B90732C5C8B0 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2CAB3BA54169F354B75C445E00DC15F0 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = A51D6B1CB24680567D407CAA0F7A1ACE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FF66D88F81B19690D787F39DAFDBDBB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91DC91E6AC68D30020C930507DB0AA6B /* Foundation.framework */; };
+		3067BD2FA5D93D794C60CAC9512AFCBB /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 521A958366FF5BF44A89EC736B34CFB9 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		31144D7C864E9C71A1AE05520A41EABF /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 83A5210A54A780630BFCCE098510222D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3421361269D50A7C604C1C97131722FF /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 310E3889F83DDE730396B90732C5C8B0 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		365F7E4646F2CB26AF7B47DC37AA007C /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D4814650D73EC866488F54A2D67E18 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		37E40A24D21A090DD555C02F5D5622E7 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89716B6A96D24231D00AB0C8F2B7C2EE /* CoreData.framework */; };
+		38E957667B2456F7B44001810C03D386 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DEE798B4DA83762C29CD7D8D3730B0E /* VOKKeyPathHelper.m */; };
+		3B871640BF0C077EC885436F77B78A4C /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A537D9F722B61F040A86A633A1ADEB5C /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m */; };
+		3C8181EA60CA01A9B891CC07714CD65D /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = D91D5E5463F76934D51AB2FFC59D546C /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		41AC1C753734F5ACB72BE76EEC9715BD /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 227F6BBE28D179CB31B4DF636979A543 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		4261FB58BBD05574EFE10742F6E9F019 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 227F6BBE28D179CB31B4DF636979A543 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		427330AE02FEEF4CC0F4576238A8CEC5 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = A2C0960CFA72441F03306FC9EC955F8C /* VOKFetchedResultsDataSource.m */; };
+		427CC9F51B4BC30F06148398B96BD0EC /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D4814650D73EC866488F54A2D67E18 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4442A6241A5019972E93609DBEB0AFDD /* VOKUtilities-iOS8.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EE09513D5B1E4CD4EA4BAC37980EF5C6 /* VOKUtilities-iOS8.0-dummy.m */; };
+		4562A8D722C9120C7C11815DED286ED5 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2F5E5AD6B5231F5D7DA2650C39E582 /* VOKPagingFetchedResultsDataSource.m */; };
+		480A9D9EEF9011CCE25D1ABCC25B1391 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E11CB0B4AE91356599EC30A92B9972A /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C5706B51658C650212796AA4751CDF7 /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAB26DA0FB2C2CF6F3E8B966842D337 /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CE974ED5A7BE92BBEF22924BEC1DCD8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		4D7EC6BDD1B548A7C597667B24173EB7 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = BBC4DD83586D3E0AFB4994434004972E /* VOKDefaultPagingAccessory.m */; };
+		4EEDF0D502A1B69C1E22DA082DA7BF45 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D425622BFD2229DC889BD761596FA01D /* Cocoa.framework */; };
+		4FD52C961B0424802F6F5FD7EFD2D545 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 0722BD137224E95065B72D89C2AFBCFD /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4FFA3BFBCBDEF88E8799354FAFAA0E0F /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DEE798B4DA83762C29CD7D8D3730B0E /* VOKKeyPathHelper.m */; };
+		52B982C1F9EB5AC57849D25CB08EF653 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D425622BFD2229DC889BD761596FA01D /* Cocoa.framework */; };
+		5594EED99914945B42D5A3822E443D10 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE703BCDCC0695C0BCCA3697885EADA5 /* Foundation.framework */; };
+		55CD6D29D095E527CCE91BD47B76370D /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = D91D5E5463F76934D51AB2FFC59D546C /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55D9B2410A5B6150AABE187DFCFF7BCA /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F2089D95BFC5705AD4E43E3CBDC443F /* CoreData.framework */; };
+		55F39C4D60B566DC7E925D7859A9D9E7 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = BDDF3ADA1E4AEB030434A241FD4B8B8E /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		572E1E5F7165FB09587BE2213561CC7C /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D4814650D73EC866488F54A2D67E18 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		574A172674FB9A472877A19C1D558C72 /* Pods-VOKCoreDataManager-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C8FDBE7F424A75BC5CBA314BD5CE0DC3 /* Pods-VOKCoreDataManager-OSX-dummy.m */; };
+		5F9574C31868350D970B5FADE3FAE082 /* ILGDynamicObjC-iOS10.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3307A89E8353106F38E6D722FD9F2AAC /* ILGDynamicObjC-iOS10.0-dummy.m */; };
+		5FFA65785C48EE7F614380C5A669B59E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91DC91E6AC68D30020C930507DB0AA6B /* Foundation.framework */; };
+		6129D1483D0B9ACF1C3BC05BAC040EA7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91DC91E6AC68D30020C930507DB0AA6B /* Foundation.framework */; };
+		62DB07783B027B5A6D558B662B4F3DC7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE703BCDCC0695C0BCCA3697885EADA5 /* Foundation.framework */; };
+		64231A44EC55F800F7E2FA8CB43F2586 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C80C1AF1B4A51B665AC7646313D71FA /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6955CB54A2648577F22F39F2B2B028C4 /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 86DB4D85A8C97A6DCDAF2D09923392DD /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m */; };
+		69F2BD91B541DC66470D45FD52AFB143 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 0722BD137224E95065B72D89C2AFBCFD /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A612F0D5B91883C22C141D936ED151B /* VOKUtilities-iOS10.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 249EC7AB8EB090B7305A598F726DBBB4 /* VOKUtilities-iOS10.0-dummy.m */; };
+		6A7A0050CE415CBC9D12B22471E3937D /* Pods-WatchApp Extension-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DDA6FB76586271443E51CF241698D6DC /* Pods-WatchApp Extension-dummy.m */; };
+		6F1F8F4108B4205BCCA46805D5F51814 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = A83571761A3EC64BB78549810DA2558F /* VOKCollectionDataSource.m */; };
+		706161E9B1E67A30338B9D7031AF22A6 /* Pods-VOKCoreDataManager-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EE9FA64AE5379867E8F4162B4D817A1 /* Pods-VOKCoreDataManager-dummy.m */; };
+		7062D29519B52F0E344E3E28D7A8B1ED /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C80C1AF1B4A51B665AC7646313D71FA /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72B1A8E71068821887B4F99755D9F5F6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE703BCDCC0695C0BCCA3697885EADA5 /* Foundation.framework */; };
+		7436CC78E0A2854FBDC008B94A0D2BF9 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D9D0CC5720AA3DAAC9C766E45CF5AC6C /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		758B13B8BFA8406B2932EBE6E50BE2CD /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 521A958366FF5BF44A89EC736B34CFB9 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		75E7A87043A39F634673D9060B7935BC /* ILGDynamicObjC-OSX10.9-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BF62C8810B96ED634A2FCBF9C13300DD /* ILGDynamicObjC-OSX10.9-dummy.m */; };
+		78601D6FAAE96FB8B1307D98B8341A40 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 039E65118EEA36942D15DABBB9EAACB4 /* VOKManagedObjectMapper.m */; };
+		79E85C6C3B5541601E4DD86439282ED2 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A9E463A83ECB0D1A6746F8BF76439B2F /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7CFB444BAF463DF47127AEA9F38C1B86 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EEA0A1935EF7399211A2BCD3991E752 /* VOKManagedObjectMap.m */; };
+		826F2C17C0F41916B7B6B607427532A0 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = A2C0960CFA72441F03306FC9EC955F8C /* VOKFetchedResultsDataSource.m */; };
+		84305DB0EC41237DF19AFD4887C381D7 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EEA0A1935EF7399211A2BCD3991E752 /* VOKManagedObjectMap.m */; };
+		87338CDCB89F6E5D8655E0B800CC6D46 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = A51D6B1CB24680567D407CAA0F7A1ACE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		876FDD63EB3512E84F61972B9737800C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		89E324ADD21F715E143A2EEA6F2A3F32 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = BDDF3ADA1E4AEB030434A241FD4B8B8E /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8E1F46B65CDCC70DB338081C9437EB3A /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4109FF539D2341CA5287721D8D377E01 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8F9D0B19A50267017931BC62EB6F4416 /* VOKUtilities-tvOS9.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F528442C02A3343B61C0AEC0031963E3 /* VOKUtilities-tvOS9.0-dummy.m */; };
+		92FB112C6EBBC197C94736137B1C4D5E /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = A83571761A3EC64BB78549810DA2558F /* VOKCollectionDataSource.m */; };
+		941BCA3A7AD57B838F0F1F571D38B030 /* Vokoder-43a9e09e-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2626459696E3F30C9A8C3096568BF160 /* Vokoder-43a9e09e-dummy.m */; };
+		96FB2676B809AEA2D73DCDBD184CF485 /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAB26DA0FB2C2CF6F3E8B966842D337 /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9791D1ADCAD055CA5A3FCDEC39A0C80E /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 310E3889F83DDE730396B90732C5C8B0 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99BA021E3B693786CD9BE02BF1C83B5C /* Vokoder-fdc3d3be-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F89761EDFF3BC77C47475E71440A115 /* Vokoder-fdc3d3be-dummy.m */; };
+		9AB20636B56FB96E445AD9B9E6B3A1DE /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = A2C0960CFA72441F03306FC9EC955F8C /* VOKFetchedResultsDataSource.m */; };
+		9F11E2522A81A7954E8350C695C8839A /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4109FF539D2341CA5287721D8D377E01 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F3D25892079C89F92D2F9FD4190D7DE /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2797C5EFB0D6E418F204877116937884 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A0ACF217DB3CD340DB7C37F297C579C4 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D425622BFD2229DC889BD761596FA01D /* Cocoa.framework */; };
+		A19A08BB12239F2FC8F21F085A4C4938 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		A46A11C143A02621A86B092896E3E74A /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = BBC4DD83586D3E0AFB4994434004972E /* VOKDefaultPagingAccessory.m */; };
+		A7F8350ED882D789F247C2A2BFC14AC0 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4109FF539D2341CA5287721D8D377E01 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A84D346F6FAD676FAD74B8DB50323438 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = A51D6B1CB24680567D407CAA0F7A1ACE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A959E6D250E9CA1161673D596D0B07DA /* Pods-VOKCoreDataManager-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CE3519B3FC051821FEC2239CA22B0E3 /* Pods-VOKCoreDataManager-tvOS-dummy.m */; };
+		AB4B6B3176D4E157FE83F035FA6B78AE /* ILGDynamicObjC-tvOS9.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F329743F37B90C2ACD5BCFCEC97DFC8 /* ILGDynamicObjC-tvOS9.0-dummy.m */; };
+		AB632F97BE96C30D53B4A836E375492B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		AFE5AAB8731020BF47620BFA1CB1449D /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 310E3889F83DDE730396B90732C5C8B0 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B394199A26A67A099751C8BE89D32ED0 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D425622BFD2229DC889BD761596FA01D /* Cocoa.framework */; };
+		B60FB7F147ACB0DFD00511D9A54270CA /* ILGDynamicObjC-iOS8.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EC1B0A9236F356043741C189C734487 /* ILGDynamicObjC-iOS8.0-dummy.m */; };
+		B7A83FFDE42EE3B7EFBCF551DF783C58 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2797C5EFB0D6E418F204877116937884 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9664DBC20AD20340C9C56C827223331 /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAB26DA0FB2C2CF6F3E8B966842D337 /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B98CD530764ABAA87671B18F6CFEA741 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D9D0CC5720AA3DAAC9C766E45CF5AC6C /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C0269007E098908DDE0D760D592777EA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */; };
+		C19713830E5C6F269FBC7D0B0DA8A3EB /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48DA15F76198935F143046A92BF85D5D /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C2F4701759C4A60265C9BD79A45B4D31 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 227F6BBE28D179CB31B4DF636979A543 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		C40624EAA1EDDA49941552C1C27D5DCD /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 83A5210A54A780630BFCCE098510222D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C41831A748898B12950AFA29B245E36A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE703BCDCC0695C0BCCA3697885EADA5 /* Foundation.framework */; };
+		C9C9F981F61CB574580B9BD26F1913B5 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C482370A22662EBCBDABF143AE65DA1 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CA1254081353C93B20714D57F78CB920 /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A9E463A83ECB0D1A6746F8BF76439B2F /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB7C7721CA6DECFE06DFA87EE1DEA341 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C80C1AF1B4A51B665AC7646313D71FA /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC8363CCBB16D7AEEA804AA0D9B304C0 /* Vokoder-07029ee6-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 773655DAAEEFB626CDB5269FAB35E6A6 /* Vokoder-07029ee6-dummy.m */; };
+		CD06AC2CCC6ABC284693A5ACEC2BEAD1 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C43930A300BDD6E51802E60CCCB0D0BA /* VOKCoreDataManager.m */; };
+		CDB6B58939B6AFA9C7D2A4C8A9CFE93E /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2797C5EFB0D6E418F204877116937884 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CEA2E028834C16198D782211E25E146F /* Pods-TodayWidget-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 00B1C1D5AD6DEFA2EA6F7FC013F189BA /* Pods-TodayWidget-dummy.m */; };
+		D23BC18771BD805135335CE68965F93E /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 521A958366FF5BF44A89EC736B34CFB9 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3241F7829CC022BF4C19FB2B9210609 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 227F6BBE28D179CB31B4DF636979A543 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		D431EF7448393C5B9DA92071BEEDC8A4 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E11CB0B4AE91356599EC30A92B9972A /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D46C5E611B79ADBD8F0797BD0AFBE378 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EEA0A1935EF7399211A2BCD3991E752 /* VOKManagedObjectMap.m */; };
+		D70E383B955AF3132141702C51A4156D /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E11CB0B4AE91356599EC30A92B9972A /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D8EDA3D717CC05288F05FB34DED12970 /* VOKCoreDataCollectionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = D91D5E5463F76934D51AB2FFC59D546C /* VOKCoreDataCollectionTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9D0B4E0CF1D9351F523C52A58EB382A /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 039E65118EEA36942D15DABBB9EAACB4 /* VOKManagedObjectMapper.m */; };
+		DACBF60E6E29FC7A0F183AAE7F50A643 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 227F6BBE28D179CB31B4DF636979A543 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
+		DB8D436A6E007C50BE090D9489B7657E /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 83A5210A54A780630BFCCE098510222D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBE0D515A2AF19B3C14494BBA1EDED5C /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A9E463A83ECB0D1A6746F8BF76439B2F /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCF8F205C4F25D6F238DD2745040DE79 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48DA15F76198935F143046A92BF85D5D /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DE2CEFD4C08C5809A68FCFBB7F7B8D37 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EEA0A1935EF7399211A2BCD3991E752 /* VOKManagedObjectMap.m */; };
+		DECF2A51D68D7AF0370D2E356236C66D /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F2089D95BFC5705AD4E43E3CBDC443F /* CoreData.framework */; };
+		E0059C3E528A2DF55E41F11BBD9FFF27 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2F5E5AD6B5231F5D7DA2650C39E582 /* VOKPagingFetchedResultsDataSource.m */; };
+		E0F2EBEDE75F30A435171819397848DB /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = A83571761A3EC64BB78549810DA2558F /* VOKCollectionDataSource.m */; };
+		E4D74D1CE5D7BCF3C09452F0B2D5DB06 /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = A51D6B1CB24680567D407CAA0F7A1ACE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E77012EC2873B09EE7575D713C2CD038 /* VOKManagedObjectMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EEA0A1935EF7399211A2BCD3991E752 /* VOKManagedObjectMap.m */; };
+		EA28A2E8787CE8FD59C9BA29E5A9C219 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DEE798B4DA83762C29CD7D8D3730B0E /* VOKKeyPathHelper.m */; };
+		EBAAF0200310330FBB4DEAF06A37B8C4 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = BDDF3ADA1E4AEB030434A241FD4B8B8E /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		ED44FA9C9CACCD25E9408DB9239815BD /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = BDDF3ADA1E4AEB030434A241FD4B8B8E /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		F16026F46C399EF77212CC0E0AEFE8D2 /* VOKManagedObjectMapperMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAB26DA0FB2C2CF6F3E8B966842D337 /* VOKManagedObjectMapperMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F1656458D3208691FDAAF26BCAE49229 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 039E65118EEA36942D15DABBB9EAACB4 /* VOKManagedObjectMapper.m */; };
+		F2576B72388B748DBD9DBEF4BA59D12E /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D9D0CC5720AA3DAAC9C766E45CF5AC6C /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F34A95F183925AC036BBA149C842EEB4 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DEE798B4DA83762C29CD7D8D3730B0E /* VOKKeyPathHelper.m */; };
+		F4BD871333AE5E366931E1B5A3418E1E /* ILGDynamicObjC-watchOS3.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 18BBC67C0C118607A919DCEFF329F696 /* ILGDynamicObjC-watchOS3.0-dummy.m */; };
+		F4E748713C20596DF44E84DE4FAA69E6 /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E11CB0B4AE91356599EC30A92B9972A /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F518A4147BB31B13EB25E7FC4917FE74 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE703BCDCC0695C0BCCA3697885EADA5 /* Foundation.framework */; };
+		F588666174877E1EB64EDB1CE7563126 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4109FF539D2341CA5287721D8D377E01 /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD17FAEBAA7AC7D0F7BF1B48D605A0BF /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D425622BFD2229DC889BD761596FA01D /* Cocoa.framework */; };
+		FD30CE8DD912972639389E526590DE2A /* VOKUtilities-watchOS3.0-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DF071EAFFD9023C09CD28A9BEB38176E /* VOKUtilities-watchOS3.0-dummy.m */; };
+		FEFDA0128F05DB6F9625CBB4FAADF6F0 /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C482370A22662EBCBDABF143AE65DA1 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		CA7A14CB0EA7172870B7CF17CDAC7107 /* PBXContainerItemProxy */ = {
+		0AC54013DD2B84DE184E637FCFCEA853 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 6B0D563CAD5EA3257860C73C8A622E25;
+			remoteGlobalIDString = 3F0FAB9F1B7683284CB9673A8D392DD3;
 			remoteInfo = "Vokoder-fdc3d3be";
 		};
-		04B38CC960DCAD33857CDDA3070B2825 /* PBXContainerItemProxy */ = {
+		198DB9635A23B1788685C39696798A8E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 772F82B4B45005A2B8D72A61BE1BFC27;
+			remoteGlobalIDString = 909EE1A623E69E268090F6690431EDAB;
 			remoteInfo = "VOKUtilities-iOS10.0";
 		};
-		345F54ACDE52ECA0ED54E06941D1A28B /* PBXContainerItemProxy */ = {
+		258B0B073CF4EDBC553F862173BE5939 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 4AB6E6A867E0C03192F04753BCC56DB2;
+			remoteGlobalIDString = 0C115C45E7548BE6DB46198B1EDEE9C9;
 			remoteInfo = "ILGDynamicObjC-iOS8.0";
 		};
-		F295BB55395E1CED4D2E32BC67F8C5E4 /* PBXContainerItemProxy */ = {
+		2A16A673925C08E46DFBC2EE79ADEA22 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 82F6302EC5FDB383B400D97DB43ABF03;
+			remoteGlobalIDString = 2F7F0943C23BC0F4C0133529464D5DC0;
 			remoteInfo = "VOKUtilities-tvOS9.0";
 		};
-		F88DBB7E48C753114167CD8136C8210E /* PBXContainerItemProxy */ = {
+		2E5A7CFE5FB73DB052C3C19102D3C3D9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = B055242C128EDCCF53DC7C1592181C09;
+			remoteGlobalIDString = B6C9639C211DF9E8E72302FD37DDA5AE;
 			remoteInfo = "ILGDynamicObjC-watchOS3.0";
 		};
-		68F9855C89B0441B6E4554B54CA780BC /* PBXContainerItemProxy */ = {
+		36D206E8ED7FB0B47AC46EB00D367606 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 039B93451C7F51D385086191C304EEF3;
+			remoteGlobalIDString = D1FC04FA1915305A1DE087E1A3FFB6FD;
 			remoteInfo = "Vokoder.root-Core-MapperMacros-OSX";
 		};
-		220D9F07E32430ECFDC5C18CCEEE67F5 /* PBXContainerItemProxy */ = {
+		39A38F2D05256C3D277AFF36D58D5133 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = B055242C128EDCCF53DC7C1592181C09;
+			remoteGlobalIDString = B6C9639C211DF9E8E72302FD37DDA5AE;
 			remoteInfo = "ILGDynamicObjC-watchOS3.0";
 		};
-		1CCC5674CE8ECC9BD450174839953315 /* PBXContainerItemProxy */ = {
+		463D8C0EAB2ADC84930A415CADED1989 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = FADC2218D666458DFB6C017FE59277E6;
+			remoteGlobalIDString = CCCF7217FD9C2EFDF11F0E0BE1388F3B;
 			remoteInfo = "ILGDynamicObjC-OSX10.9";
 		};
-		AED3134F3F7D764F3B0A212FF6A68488 /* PBXContainerItemProxy */ = {
+		51250E911A6914DEB2A3836BD5C2FF2C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A9C28832CA7ABDF5308A8697E2AD5CC1;
+			remoteGlobalIDString = F10CB8AE3F4245CEA38EC599242D3FEC;
 			remoteInfo = "Vokoder-43a9e09e";
 		};
-		EC18ECEC0DABE2B60EC4B7BB2914EF53 /* PBXContainerItemProxy */ = {
+		52228221B375F0D36830B83D3ECCE64D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 4AB6E6A867E0C03192F04753BCC56DB2;
+			remoteGlobalIDString = 0C115C45E7548BE6DB46198B1EDEE9C9;
 			remoteInfo = "ILGDynamicObjC-iOS8.0";
 		};
-		5CA71C13B1F090E4E9EEDAF5609A481F /* PBXContainerItemProxy */ = {
+		58FF2F566A56A1F12AD3FA85A2940D3E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7A0A41400F1B71C96AAB4C1E0230F110;
+			remoteGlobalIDString = AA75B5AC10E44233A4C5AB7C8278A16A;
 			remoteInfo = "VOKUtilities-watchOS3.0";
 		};
-		FB9A841F3621D647A57FED3DDF78738C /* PBXContainerItemProxy */ = {
+		60C2DC3F11F14BDABA5F7C7AD5872DB5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 5DBFB1D6ADE4C2238F5889A1EAB945CE;
+			remoteGlobalIDString = AE27C772C4215696CDDD8372D69BAF5D;
 			remoteInfo = "VOKUtilities-iOS8.0";
 		};
-		27F177D70259459837D40F47B9420649 /* PBXContainerItemProxy */ = {
+		6FA28D4AB7A3B56EF843DB16CD1CC5CB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 82F6302EC5FDB383B400D97DB43ABF03;
+			remoteGlobalIDString = 2F7F0943C23BC0F4C0133529464D5DC0;
 			remoteInfo = "VOKUtilities-tvOS9.0";
 		};
-		D565656D99625BB98E55330592E592EC /* PBXContainerItemProxy */ = {
+		869694DF9604E7A29B649FF00B4769AA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 5DBFB1D6ADE4C2238F5889A1EAB945CE;
+			remoteGlobalIDString = AE27C772C4215696CDDD8372D69BAF5D;
 			remoteInfo = "VOKUtilities-iOS8.0";
 		};
-		9B85C8CFA7D8FEAD0915D1AD43B4DB9B /* PBXContainerItemProxy */ = {
+		A1C099A2D46F6ACC827FF618237A4700 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A86E6132E337186EFFC6D495AFCB1C66;
+			remoteGlobalIDString = 5473A142FC5A8D0C655B183280456A06;
 			remoteInfo = "Vokoder-07029ee6";
 		};
-		37E21C9F9A8789BA6DD166589EC96AD2 /* PBXContainerItemProxy */ = {
+		A9302D9DE9ECF4D095C78BF77F81CFAB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 830608453A64AF3F5591F52ED368B223;
+			remoteGlobalIDString = 47DD822514431098BFCCFDCC6E07F4D2;
 			remoteInfo = "VOKUtilities-OSX10.9";
 		};
-		C1EE3FDB414D73D3ED9AF4F38AF6314D /* PBXContainerItemProxy */ = {
+		B42A991951D63240AF35D174769CC975 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7563863CEAB51B07E9E8D87776F044CC;
+			remoteGlobalIDString = B3CE1BF250548E4A5C0984BF85E3FCA1;
 			remoteInfo = "Vokoder.root-Core-MapperMacros-watchOS";
 		};
-		6CA6DB0D716AC53C1F8D1D4DFB84D830 /* PBXContainerItemProxy */ = {
+		B6EBC1CAB71A2440DEF53AA47ECEACE6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 5DBFB1D6ADE4C2238F5889A1EAB945CE;
+			remoteGlobalIDString = AE27C772C4215696CDDD8372D69BAF5D;
 			remoteInfo = "VOKUtilities-iOS8.0";
 		};
-		767E7C0E7A983EC52082AEB0F039AC48 /* PBXContainerItemProxy */ = {
+		BCD6EAD5FF1796DB15A2BE70048ADBAE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2A008476970576E0B5C78E2BFDF0C345;
+			remoteGlobalIDString = 0A234DB0827360575AE0E68781ED3E5B;
 			remoteInfo = "ILGDynamicObjC-tvOS9.0";
 		};
-		E59E23FA60162D2A74806B081F33BD3D /* PBXContainerItemProxy */ = {
+		C161B722D5DA89A04DFD608855DFC010 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 4AB6E6A867E0C03192F04753BCC56DB2;
+			remoteGlobalIDString = 0C115C45E7548BE6DB46198B1EDEE9C9;
 			remoteInfo = "ILGDynamicObjC-iOS8.0";
 		};
-		4280A94A0AB72B030F5A87164A31490E /* PBXContainerItemProxy */ = {
+		D6ECBC6D09EDEA7AE683DFE5DEAF0427 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2A008476970576E0B5C78E2BFDF0C345;
+			remoteGlobalIDString = 0A234DB0827360575AE0E68781ED3E5B;
 			remoteInfo = "ILGDynamicObjC-tvOS9.0";
 		};
-		B1390FF671658A221CA6DB949BADEA97 /* PBXContainerItemProxy */ = {
+		EBAF0571A93386A0C67397551630AE40 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7A0A41400F1B71C96AAB4C1E0230F110;
+			remoteGlobalIDString = AA75B5AC10E44233A4C5AB7C8278A16A;
 			remoteInfo = "VOKUtilities-watchOS3.0";
 		};
-		96E04CCEBBCB7451A07E00FC0E4E2531 /* PBXContainerItemProxy */ = {
+		EC9C56D3F361077CA6F23E143C7D91F4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = FADC2218D666458DFB6C017FE59277E6;
+			remoteGlobalIDString = CCCF7217FD9C2EFDF11F0E0BE1388F3B;
 			remoteInfo = "ILGDynamicObjC-OSX10.9";
 		};
-		D0C8D0C2D31DF142CF872599D66C5378 /* PBXContainerItemProxy */ = {
+		F344A23A067040597C2DE05491ACA3FA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3F19AA1185A08DA68DF49A63F2775D46;
+			remoteGlobalIDString = A7515B1D5B3879EF823CC72A4F4CBFCC;
 			remoteInfo = "ILGDynamicObjC-iOS10.0";
 		};
-		A30B0A48B06411D6C1CAFF1A6B28CB90 /* PBXContainerItemProxy */ = {
+		FBACF01101E92DD9294FD26933EFD4BD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 830608453A64AF3F5591F52ED368B223;
+			remoteGlobalIDString = 47DD822514431098BFCCFDCC6E07F4D2;
 			remoteInfo = "VOKUtilities-OSX10.9";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		012F0A9F9A7CDBE88D70A160CAF549B0 /* libVOKUtilities-watchOS3.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-watchOS3.0.a"; path = "libVOKUtilities-watchOS3.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		042F42430627771693D1FDFB00E94309 /* VOKUtilities-iOS8.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-iOS8.0.xcconfig"; path = "../VOKUtilities-iOS8.0/VOKUtilities-iOS8.0.xcconfig"; sourceTree = "<group>"; };
-		066C285FCB8B5E8BA0EBCC8F740081AD /* libVokoder-07029ee6.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder-07029ee6.a"; path = "libVokoder-07029ee6.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		06CE61B68B80F3DAE49A85578C5902D9 /* ILGDynamicObjC-OSX10.9-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ILGDynamicObjC-OSX10.9-prefix.pch"; sourceTree = "<group>"; };
-		083F6D58998BAB74E2A87D18C2293925 /* Pods-VOKCoreDataManagerTests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManagerTests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		091B0FE63D6828648A4E44A2FB793E5E /* libVOKUtilities-tvOS9.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-tvOS9.0.a"; path = "libVOKUtilities-tvOS9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0A0DCF2DBCDE1AE8BF0E4D3AC368807C /* Pods-VOKCoreDataManagerTests-tvOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManagerTests-tvOS-frameworks.sh"; sourceTree = "<group>"; };
-		0B18AA4C6F3810B63A758E6F55368A51 /* Pods-VOKCoreDataManager-tvOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-tvOS-resources.sh"; sourceTree = "<group>"; };
-		0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
-		0F599B152C838E6E92557EDDA9F762C8 /* Pods-TodayWidget-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TodayWidget-dummy.m"; sourceTree = "<group>"; };
-		0F8E0E10BEABF0C6573568FE8E546BA0 /* Pods-VOKCoreDataManager-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		1006E061CE81334B5F18D76F03E84A1A /* libPods-VOKCoreDataManagerTests-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManagerTests-tvOS.a"; path = "libPods-VOKCoreDataManagerTests-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		10CC226F117CBBB79BF03824AC645A56 /* Vokoder.root-Core-MapperMacros-watchOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Vokoder.root-Core-MapperMacros-watchOS.xcconfig"; path = "../Vokoder.root-Core-MapperMacros-watchOS/Vokoder.root-Core-MapperMacros-watchOS.xcconfig"; sourceTree = "<group>"; };
-		11A1254258740229172AFBF17D09766B /* VOKUtilities-iOS10.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-iOS10.0-dummy.m"; path = "../VOKUtilities-iOS10.0/VOKUtilities-iOS10.0-dummy.m"; sourceTree = "<group>"; };
-		121EEAB77CB65EEBC6F733CA71FC7FAB /* Pods-TodayWidget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TodayWidget.release.xcconfig"; sourceTree = "<group>"; };
-		15E61F3ED71D4BB874AA0377FFD6913A /* Pods-VOKCoreDataManager-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-OSX-dummy.m"; sourceTree = "<group>"; };
-		1BEF41F9488CF0AD0F1BEAB977EE1344 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
-		1F90FCCF9E010C8FB81278273CB8C6BE /* Vokoder-fdc3d3be-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Vokoder-fdc3d3be-dummy.m"; path = "../Vokoder-fdc3d3be/Vokoder-fdc3d3be-dummy.m"; sourceTree = "<group>"; };
-		1F920122B363EAB2F5D908F0E79FDF3D /* VOKUtilities-iOS8.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-iOS8.0-dummy.m"; path = "../VOKUtilities-iOS8.0/VOKUtilities-iOS8.0-dummy.m"; sourceTree = "<group>"; };
-		21FF87D5FB7B4CFBC516A866A43B700A /* libPods-WatchApp Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-WatchApp Extension.a"; path = "libPods-WatchApp Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2502BE013CCA309B25AD12C6FBC86067 /* Pods-VOKCoreDataManager-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
-		2579DB4632D3A27C34327639D85722C9 /* ILGDynamicObjC-iOS10.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ILGDynamicObjC-iOS10.0.xcconfig"; path = "../ILGDynamicObjC-iOS10.0/ILGDynamicObjC-iOS10.0.xcconfig"; sourceTree = "<group>"; };
-		26E4FE111178C5C067F328C472B591B8 /* VOKUtilities-watchOS3.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-watchOS3.0-dummy.m"; path = "../VOKUtilities-watchOS3.0/VOKUtilities-watchOS3.0-dummy.m"; sourceTree = "<group>"; };
-		28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
-		2B3D364944B60CF2A35EC743DF304EE9 /* ILGDynamicObjC-iOS8.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ILGDynamicObjC-iOS8.0-prefix.pch"; path = "../ILGDynamicObjC-iOS8.0/ILGDynamicObjC-iOS8.0-prefix.pch"; sourceTree = "<group>"; };
-		2BA27034E65288609E599B4DA7D5DFC9 /* Vokoder.root-Core-MapperMacros-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Vokoder.root-Core-MapperMacros-OSX-dummy.m"; path = "../Vokoder.root-Core-MapperMacros-OSX/Vokoder.root-Core-MapperMacros-OSX-dummy.m"; sourceTree = "<group>"; };
-		2C05BF495E3C46D0AA1D04F61CD06BAB /* libILGDynamicObjC-watchOS3.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-watchOS3.0.a"; path = "libILGDynamicObjC-watchOS3.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2DDE38143B617CB415B17CDC63D5B998 /* libVOKUtilities-iOS8.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-iOS8.0.a"; path = "libVOKUtilities-iOS8.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2E4D5215C4C2D177AA6A0B6E2D1BAB00 /* ILGDynamicObjC-iOS10.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ILGDynamicObjC-iOS10.0-prefix.pch"; path = "../ILGDynamicObjC-iOS10.0/ILGDynamicObjC-iOS10.0-prefix.pch"; sourceTree = "<group>"; };
-		2E9BF54A9471DCEB8BF1280D47F24771 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKKeyPathHelper.m; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.m; sourceTree = "<group>"; };
-		311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Vokoder.h; sourceTree = "<group>"; };
-		3A5F0559A548C85246C23DC7B387C289 /* Pods-VOKCoreDataManagerTests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManagerTests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		3C1EAC16934CC93F3643B1C1FEDFF267 /* Pods-VOKCoreDataManager-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-dummy.m"; sourceTree = "<group>"; };
-		3EC12C7CE4C91B4DDCDED5DE9018057A /* VOKUtilities-OSX10.9.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "VOKUtilities-OSX10.9.xcconfig"; sourceTree = "<group>"; };
-		3EFCE4C7258AA749F7C0C8C56D0A0238 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS3.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		3F9C0F760326095547406F66F907A7CD /* Pods-VOKCoreDataManager-OSX-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-OSX-resources.sh"; sourceTree = "<group>"; };
-		401D2715E3ECF45767B49F2CC295F881 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		41449AC4115C95FEE99A662AE575B165 /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Vokoder.root-Core-MapperMacros-watchOS-dummy.m"; path = "../Vokoder.root-Core-MapperMacros-watchOS/Vokoder.root-Core-MapperMacros-watchOS-dummy.m"; sourceTree = "<group>"; };
-		435AE67FC30AD5773F7DF4D4A2A47516 /* Pods-VOKCoreDataManagerTests-tvOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManagerTests-tvOS-resources.sh"; sourceTree = "<group>"; };
-		4441C392D8828C60F1289E860A23C911 /* libPods-TodayWidget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-TodayWidget.a"; path = "libPods-TodayWidget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		474BBE2194A46BC7E8A348CFC9D76E77 /* libVOKUtilities-iOS10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-iOS10.0.a"; path = "libVOKUtilities-iOS10.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
-		4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
-		4AEC4E19A44C1415B751DD9150E36B34 /* Pods-VOKCoreDataManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.debug.xcconfig"; sourceTree = "<group>"; };
-		4D5D60B13DF1C32B14FCB18E2F196EAA /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		50A3B698A62926F6226DDBBAB560654C /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManagerTests-tvOS-dummy.m"; sourceTree = "<group>"; };
-		5355D5F9014D0D3BB6BDA8CFF22AE9D4 /* Vokoder-43a9e09e-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Vokoder-43a9e09e-prefix.pch"; path = "../Vokoder-43a9e09e/Vokoder-43a9e09e-prefix.pch"; sourceTree = "<group>"; };
-		54467A35B42FBC45238FF67E4BF1B484 /* Vokoder-07029ee6-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Vokoder-07029ee6-prefix.pch"; sourceTree = "<group>"; };
-		563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
-		58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
-		5B3804CD0525DB45033DD1C9F0EE7EE1 /* Pods-VOKCoreDataManager-tvOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-tvOS-frameworks.sh"; sourceTree = "<group>"; };
-		5B73B757A70916AA67D68FF84EA2BF50 /* Pods-VOKCoreDataManagerTests-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManagerTests-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
-		5B90E32C0EF1EA42CACA2C9044DDACDF /* Vokoder.root-Core-MapperMacros-watchOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Vokoder.root-Core-MapperMacros-watchOS-prefix.pch"; path = "../Vokoder.root-Core-MapperMacros-watchOS/Vokoder.root-Core-MapperMacros-watchOS-prefix.pch"; sourceTree = "<group>"; };
-		5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
-		60BABD577094FC9C8A9957F04FCFF967 /* libVOKUtilities-OSX10.9.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-OSX10.9.a"; path = "libVOKUtilities-OSX10.9.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		61C4E0677C83F766260DB28F176CC051 /* Pods-VOKCoreDataManager Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-resources.sh"; sourceTree = "<group>"; };
-		63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
-		63C3F1515EF08D989ADD8EAB39DD4E9E /* libPods-VOKCoreDataManager-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManager-OSX.a"; path = "libPods-VOKCoreDataManager-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		66438280191783D51E1F8CC0AA43700B /* Pods-VOKCoreDataManager-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-acknowledgements.plist"; sourceTree = "<group>"; };
-		6746A42342EC06B188B85B914FDC4796 /* ILGDynamicObjC-watchOS3.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ILGDynamicObjC-watchOS3.0.xcconfig"; path = "../ILGDynamicObjC-watchOS3.0/ILGDynamicObjC-watchOS3.0.xcconfig"; sourceTree = "<group>"; };
-		68B1BD5126083CABD8F9C6E59EBAF3E7 /* Pods-VOKCoreDataManagerTests-OSX-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManagerTests-OSX-resources.sh"; sourceTree = "<group>"; };
-		695A55226F1671D0C255C45400CC6E5E /* Pods-VOKCoreDataManager-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager-OSX.debug.xcconfig"; sourceTree = "<group>"; };
-		6D027326B67067ACEBDBE37DB79F7385 /* Pods-VOKCoreDataManager-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-tvOS-dummy.m"; sourceTree = "<group>"; };
-		6D558860809A7C7B876A65673A136A8F /* VOKUtilities-tvOS9.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-tvOS9.0-prefix.pch"; path = "../VOKUtilities-tvOS9.0/VOKUtilities-tvOS9.0-prefix.pch"; sourceTree = "<group>"; };
-		6E32A138087D38C5B2F94CAD0BFCC341 /* Pods-TodayWidget-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TodayWidget-resources.sh"; sourceTree = "<group>"; };
-		6E969E56DA711F59E2423C398FA26E74 /* VOKUtilities-OSX10.9-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-OSX10.9-prefix.pch"; sourceTree = "<group>"; };
-		6F9487FE2E21E990EF6C666989C34D01 /* libVokoder-43a9e09e.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder-43a9e09e.a"; path = "libVokoder-43a9e09e.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		701A7F006E59848A3FA96619714A2223 /* Pods-WatchApp Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-WatchApp Extension.debug.xcconfig"; sourceTree = "<group>"; };
-		73831ABF987475486391C975F9F05112 /* libPods-VOKCoreDataManagerTests-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManagerTests-OSX.a"; path = "libPods-VOKCoreDataManagerTests-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
-		775D86E87223CD14F633CCDF0C3A2B79 /* libVokoder.root-Core-MapperMacros-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder.root-Core-MapperMacros-OSX.a"; path = "libVokoder.root-Core-MapperMacros-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		777B0F79A65AFEF863579BE5646E1DF1 /* Pods-WatchApp Extension-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-WatchApp Extension-resources.sh"; sourceTree = "<group>"; };
-		78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
-		7C45AB067EA884E144C2DB09417ACAD4 /* Pods-VOKCoreDataManagerTests-OSX-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManagerTests-OSX-frameworks.sh"; sourceTree = "<group>"; };
-		7D13E5AD07A409EAF8DC80F587980045 /* ILGDynamicObjC-iOS8.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ILGDynamicObjC-iOS8.0-dummy.m"; path = "../ILGDynamicObjC-iOS8.0/ILGDynamicObjC-iOS8.0-dummy.m"; sourceTree = "<group>"; };
-		7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
-		7E58709DA76AFCA54DD99E99F8816216 /* VOKUtilities-OSX10.9-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VOKUtilities-OSX10.9-dummy.m"; sourceTree = "<group>"; };
-		809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
-		816CFB2F4CCA32B132D3140C7EB26A61 /* Pods-VOKCoreDataManager-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		82172DDFD8E6F88B65EEA9534A3D9C8F /* Pods-VOKCoreDataManager Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-dummy.m"; sourceTree = "<group>"; };
-		82E3E7B746BAE97CD6D2774290142ED7 /* Vokoder-43a9e09e-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Vokoder-43a9e09e-dummy.m"; path = "../Vokoder-43a9e09e/Vokoder-43a9e09e-dummy.m"; sourceTree = "<group>"; };
-		869B5154502141C012BA472A1C847BDE /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
-		88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
-		91BDAD172EE3777442B5BBB4E49FFAF5 /* libVokoder.root-Core-MapperMacros-watchOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder.root-Core-MapperMacros-watchOS.a"; path = "libVokoder.root-Core-MapperMacros-watchOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		928F6652087C28B56E197BF3DE359403 /* Pods-TodayWidget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TodayWidget.debug.xcconfig"; sourceTree = "<group>"; };
-		94233026138E58D9784E48FD9C11030D /* ILGDynamicObjC-watchOS3.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ILGDynamicObjC-watchOS3.0-prefix.pch"; path = "../ILGDynamicObjC-watchOS3.0/ILGDynamicObjC-watchOS3.0-prefix.pch"; sourceTree = "<group>"; };
-		9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapperMacros.h; sourceTree = "<group>"; };
-		94FCD283DFD1D103959D5BE108B9B624 /* Pods-VOKCoreDataManager Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-frameworks.sh"; sourceTree = "<group>"; };
-		9700B3DB8E75CDDF195B88F098F05B98 /* VOKUtilities-tvOS9.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-tvOS9.0.xcconfig"; path = "../VOKUtilities-tvOS9.0/VOKUtilities-tvOS9.0.xcconfig"; sourceTree = "<group>"; };
-		971C8DEDE933277B3AE4E882338A8214 /* Pods-WatchApp Extension-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-WatchApp Extension-acknowledgements.plist"; sourceTree = "<group>"; };
-		97E69364E78828F1A5FB7744B844A007 /* Pods-VOKCoreDataManager-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
-		99DB30539EE330C93A159C435206F074 /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		9C03B3C5377C15525FE5987D4D450838 /* libILGDynamicObjC-iOS8.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-iOS8.0.a"; path = "libILGDynamicObjC-iOS8.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9C82F70917641C70EE55D41167D7E59E /* Vokoder-fdc3d3be.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Vokoder-fdc3d3be.xcconfig"; path = "../Vokoder-fdc3d3be/Vokoder-fdc3d3be.xcconfig"; sourceTree = "<group>"; };
-		9DA9C1C60E4F548C3D7AE3E5A9DDC1EA /* libPods-VOKCoreDataManager.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManager.a"; path = "libPods-VOKCoreDataManager.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9E19EE33BD8E73E19FF9CF2B455F8CF1 /* Pods-VOKCoreDataManager-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9E22AD87D6173DD697749070C13776D0 /* Vokoder-07029ee6.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Vokoder-07029ee6.xcconfig"; sourceTree = "<group>"; };
-		9E63444472FADBEC7159920FEBA28A00 /* ILGDynamicObjC-OSX10.9.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ILGDynamicObjC-OSX10.9.xcconfig"; sourceTree = "<group>"; };
-		A0BC3E14560091A93BC0EF4B3C3FB875 /* libPods-VOKCoreDataManager-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManager-tvOS.a"; path = "libPods-VOKCoreDataManager-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A1B58FA45A045846147421FED31002DE /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
-		A1DBF133507242CA23B6647425441B66 /* Pods-VOKCoreDataManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.release.xcconfig"; sourceTree = "<group>"; };
-		A1F1F957336FD448D73A0FA0BB334A2C /* Pods-TodayWidget-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TodayWidget-acknowledgements.plist"; sourceTree = "<group>"; };
-		A2487DEB43122640319AB8CEE6B754F0 /* Pods-VOKCoreDataManagerTests-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManagerTests-OSX.debug.xcconfig"; sourceTree = "<group>"; };
-		A35665478787B839BD2D1E47D2B76BDD /* VOKUtilities-watchOS3.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-watchOS3.0.xcconfig"; path = "../VOKUtilities-watchOS3.0/VOKUtilities-watchOS3.0.xcconfig"; sourceTree = "<group>"; };
-		A38FF61C71733211E6DDB19385503404 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A9A34B73FE8744709086EEDE7B8E260E /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS3.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
-		A9B1DC84C4E1F1C6AA5796D49FBBD731 /* VOKUtilities-watchOS3.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-watchOS3.0-prefix.pch"; path = "../VOKUtilities-watchOS3.0/VOKUtilities-watchOS3.0-prefix.pch"; sourceTree = "<group>"; };
-		AB9B7E1C33A0AC0AEC39367FE1B2753C /* libVokoder-fdc3d3be.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder-fdc3d3be.a"; path = "libVokoder-fdc3d3be.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
-		ADDCC00802B3ED1F8E1BE5631AF75BC4 /* Pods-WatchApp Extension-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-WatchApp Extension-acknowledgements.markdown"; sourceTree = "<group>"; };
-		B078387F629D340EBA92DD1FCD6A5250 /* Pods-VOKCoreDataManager-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
-		B44BBB10D6BD3AC3BCE0B21191DF7E32 /* VOKUtilities-iOS10.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-iOS10.0-prefix.pch"; path = "../VOKUtilities-iOS10.0/VOKUtilities-iOS10.0-prefix.pch"; sourceTree = "<group>"; };
-		B4EFDCF5E3A1C9DE1EF57F56A5E89A9E /* VOKUtilities-tvOS9.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-tvOS9.0-dummy.m"; path = "../VOKUtilities-tvOS9.0/VOKUtilities-tvOS9.0-dummy.m"; sourceTree = "<group>"; };
-		B508BB2C656A01663ED09C2BD6DBF60D /* ILGDynamicObjC-tvOS9.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ILGDynamicObjC-tvOS9.0-dummy.m"; path = "../ILGDynamicObjC-tvOS9.0/ILGDynamicObjC-tvOS9.0-dummy.m"; sourceTree = "<group>"; };
-		B7E1436723B14D27E6BA24BED48AC926 /* Pods-WatchApp Extension-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-WatchApp Extension-dummy.m"; sourceTree = "<group>"; };
-		BABD7645020D9F8280BB1EF781091F4C /* libILGDynamicObjC-iOS10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-iOS10.0.a"; path = "libILGDynamicObjC-iOS10.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BAD21DFB02DACBE61BE0CD79929B2470 /* Pods-VOKCoreDataManagerTests-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManagerTests-OSX-dummy.m"; sourceTree = "<group>"; };
-		C094F1C98A2C41ACD73C6F158B47023F /* Pods-WatchApp Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-WatchApp Extension.release.xcconfig"; sourceTree = "<group>"; };
-		C4C644F3188FDA12FA9970CC24FF7F91 /* Pods-VOKCoreDataManagerTests-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManagerTests-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
-		C726B5976E46922C44C8EFA843D7DDDA /* Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
-		C7FDB6DA1D9C8344F63ADE0BA56C55AC /* Vokoder-43a9e09e.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Vokoder-43a9e09e.xcconfig"; path = "../Vokoder-43a9e09e/Vokoder-43a9e09e.xcconfig"; sourceTree = "<group>"; };
-		C931D38FC2455FFC3D8D9F69DA9F8276 /* Pods-VOKCoreDataManager-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
-		C9E87A90A0263D062114FF0A770907E3 /* ILGDynamicObjC-OSX10.9-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-OSX10.9-dummy.m"; sourceTree = "<group>"; };
-		CBD594A897BF2B25B03804CA7DF9BD39 /* Vokoder.root-Core-MapperMacros-OSX.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Vokoder.root-Core-MapperMacros-OSX.xcconfig"; path = "../Vokoder.root-Core-MapperMacros-OSX/Vokoder.root-Core-MapperMacros-OSX.xcconfig"; sourceTree = "<group>"; };
-		CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
-		CDB20D673EC26CEAA279E49DCA096F01 /* ILGDynamicObjC-iOS8.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ILGDynamicObjC-iOS8.0.xcconfig"; path = "../ILGDynamicObjC-iOS8.0/ILGDynamicObjC-iOS8.0.xcconfig"; sourceTree = "<group>"; };
-		CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
-		CEE5E57B0BBE5728330045505D55E11C /* Pods-VOKCoreDataManager-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager-OSX.release.xcconfig"; sourceTree = "<group>"; };
-		CF9ED222207E10F412CE86CA603947AD /* libPods-VOKCoreDataManager Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManager Tests.a"; path = "libPods-VOKCoreDataManager Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D0ECBD75C14DE7E28A7EC77D2E000DE1 /* Pods-TodayWidget-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-TodayWidget-acknowledgements.markdown"; sourceTree = "<group>"; };
-		D40257CD208964BCE78B70C34005C8C5 /* Vokoder-fdc3d3be-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Vokoder-fdc3d3be-prefix.pch"; path = "../Vokoder-fdc3d3be/Vokoder-fdc3d3be-prefix.pch"; sourceTree = "<group>"; };
-		DA0098176104446F883E6B65527B8A0A /* ILGDynamicObjC-iOS10.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ILGDynamicObjC-iOS10.0-dummy.m"; path = "../ILGDynamicObjC-iOS10.0/ILGDynamicObjC-iOS10.0-dummy.m"; sourceTree = "<group>"; };
-		DEE627662872CB24AE24EF8A1B15A39E /* Vokoder-07029ee6-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Vokoder-07029ee6-dummy.m"; sourceTree = "<group>"; };
-		DEEB8C66CC5B1B7454B655E292186A1B /* Pods-VOKCoreDataManager-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-frameworks.sh"; sourceTree = "<group>"; };
-		E06163AF4D915009488688232A7B4C4D /* VOKUtilities-iOS8.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-iOS8.0-prefix.pch"; path = "../VOKUtilities-iOS8.0/VOKUtilities-iOS8.0-prefix.pch"; sourceTree = "<group>"; };
-		E13F3EDD2F47EF0B51BF6F98D0F0D66C /* Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
-		E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
-		E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
-		E646F53576D2B76A6A6E9AD7DF6C4B29 /* ILGDynamicObjC-watchOS3.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ILGDynamicObjC-watchOS3.0-dummy.m"; path = "../ILGDynamicObjC-watchOS3.0/ILGDynamicObjC-watchOS3.0-dummy.m"; sourceTree = "<group>"; };
-		E6F54BB5AB37176AAA83A49176FA0059 /* VOKUtilities-iOS10.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-iOS10.0.xcconfig"; path = "../VOKUtilities-iOS10.0/VOKUtilities-iOS10.0.xcconfig"; sourceTree = "<group>"; };
-		E8547EA323C1AA719A1FF131E70AEE1D /* Pods-VOKCoreDataManager-OSX-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-OSX-frameworks.sh"; sourceTree = "<group>"; };
-		E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
-		E9ED29E7E1F76D0FF99CF9DB16183B62 /* Vokoder.root-Core-MapperMacros-OSX-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Vokoder.root-Core-MapperMacros-OSX-prefix.pch"; path = "../Vokoder.root-Core-MapperMacros-OSX/Vokoder.root-Core-MapperMacros-OSX-prefix.pch"; sourceTree = "<group>"; };
-		EBEA8207C0D661ACB025E6D82502CA38 /* ILGDynamicObjC-tvOS9.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ILGDynamicObjC-tvOS9.0-prefix.pch"; path = "../ILGDynamicObjC-tvOS9.0/ILGDynamicObjC-tvOS9.0-prefix.pch"; sourceTree = "<group>"; };
-		F5BC8660565E6934A19C07FB2098C015 /* ILGDynamicObjC-tvOS9.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ILGDynamicObjC-tvOS9.0.xcconfig"; path = "../ILGDynamicObjC-tvOS9.0/ILGDynamicObjC-tvOS9.0.xcconfig"; sourceTree = "<group>"; };
-		F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
-		F81B0DE028348E52206FD42D4DC16375 /* Pods-VOKCoreDataManagerTests-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManagerTests-OSX.release.xcconfig"; sourceTree = "<group>"; };
-		F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKKeyPathHelper.h; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.h; sourceTree = "<group>"; };
-		F8A822E5E3CDFCC86FEC214C99131A21 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		F9A0609938E5CA1367E1F89470849D81 /* libILGDynamicObjC-OSX10.9.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-OSX10.9.a"; path = "libILGDynamicObjC-OSX10.9.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F9EA45BBC0D3AEFE43074A41F86C2A5E /* Pods-WatchApp Extension-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-WatchApp Extension-frameworks.sh"; sourceTree = "<group>"; };
-		FBDE53507268195ABEBE26048C784F33 /* Pods-VOKCoreDataManager Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.release.xcconfig"; sourceTree = "<group>"; };
-		FCA7CA01E95D374CCBF80D4DC4F6D327 /* Pods-VOKCoreDataManager-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-resources.sh"; sourceTree = "<group>"; };
-		FCCC98393094B15D22C29F6DF6BD111D /* libILGDynamicObjC-tvOS9.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-tvOS9.0.a"; path = "libILGDynamicObjC-tvOS9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		00B1C1D5AD6DEFA2EA6F7FC013F189BA /* Pods-TodayWidget-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TodayWidget-dummy.m"; sourceTree = "<group>"; };
+		02EE4FC2B5A5C8BF8A41098711CFFB96 /* Vokoder.root-Core-MapperMacros-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Vokoder.root-Core-MapperMacros-OSX-dummy.m"; path = "../Vokoder.root-Core-MapperMacros-OSX/Vokoder.root-Core-MapperMacros-OSX-dummy.m"; sourceTree = "<group>"; };
+		039E65118EEA36942D15DABBB9EAACB4 /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
+		0722BD137224E95065B72D89C2AFBCFD /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
+		0822D55044354A39166D9FB00608562A /* ILGDynamicObjC-watchOS3.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ILGDynamicObjC-watchOS3.0.xcconfig"; path = "../ILGDynamicObjC-watchOS3.0/ILGDynamicObjC-watchOS3.0.xcconfig"; sourceTree = "<group>"; };
+		0829DC05EF10616A90D5DF6DBF009707 /* VOKUtilities-iOS10.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-iOS10.0-prefix.pch"; path = "../VOKUtilities-iOS10.0/VOKUtilities-iOS10.0-prefix.pch"; sourceTree = "<group>"; };
+		085798873D67A80FB040EA3B6A743517 /* libVokoder.root-Core-MapperMacros-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder.root-Core-MapperMacros-OSX.a"; path = "libVokoder.root-Core-MapperMacros-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0D930BD0A47458465742C522AB38F134 /* libVOKUtilities-watchOS3.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-watchOS3.0.a"; path = "libVOKUtilities-watchOS3.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E11CB0B4AE91356599EC30A92B9972A /* Vokoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Vokoder.h; sourceTree = "<group>"; };
+		0F2089D95BFC5705AD4E43E3CBDC443F /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		12178C220C625240393129263706C656 /* Pods-WatchApp Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-WatchApp Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		123BB9266A782F96C3F82E512E8891DB /* ILGDynamicObjC-OSX10.9.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ILGDynamicObjC-OSX10.9.xcconfig"; sourceTree = "<group>"; };
+		12C49CD1056AAD495FDA5BF1EA384CE9 /* VOKUtilities-iOS10.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-iOS10.0.xcconfig"; path = "../VOKUtilities-iOS10.0/VOKUtilities-iOS10.0.xcconfig"; sourceTree = "<group>"; };
+		137CEBF5CEC0D192C01F155F008C1889 /* Pods-VOKCoreDataManager-OSX-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-OSX-frameworks.sh"; sourceTree = "<group>"; };
+		175B97ED97FF11884C8CA8C5716833D9 /* Pods-VOKCoreDataManager-tvOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-tvOS-frameworks.sh"; sourceTree = "<group>"; };
+		18BBC67C0C118607A919DCEFF329F696 /* ILGDynamicObjC-watchOS3.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ILGDynamicObjC-watchOS3.0-dummy.m"; path = "../ILGDynamicObjC-watchOS3.0/ILGDynamicObjC-watchOS3.0-dummy.m"; sourceTree = "<group>"; };
+		18F022ECB974D204BBFAF860AB26BE98 /* Pods-VOKCoreDataManager.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.release.xcconfig"; sourceTree = "<group>"; };
+		1AE9A2733CEB631B9297DF5ED0D30AEC /* libVOKUtilities-OSX10.9.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-OSX10.9.a"; path = "libVOKUtilities-OSX10.9.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1BE54F210803C0119522666D4C3789E4 /* Pods-VOKCoreDataManager-tvOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-tvOS-resources.sh"; sourceTree = "<group>"; };
+		1E78DEB2F932136C3E98D48AD1ABD656 /* ILGDynamicObjC-watchOS3.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ILGDynamicObjC-watchOS3.0-prefix.pch"; path = "../ILGDynamicObjC-watchOS3.0/ILGDynamicObjC-watchOS3.0-prefix.pch"; sourceTree = "<group>"; };
+		1EE9FA64AE5379867E8F4162B4D817A1 /* Pods-VOKCoreDataManager-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-dummy.m"; sourceTree = "<group>"; };
+		1FF2BA4CAB1FB2656362DEE994F1CAE1 /* Pods-VOKCoreDataManager-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-acknowledgements.markdown"; sourceTree = "<group>"; };
+		201D9EB35DF7F2E4F51395D95D807000 /* VOKUtilities-iOS8.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-iOS8.0.xcconfig"; path = "../VOKUtilities-iOS8.0/VOKUtilities-iOS8.0.xcconfig"; sourceTree = "<group>"; };
+		227F6BBE28D179CB31B4DF636979A543 /* NSManagedObject+VOKManagedObjectAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+VOKManagedObjectAdditions.m"; sourceTree = "<group>"; };
+		23CF117C75623C0A52AF3966769DEAED /* Pods-VOKCoreDataManagerTests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManagerTests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		242689EB3526057D02B5839C6FE129F2 /* Pods-VOKCoreDataManagerTests-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManagerTests-OSX.release.xcconfig"; sourceTree = "<group>"; };
+		249EC7AB8EB090B7305A598F726DBBB4 /* VOKUtilities-iOS10.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-iOS10.0-dummy.m"; path = "../VOKUtilities-iOS10.0/VOKUtilities-iOS10.0-dummy.m"; sourceTree = "<group>"; };
+		25CA4DC541F4315641B27252789BC11E /* libVOKUtilities-tvOS9.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-tvOS9.0.a"; path = "libVOKUtilities-tvOS9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2626459696E3F30C9A8C3096568BF160 /* Vokoder-43a9e09e-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Vokoder-43a9e09e-dummy.m"; path = "../Vokoder-43a9e09e/Vokoder-43a9e09e-dummy.m"; sourceTree = "<group>"; };
+		2797C5EFB0D6E418F204877116937884 /* VOKManagedObjectMapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapper.h; sourceTree = "<group>"; };
+		27BEF371CA71482BA0F90C63244554D2 /* Pods-VOKCoreDataManagerTests-OSX-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManagerTests-OSX-resources.sh"; sourceTree = "<group>"; };
+		29B3979E5DCC7013963C33CC7603148A /* Pods-TodayWidget-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TodayWidget-resources.sh"; sourceTree = "<group>"; };
+		2C80C1AF1B4A51B665AC7646313D71FA /* VOKCoreDataManagerInternalMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManagerInternalMacros.h; sourceTree = "<group>"; };
+		2F16018059E07FFE33BA6CAE4B20A3FE /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		310E3889F83DDE730396B90732C5C8B0 /* VOKManagedObjectMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMap.h; sourceTree = "<group>"; };
+		32280C1E9AA2275E2847AB485F7E3B3A /* Pods-VOKCoreDataManager-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
+		3307A89E8353106F38E6D722FD9F2AAC /* ILGDynamicObjC-iOS10.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ILGDynamicObjC-iOS10.0-dummy.m"; path = "../ILGDynamicObjC-iOS10.0/ILGDynamicObjC-iOS10.0-dummy.m"; sourceTree = "<group>"; };
+		339398E133813BCE26F4E531B62ED799 /* VOKUtilities-OSX10.9.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "VOKUtilities-OSX10.9.xcconfig"; sourceTree = "<group>"; };
+		35D4814650D73EC866488F54A2D67E18 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
+		36D9A4DC3B1A125B1D5CCE302D8F1EDA /* VOKUtilities-iOS8.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-iOS8.0-prefix.pch"; path = "../VOKUtilities-iOS8.0/VOKUtilities-iOS8.0-prefix.pch"; sourceTree = "<group>"; };
+		384263883049C22706A76345B43FDDE4 /* libVokoder-43a9e09e.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder-43a9e09e.a"; path = "libVokoder-43a9e09e.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		387F115E6362EADCAEFF6C411628107F /* Vokoder-07029ee6-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Vokoder-07029ee6-prefix.pch"; sourceTree = "<group>"; };
+		3C61847DB7A6DA88D9BC36D1749F02D4 /* libPods-VOKCoreDataManager.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManager.a"; path = "libPods-VOKCoreDataManager.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CC2041D7E575A04429B998BFEE9E6AD /* Pods-VOKCoreDataManagerTests-tvOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManagerTests-tvOS-frameworks.sh"; sourceTree = "<group>"; };
+		3CE037145D600CAE7611AAAD52F11819 /* libPods-VOKCoreDataManagerTests-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManagerTests-tvOS.a"; path = "libPods-VOKCoreDataManagerTests-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3DEE798B4DA83762C29CD7D8D3730B0E /* VOKKeyPathHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKKeyPathHelper.m; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.m; sourceTree = "<group>"; };
+		3E7731EED349F4BAA86AD357B9D186F5 /* libILGDynamicObjC-OSX10.9.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-OSX10.9.a"; path = "libILGDynamicObjC-OSX10.9.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3EEA0A1935EF7399211A2BCD3991E752 /* VOKManagedObjectMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMap.m; sourceTree = "<group>"; };
+		4109FF539D2341CA5287721D8D377E01 /* NSManagedObject+VOKManagedObjectAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+VOKManagedObjectAdditions.h"; sourceTree = "<group>"; };
+		4432D8541F20799C23DEE42D5CCEDBFF /* Pods-VOKCoreDataManager-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		45B6E117E8CDB8476988AE421220A1D0 /* Pods-WatchApp Extension-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-WatchApp Extension-acknowledgements.markdown"; sourceTree = "<group>"; };
+		48DA15F76198935F143046A92BF85D5D /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
+		521A958366FF5BF44A89EC736B34CFB9 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
+		524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		530A969A524869B061EB8E86836D66D4 /* libVokoder.root-Core-MapperMacros-watchOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder.root-Core-MapperMacros-watchOS.a"; path = "libVokoder.root-Core-MapperMacros-watchOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		553549EFA679B8A59F83573CB40F58FF /* Pods-VOKCoreDataManager-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
+		5A40B3D080F77790B09C44712042846D /* Pods-VOKCoreDataManager-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager-OSX.release.xcconfig"; sourceTree = "<group>"; };
+		5B56A6ABEF8F00FDAE2581F8373C1F20 /* Pods-VOKCoreDataManagerTests-OSX-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManagerTests-OSX-frameworks.sh"; sourceTree = "<group>"; };
+		5D943398B27AE869F6B49ABF7B206FDC /* VOKUtilities-OSX10.9-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-OSX10.9-prefix.pch"; sourceTree = "<group>"; };
+		5F329743F37B90C2ACD5BCFCEC97DFC8 /* ILGDynamicObjC-tvOS9.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ILGDynamicObjC-tvOS9.0-dummy.m"; path = "../ILGDynamicObjC-tvOS9.0/ILGDynamicObjC-tvOS9.0-dummy.m"; sourceTree = "<group>"; };
+		5F64AC3872552EEAC9BB4EBBC4A1C680 /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		62DA861B7AADDD554BA6787E4FC5CC3F /* VOKUtilities-tvOS9.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-tvOS9.0.xcconfig"; path = "../VOKUtilities-tvOS9.0/VOKUtilities-tvOS9.0.xcconfig"; sourceTree = "<group>"; };
+		64142C568D6CFA890CEDDA2E2DA3FCEF /* Pods-TodayWidget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TodayWidget.debug.xcconfig"; sourceTree = "<group>"; };
+		64F005CCB40EDE27A2C7F87D947C147A /* Pods-VOKCoreDataManager Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-frameworks.sh"; sourceTree = "<group>"; };
+		6DF3D76A0E74B3FE12499AF2CDBB3B46 /* ILGDynamicObjC-iOS8.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ILGDynamicObjC-iOS8.0.xcconfig"; path = "../ILGDynamicObjC-iOS8.0/ILGDynamicObjC-iOS8.0.xcconfig"; sourceTree = "<group>"; };
+		6EC1B0A9236F356043741C189C734487 /* ILGDynamicObjC-iOS8.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ILGDynamicObjC-iOS8.0-dummy.m"; path = "../ILGDynamicObjC-iOS8.0/ILGDynamicObjC-iOS8.0-dummy.m"; sourceTree = "<group>"; };
+		709585C36368811AC1D9697E5DBB5EF5 /* Vokoder-07029ee6.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Vokoder-07029ee6.xcconfig"; sourceTree = "<group>"; };
+		72754AB4E960B9263917C6029CCF050E /* VOKUtilities-watchOS3.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-watchOS3.0-prefix.pch"; path = "../VOKUtilities-watchOS3.0/VOKUtilities-watchOS3.0-prefix.pch"; sourceTree = "<group>"; };
+		7352ED4444C19481CC17378C2FE27A19 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		75FF86E0104378C3A12B5AC1D933BF7A /* libILGDynamicObjC-watchOS3.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-watchOS3.0.a"; path = "libILGDynamicObjC-watchOS3.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7639258F331D52B880154D63E782D7A6 /* ILGDynamicObjC-tvOS9.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ILGDynamicObjC-tvOS9.0.xcconfig"; path = "../ILGDynamicObjC-tvOS9.0/ILGDynamicObjC-tvOS9.0.xcconfig"; sourceTree = "<group>"; };
+		77118E2573E1FBFEB6E82786750837EE /* Pods-VOKCoreDataManager Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager Tests-dummy.m"; sourceTree = "<group>"; };
+		773655DAAEEFB626CDB5269FAB35E6A6 /* Vokoder-07029ee6-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Vokoder-07029ee6-dummy.m"; sourceTree = "<group>"; };
+		77C2F18192329FDEB94436161E9CDF88 /* Pods-WatchApp Extension-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-WatchApp Extension-acknowledgements.plist"; sourceTree = "<group>"; };
+		7BC95B5FA7DD23673D1DC56B026A8A8C /* libPods-VOKCoreDataManager-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManager-OSX.a"; path = "libPods-VOKCoreDataManager-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7BE66F99CFBD1158700CBA78A581B33C /* VOKUtilities-tvOS9.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-tvOS9.0-prefix.pch"; path = "../VOKUtilities-tvOS9.0/VOKUtilities-tvOS9.0-prefix.pch"; sourceTree = "<group>"; };
+		7CE3519B3FC051821FEC2239CA22B0E3 /* Pods-VOKCoreDataManager-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-tvOS-dummy.m"; sourceTree = "<group>"; };
+		7F654DD7B9B6C5F8A2D1B22E1FC39017 /* Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
+		80C67A00CBB4DB91E7F2B379001F2289 /* Pods-VOKCoreDataManagerTests-tvOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManagerTests-tvOS-resources.sh"; sourceTree = "<group>"; };
+		834DCAF6A2F5FBE14EA7AC3A00C677A9 /* libVOKUtilities-iOS10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-iOS10.0.a"; path = "libVOKUtilities-iOS10.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		83A5210A54A780630BFCCE098510222D /* VOKKeyPathHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKKeyPathHelper.h; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.h; sourceTree = "<group>"; };
+		86DB4D85A8C97A6DCDAF2D09923392DD /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManagerTests-tvOS-dummy.m"; sourceTree = "<group>"; };
+		879EAB0203F40FAFEB5CFE9C736732B8 /* Pods-VOKCoreDataManager-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager-OSX.debug.xcconfig"; sourceTree = "<group>"; };
+		8877FAEF7810195BFDC5E166FD00BC5C /* Pods-VOKCoreDataManagerTests-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManagerTests-OSX.debug.xcconfig"; sourceTree = "<group>"; };
+		89716B6A96D24231D00AB0C8F2B7C2EE /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		897BD57F8A563D5FE8B40A0B7B3D48FC /* Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
+		89C28DEC52743FA31E609674BE81B735 /* libILGDynamicObjC-tvOS9.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-tvOS9.0.a"; path = "libILGDynamicObjC-tvOS9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8AC9E0102E8FE389921ADBDDC8FF49D8 /* Pods-TodayWidget-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-TodayWidget-acknowledgements.markdown"; sourceTree = "<group>"; };
+		8C30D8E728A343D3553ECAD52DD15F5B /* Pods-VOKCoreDataManager-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		8C482370A22662EBCBDABF143AE65DA1 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		8DB45E93EADED6344C252DD1FB4F2423 /* Pods-VOKCoreDataManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager.debug.xcconfig"; sourceTree = "<group>"; };
+		8DB738C95F2DE503CC441547763906D9 /* Pods-TodayWidget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TodayWidget.release.xcconfig"; sourceTree = "<group>"; };
+		91DC91E6AC68D30020C930507DB0AA6B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS3.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		943322D0A26187E027E2764D4EC85A77 /* libVokoder-07029ee6.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder-07029ee6.a"; path = "libVokoder-07029ee6.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		944710C3649D0EDB774CD8EDC4DCC971 /* Pods-VOKCoreDataManager Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager Tests-resources.sh"; sourceTree = "<group>"; };
+		95AB9EE21EB6A93107C55C85E236B4BF /* libPods-VOKCoreDataManager Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManager Tests.a"; path = "libPods-VOKCoreDataManager Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		985003308B1C6CFEF05E5F64F040FC89 /* Pods-WatchApp Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-WatchApp Extension.release.xcconfig"; sourceTree = "<group>"; };
+		9AF7275329537EADCF12B27F2EECBD8A /* Pods-VOKCoreDataManagerTests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManagerTests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		9BA6C7F8BFBB540D271B7C39AE4D8F56 /* Vokoder.root-Core-MapperMacros-OSX-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Vokoder.root-Core-MapperMacros-OSX-prefix.pch"; path = "../Vokoder.root-Core-MapperMacros-OSX/Vokoder.root-Core-MapperMacros-OSX-prefix.pch"; sourceTree = "<group>"; };
+		9DDBA1D4CA1F7F7B54DE18C40A053415 /* libPods-WatchApp Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-WatchApp Extension.a"; path = "libPods-WatchApp Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E162345569AC2BF6551C77E0431969D /* ILGDynamicObjC-tvOS9.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ILGDynamicObjC-tvOS9.0-prefix.pch"; path = "../ILGDynamicObjC-tvOS9.0/ILGDynamicObjC-tvOS9.0-prefix.pch"; sourceTree = "<group>"; };
+		9F031FFF1DE23E344F2DF5B559741D35 /* libILGDynamicObjC-iOS10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-iOS10.0.a"; path = "libILGDynamicObjC-iOS10.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F89761EDFF3BC77C47475E71440A115 /* Vokoder-fdc3d3be-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Vokoder-fdc3d3be-dummy.m"; path = "../Vokoder-fdc3d3be/Vokoder-fdc3d3be-dummy.m"; sourceTree = "<group>"; };
+		A2C0960CFA72441F03306FC9EC955F8C /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		A51D6B1CB24680567D407CAA0F7A1ACE /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
+		A537D9F722B61F040A86A633A1ADEB5C /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Vokoder.root-Core-MapperMacros-watchOS-dummy.m"; path = "../Vokoder.root-Core-MapperMacros-watchOS/Vokoder.root-Core-MapperMacros-watchOS-dummy.m"; sourceTree = "<group>"; };
+		A6E740100759BC1AEB864C35081CB978 /* libVokoder-fdc3d3be.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVokoder-fdc3d3be.a"; path = "libVokoder-fdc3d3be.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A83571761A3EC64BB78549810DA2558F /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
+		A9E463A83ECB0D1A6746F8BF76439B2F /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
+		AAE3F3A1C8CF402CEB9FB0A16E937B4E /* Pods-VOKCoreDataManagerTests-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManagerTests-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
+		ACC93AC3354867D4E1A9EA57B514B986 /* VOKUtilities-OSX10.9-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VOKUtilities-OSX10.9-dummy.m"; sourceTree = "<group>"; };
+		AE5A89F0E56D4213B15C9B798CEAC9D3 /* Pods-VOKCoreDataManager-OSX-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-OSX-resources.sh"; sourceTree = "<group>"; };
+		B35AEEFA32F827F824257B551216CA40 /* Pods-VOKCoreDataManagerTests-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManagerTests-OSX-dummy.m"; sourceTree = "<group>"; };
+		B4D70FC55279FF036ED49145ABFDB1EC /* Vokoder-43a9e09e.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Vokoder-43a9e09e.xcconfig"; path = "../Vokoder-43a9e09e/Vokoder-43a9e09e.xcconfig"; sourceTree = "<group>"; };
+		B669B29C55DF73AE4CCA35D1DBFA0FBA /* libPods-TodayWidget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-TodayWidget.a"; path = "libPods-TodayWidget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B856F3CFBAE274FF48463610B4D47431 /* ILGDynamicObjC-iOS8.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ILGDynamicObjC-iOS8.0-prefix.pch"; path = "../ILGDynamicObjC-iOS8.0/ILGDynamicObjC-iOS8.0-prefix.pch"; sourceTree = "<group>"; };
+		B8EBE3D4A209FFE5CA056F1E82CA7365 /* Vokoder-43a9e09e-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Vokoder-43a9e09e-prefix.pch"; path = "../Vokoder-43a9e09e/Vokoder-43a9e09e-prefix.pch"; sourceTree = "<group>"; };
+		B90F4F8E35E9494213EE548E18CF4C60 /* Vokoder.root-Core-MapperMacros-watchOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Vokoder.root-Core-MapperMacros-watchOS.xcconfig"; path = "../Vokoder.root-Core-MapperMacros-watchOS/Vokoder.root-Core-MapperMacros-watchOS.xcconfig"; sourceTree = "<group>"; };
+		BBC4DD83586D3E0AFB4994434004972E /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
+		BCC0FF64C3F3E287CEAECA22685202E8 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS3.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
+		BDDF3ADA1E4AEB030434A241FD4B8B8E /* ILGClasses.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ILGClasses.m; path = Pod/ILGClasses/ILGClasses.m; sourceTree = "<group>"; };
+		BE0E8BA9D1D2B080C2BEA9741E7ED987 /* libILGDynamicObjC-iOS8.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libILGDynamicObjC-iOS8.0.a"; path = "libILGDynamicObjC-iOS8.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BED15F08A06BAA2A3BB8DE826104D4D1 /* Pods-VOKCoreDataManagerTests-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManagerTests-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
+		BF62C8810B96ED634A2FCBF9C13300DD /* ILGDynamicObjC-OSX10.9-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-OSX10.9-dummy.m"; sourceTree = "<group>"; };
+		BF859A556407AB3B779037550A73BD61 /* Pods-VOKCoreDataManager-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
+		C2319594E52947BD6FFA07571BAAF4F7 /* VOKUtilities-watchOS3.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-watchOS3.0.xcconfig"; path = "../VOKUtilities-watchOS3.0/VOKUtilities-watchOS3.0.xcconfig"; sourceTree = "<group>"; };
+		C2AF078AB0B6B0EA905EA98ECAD81F57 /* libPods-VOKCoreDataManager-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManager-tvOS.a"; path = "libPods-VOKCoreDataManager-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C43930A300BDD6E51802E60CCCB0D0BA /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
+		C4453F87DEB288348F49730EEA8D995E /* Pods-VOKCoreDataManager Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKCoreDataManager Tests.release.xcconfig"; sourceTree = "<group>"; };
+		C47D0C3C9C886EB71766440D090D84F4 /* libPods-VOKCoreDataManagerTests-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKCoreDataManagerTests-OSX.a"; path = "libPods-VOKCoreDataManagerTests-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C788AC783CE6FEB20516FD5EB2848839 /* Vokoder.root-Core-MapperMacros-watchOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Vokoder.root-Core-MapperMacros-watchOS-prefix.pch"; path = "../Vokoder.root-Core-MapperMacros-watchOS/Vokoder.root-Core-MapperMacros-watchOS-prefix.pch"; sourceTree = "<group>"; };
+		C87D8A69D8DB306B4C1B788C8A3DEEC5 /* Pods-WatchApp Extension-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-WatchApp Extension-frameworks.sh"; sourceTree = "<group>"; };
+		C8FDBE7F424A75BC5CBA314BD5CE0DC3 /* Pods-VOKCoreDataManager-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKCoreDataManager-OSX-dummy.m"; sourceTree = "<group>"; };
+		CB47F8B49375B3DB7D3EB7AA68DA9386 /* Vokoder.root-Core-MapperMacros-OSX.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Vokoder.root-Core-MapperMacros-OSX.xcconfig"; path = "../Vokoder.root-Core-MapperMacros-OSX/Vokoder.root-Core-MapperMacros-OSX.xcconfig"; sourceTree = "<group>"; };
+		CD69CE6196BAE8CE0D0608DDBAAA020D /* Pods-WatchApp Extension-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-WatchApp Extension-resources.sh"; sourceTree = "<group>"; };
+		CDAB26DA0FB2C2CF6F3E8B966842D337 /* VOKManagedObjectMapperMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKManagedObjectMapperMacros.h; sourceTree = "<group>"; };
+		CDFFC814F1B01089D5B0D624B69FEBEE /* Pods-VOKCoreDataManager-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-resources.sh"; sourceTree = "<group>"; };
+		D1293E065D42D768205B207270C2356E /* Vokoder-fdc3d3be-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Vokoder-fdc3d3be-prefix.pch"; path = "../Vokoder-fdc3d3be/Vokoder-fdc3d3be-prefix.pch"; sourceTree = "<group>"; };
+		D18623CBBFD7CD618675FBAC976D3742 /* ILGDynamicObjC-iOS10.0.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ILGDynamicObjC-iOS10.0.xcconfig"; path = "../ILGDynamicObjC-iOS10.0/ILGDynamicObjC-iOS10.0.xcconfig"; sourceTree = "<group>"; };
+		D425622BFD2229DC889BD761596FA01D /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		D4BA686AE29FE18AA38F37E1001B693E /* Pods-VOKCoreDataManager-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-VOKCoreDataManager-frameworks.sh"; sourceTree = "<group>"; };
+		D91D5E5463F76934D51AB2FFC59D546C /* VOKCoreDataCollectionTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataCollectionTypes.h; sourceTree = "<group>"; };
+		D9D0CC5720AA3DAAC9C766E45CF5AC6C /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
+		DCE46F0FA451203C4B177CB97185B36B /* Pods-VOKCoreDataManager-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKCoreDataManager-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
+		DDA6FB76586271443E51CF241698D6DC /* Pods-WatchApp Extension-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-WatchApp Extension-dummy.m"; sourceTree = "<group>"; };
+		DDA71DEC128940B8DAB0A12B04263CFC /* ILGDynamicObjC-iOS10.0-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ILGDynamicObjC-iOS10.0-prefix.pch"; path = "../ILGDynamicObjC-iOS10.0/ILGDynamicObjC-iOS10.0-prefix.pch"; sourceTree = "<group>"; };
+		DF04FC76E417F688040F041EEA262C6F /* ILGDynamicObjC-OSX10.9-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ILGDynamicObjC-OSX10.9-prefix.pch"; sourceTree = "<group>"; };
+		DF071EAFFD9023C09CD28A9BEB38176E /* VOKUtilities-watchOS3.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-watchOS3.0-dummy.m"; path = "../VOKUtilities-watchOS3.0/VOKUtilities-watchOS3.0-dummy.m"; sourceTree = "<group>"; };
+		DF5CDD4C869B4BEEF7CF3640366AEED0 /* Pods-TodayWidget-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TodayWidget-acknowledgements.plist"; sourceTree = "<group>"; };
+		E7568C58ACCAA3EDD1E4713AF3B81B0C /* Vokoder-fdc3d3be.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Vokoder-fdc3d3be.xcconfig"; path = "../Vokoder-fdc3d3be/Vokoder-fdc3d3be.xcconfig"; sourceTree = "<group>"; };
+		E89B993C8180F85E9D8901BF9BAA393D /* Pods-VOKCoreDataManager-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager-acknowledgements.plist"; sourceTree = "<group>"; };
+		ED3CE8BE75D7D627CE0B3DFBE8241DC1 /* libVOKUtilities-iOS8.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-iOS8.0.a"; path = "libVOKUtilities-iOS8.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EE09513D5B1E4CD4EA4BAC37980EF5C6 /* VOKUtilities-iOS8.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-iOS8.0-dummy.m"; path = "../VOKUtilities-iOS8.0/VOKUtilities-iOS8.0-dummy.m"; sourceTree = "<group>"; };
+		EE703BCDCC0695C0BCCA3697885EADA5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		EF2F5E5AD6B5231F5D7DA2650C39E582 /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
+		F528442C02A3343B61C0AEC0031963E3 /* VOKUtilities-tvOS9.0-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-tvOS9.0-dummy.m"; path = "../VOKUtilities-tvOS9.0/VOKUtilities-tvOS9.0-dummy.m"; sourceTree = "<group>"; };
+		FBC93AAC731F32F0D5EAA9C1EF1A977B /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKCoreDataManager Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		9705A6FECE3EA790824536A67108E916 /* Frameworks */ = {
+		017B6ED21EDBA580593C392B20A59AE7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9D4D7E8EFD7E36D37FCC4752A1FBAF0E /* Foundation.framework in Frameworks */,
+				876FDD63EB3512E84F61972B9737800C /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F9BA38C67260C6ED66E32CB07929B991 /* Frameworks */ = {
+		0A2623FD3FEA4D41EB286193E13B4C19 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65B1ED16AD8C7AA351BF7A872F698F8C /* Cocoa.framework in Frameworks */,
+				4EEDF0D502A1B69C1E22DA082DA7BF45 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C5F028CC333FB54921DC558268C2460B /* Frameworks */ = {
+		0C5A8FF94918E3D91D56609D4F12DEC5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F5F23DA6453D28D95E8A733A85601B1C /* Foundation.framework in Frameworks */,
+				72B1A8E71068821887B4F99755D9F5F6 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C892977BEF1C9F4CEC43EDE0D1F40FB6 /* Frameworks */ = {
+		10902616494876AF49A0543E2CC817BC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E58204A8205C8159D1F6DA3FE719D2AB /* Foundation.framework in Frameworks */,
+				AB632F97BE96C30D53B4A836E375492B /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E2BBA8E0FEA1A74D432CD3E12690C43E /* Frameworks */ = {
+		1AB91CBCF57970C0E0B5078E297B4723 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4BA15FD945CC92F7509238BFBC6515C6 /* Foundation.framework in Frameworks */,
+				C41831A748898B12950AFA29B245E36A /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3637DF4BAB4DF16A93E8A1163D59077C /* Frameworks */ = {
+		3B593D9ABD41F094C991309D2F114552 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E78C5052267BCCFBEB22F27B3A00EA9F /* Cocoa.framework in Frameworks */,
-				A66A81E509C40E74D7AA088CCC1FF9FB /* CoreData.framework in Frameworks */,
+				FD17FAEBAA7AC7D0F7BF1B48D605A0BF /* Cocoa.framework in Frameworks */,
+				0D5E14E5142F40C5A4FA2BE16FAFC1BE /* CoreData.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EF18044A09514CD811257A1D01E8208C /* Frameworks */ = {
+		40AAF9A3BC5E671040EA47286DC80290 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C7594F21A0AECD01716AE7F09DD30209 /* Foundation.framework in Frameworks */,
+				045626A337D27B79B5F1DFA71B4E41D0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B5C67F9E32BC71528FC0169332D88E19 /* Frameworks */ = {
+		4B92A6F10C1BC3A54B2DB79524937D7D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E3B3136AFD1DAC359D11181B486F30B9 /* Foundation.framework in Frameworks */,
+				5594EED99914945B42D5A3822E443D10 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DA0E5D65344A5E149D9FA9010C4533C0 /* Frameworks */ = {
+		64FE22A5308BF1171E6B0AF8E535C214 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5EF2E643525616EC375997F2AEB86E21 /* Foundation.framework in Frameworks */,
+				A19A08BB12239F2FC8F21F085A4C4938 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D9C6784E5CA0DE435F9022A5BD1BE1AD /* Frameworks */ = {
+		792FDE4052A094713E2C42AC5D3AF39F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BDD8B57802D9673AD52A1A618EC6CF6F /* Foundation.framework in Frameworks */,
+				087B92FCA40D5EAF5DF821EE4FABB13F /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F93A5DF5D5D3A9FC8F058C69737801C2 /* Frameworks */ = {
+		8617A12C2A24565823C9881D9F69EFDE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0DB6A46CE2F6D5966ED8D9DF06BA2B55 /* Cocoa.framework in Frameworks */,
+				B394199A26A67A099751C8BE89D32ED0 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		63130B3F7ED5E693AC24DDA5AC693817 /* Frameworks */ = {
+		870C9A19B5B0396E96B391037A3C4C02 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6993215C457638263962E17F9A066163 /* Foundation.framework in Frameworks */,
+				5FFA65785C48EE7F614380C5A669B59E /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B3F3DA62DED8E6D96C31A22FA58B690B /* Frameworks */ = {
+		8EAC365920410C7FBE56B121F93B1363 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				825286991F22E1D3962B06DB2F2BC854 /* Cocoa.framework in Frameworks */,
+				A0ACF217DB3CD340DB7C37F297C579C4 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C3E5A285980D6BA2FF9238B573470C95 /* Frameworks */ = {
+		915918B96A0A163C62FABDA6BC0004FA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3CEC4C3BC960907305B96B5B2355A869 /* CoreData.framework in Frameworks */,
-				6D9831C017C990F306AE2D41405A196A /* Foundation.framework in Frameworks */,
+				55D9B2410A5B6150AABE187DFCFF7BCA /* CoreData.framework in Frameworks */,
+				4CE974ED5A7BE92BBEF22924BEC1DCD8 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C8147EE810BFF6D3979BE9457FC7E754 /* Frameworks */ = {
+		993736DF3ACEBE8D478446A54DD11BD8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F28F423A4D4ABFB740076745484CC9FA /* Foundation.framework in Frameworks */,
+				2FF66D88F81B19690D787F39DAFDBDBB /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F45E34859BC913A0A1BCE49E84469D8E /* Frameworks */ = {
+		9FC3CEFC721D6E782B42FB79514F80AD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A11FD9C14B7FFC323F364B560147150D /* Cocoa.framework in Frameworks */,
+				52B982C1F9EB5AC57849D25CB08EF653 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		54559F7DB17C4EFC7473F3BF28CB5E6D /* Frameworks */ = {
+		A834C341F3F51A30B348F29306FB29F2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B1870391FEF30266A0F1F2CD9C29FBA9 /* Foundation.framework in Frameworks */,
+				C0269007E098908DDE0D760D592777EA /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ED65389C15181290EEB875DDF5AD9B07 /* Frameworks */ = {
+		AE82542A92BDBFB6F667BE6BE1C897AA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EE0F115D4931F05A794E9B3DBB3E887A /* CoreData.framework in Frameworks */,
-				E7D998634E2AA6974F94679E1626C875 /* Foundation.framework in Frameworks */,
+				0915349CC81E429185BE68BD93586F9D /* CoreData.framework in Frameworks */,
+				6129D1483D0B9ACF1C3BC05BAC040EA7 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F256554D282483F25C4B318B383E2ED6 /* Frameworks */ = {
+		C8C676AB8424039AB9F8C4B02708CF0E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5675C02FADF11EB8E8320E724210568E /* Foundation.framework in Frameworks */,
+				0F0425993229B187D8C29E97B38404F5 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D7BC2912A05C8F68194FF8AC7A9CC89F /* Frameworks */ = {
+		CDD39C24292C1A0E4AB34F3558EE5978 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D7DE79A214E3100E67063F537318A98A /* CoreData.framework in Frameworks */,
-				A786F7556ADB2F74928A06234C3B0A84 /* Foundation.framework in Frameworks */,
+				DECF2A51D68D7AF0370D2E356236C66D /* CoreData.framework in Frameworks */,
+				0994703F9794794765C0762F51907088 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C560D008759515ED9B8054B8A567DE21 /* Frameworks */ = {
+		EA453B9A51CC86C82101FC51765AD965 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D3E5E5E0698E1423CF8F9362F1A2C29F /* CoreData.framework in Frameworks */,
-				300E953DC4BC3AB71E97A7B92966A920 /* Foundation.framework in Frameworks */,
+				37E40A24D21A090DD555C02F5D5622E7 /* CoreData.framework in Frameworks */,
+				F518A4147BB31B13EB25E7FC4917FE74 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DAC065575638A31C0EB8030CD2BF58AE /* Frameworks */ = {
+		F429E9C77E5AAC43A8582E2D2F873889 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FF0BD2F894A5249B34F67C7D74EE3259 /* Foundation.framework in Frameworks */,
+				62DB07783B027B5A6D558B662B4F3DC7 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6D0766FE9B9B89DEAD6EA3CD4903305F /* Frameworks */ = {
+		FA6C637DC7469BFF03423B36DE0F9082 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EFAA0FA4E463363BF9693C38FFD0DE01 /* Foundation.framework in Frameworks */,
+				1BDB18C364B819D884ED267A7DB0E154 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		FA69128BA538E22FB0AF31EEBAD8D0E8 /* Support Files */ = {
+		0850EFDAE6A5123D6AB6FDD9119F5FE9 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				7E58709DA76AFCA54DD99E99F8816216 /* VOKUtilities-OSX10.9-dummy.m */,
-				6E969E56DA711F59E2423C398FA26E74 /* VOKUtilities-OSX10.9-prefix.pch */,
-				3EC12C7CE4C91B4DDCDED5DE9018057A /* VOKUtilities-OSX10.9.xcconfig */,
-				11A1254258740229172AFBF17D09766B /* VOKUtilities-iOS10.0-dummy.m */,
-				B44BBB10D6BD3AC3BCE0B21191DF7E32 /* VOKUtilities-iOS10.0-prefix.pch */,
-				E6F54BB5AB37176AAA83A49176FA0059 /* VOKUtilities-iOS10.0.xcconfig */,
-				1F920122B363EAB2F5D908F0E79FDF3D /* VOKUtilities-iOS8.0-dummy.m */,
-				E06163AF4D915009488688232A7B4C4D /* VOKUtilities-iOS8.0-prefix.pch */,
-				042F42430627771693D1FDFB00E94309 /* VOKUtilities-iOS8.0.xcconfig */,
-				B4EFDCF5E3A1C9DE1EF57F56A5E89A9E /* VOKUtilities-tvOS9.0-dummy.m */,
-				6D558860809A7C7B876A65673A136A8F /* VOKUtilities-tvOS9.0-prefix.pch */,
-				9700B3DB8E75CDDF195B88F098F05B98 /* VOKUtilities-tvOS9.0.xcconfig */,
-				26E4FE111178C5C067F328C472B591B8 /* VOKUtilities-watchOS3.0-dummy.m */,
-				A9B1DC84C4E1F1C6AA5796D49FBBD731 /* VOKUtilities-watchOS3.0-prefix.pch */,
-				A35665478787B839BD2D1E47D2B76BDD /* VOKUtilities-watchOS3.0.xcconfig */,
+				12C49CD1056AAD495FDA5BF1EA384CE9 /* VOKUtilities-iOS10.0.xcconfig */,
+				249EC7AB8EB090B7305A598F726DBBB4 /* VOKUtilities-iOS10.0-dummy.m */,
+				0829DC05EF10616A90D5DF6DBF009707 /* VOKUtilities-iOS10.0-prefix.pch */,
+				201D9EB35DF7F2E4F51395D95D807000 /* VOKUtilities-iOS8.0.xcconfig */,
+				EE09513D5B1E4CD4EA4BAC37980EF5C6 /* VOKUtilities-iOS8.0-dummy.m */,
+				36D9A4DC3B1A125B1D5CCE302D8F1EDA /* VOKUtilities-iOS8.0-prefix.pch */,
+				339398E133813BCE26F4E531B62ED799 /* VOKUtilities-OSX10.9.xcconfig */,
+				ACC93AC3354867D4E1A9EA57B514B986 /* VOKUtilities-OSX10.9-dummy.m */,
+				5D943398B27AE869F6B49ABF7B206FDC /* VOKUtilities-OSX10.9-prefix.pch */,
+				62DA861B7AADDD554BA6787E4FC5CC3F /* VOKUtilities-tvOS9.0.xcconfig */,
+				F528442C02A3343B61C0AEC0031963E3 /* VOKUtilities-tvOS9.0-dummy.m */,
+				7BE66F99CFBD1158700CBA78A581B33C /* VOKUtilities-tvOS9.0-prefix.pch */,
+				C2319594E52947BD6FFA07571BAAF4F7 /* VOKUtilities-watchOS3.0.xcconfig */,
+				DF071EAFFD9023C09CD28A9BEB38176E /* VOKUtilities-watchOS3.0-dummy.m */,
+				72754AB4E960B9263917C6029CCF050E /* VOKUtilities-watchOS3.0-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/VOKUtilities-OSX10.9";
 			sourceTree = "<group>";
 		};
-		2841E6A5AFA6C5740FA47D68784B43B8 /* Vokoder */ = {
+		08CFF4FA26003D3ED27349D856037083 /* Vokoder */ = {
 			isa = PBXGroup;
 			children = (
-				92AA232EE3E496566240A00B61598355 /* Core */,
-				D291960F19FD2FE625E66028614C79A8 /* DataSources */,
-				517BAE0EB2FC6EAB1D352BBA63C2E5FF /* MapperMacros */,
-				21C815DB339F7DD825A5E4CB08881309 /* Support Files */,
+				1DF8E4AEA0AE523A4538A0C4CE33BBDB /* Core */,
+				A7C2917B05B67317F295B13F0A392BC1 /* DataSources */,
+				81220C977763C0D959F9B5D4FC7C3945 /* MapperMacros */,
+				90430806155E78F98BCBF3F3AFA04E92 /* Support Files */,
 			);
 			name = Vokoder;
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		73AB5E5F94B4DE5984CD16FDB5EABFD4 /* xUnique */ = {
+		08FC1C11FFA03D2040181A0AB8520A42 /* xUnique */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -749,529 +749,529 @@
 			path = xUnique;
 			sourceTree = "<group>";
 		};
-		DC922EC5F6A4C858F3D3657B1D19245D /* PagingFetchedResults */ = {
+		1449D0254E1393CB9050F3943C3C6D28 /* PagingFetchedResults */ = {
 			isa = PBXGroup;
 			children = (
-				2757FE2226489748E1B034F311E8325A /* Pod */,
+				8086D39D13590CFCBA7D9A4163F7369A /* Pod */,
 			);
 			name = PagingFetchedResults;
 			sourceTree = "<group>";
 		};
-		0BA6A3697D7736F3A930525826963BB3 /* Classes */ = {
+		1525D405FF372F872E9FE0F5F450642C /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				CA9F64BFACD9A6B9EFC6C13F107B6ABF /* Optional Data Sources */,
+				32874034339324736B8E2CC8AA033091 /* Optional Data Sources */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		9F13F589B0EAC0C9A4E03BAED2800F3F /* tvOS */ = {
+		1610FCFFC518173F5A896A3818D1A756 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				A1B58FA45A045846147421FED31002DE /* CoreData.framework */,
-				F8A822E5E3CDFCC86FEC214C99131A21 /* Foundation.framework */,
+				89716B6A96D24231D00AB0C8F2B7C2EE /* CoreData.framework */,
+				EE703BCDCC0695C0BCCA3697885EADA5 /* Foundation.framework */,
 			);
 			name = tvOS;
 			sourceTree = "<group>";
 		};
-		92AA232EE3E496566240A00B61598355 /* Core */ = {
+		1DF8E4AEA0AE523A4538A0C4CE33BBDB /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				7B6B69F12063310EFEBC024790A2398E /* Pod */,
+				9BE99E297F45A7CA0E5F83B9D3F5E2D8 /* Pod */,
 			);
 			name = Core;
 			sourceTree = "<group>";
 		};
-		1432AA59D8B53139E350543A9C80D7F8 /* Pods */ = {
+		23A1BCFAF0B252A99191D410D963BB63 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BD69F150A8C2569270FC79BDA1504428 /* ILGDynamicObjC */,
-				0628D34B912C2431236471EF4C7720C0 /* VOKUtilities */,
-				73AB5E5F94B4DE5984CD16FDB5EABFD4 /* xUnique */,
+				2D1A3126489A6C3D23F36C8D3FECC598 /* ILGDynamicObjC */,
+				317E4E68488687D4E8C71777164E3DF0 /* VOKUtilities */,
+				08FC1C11FFA03D2040181A0AB8520A42 /* xUnique */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		17B48808F3947CFF29A731689991D883 /* Pods-VOKCoreDataManagerTests-tvOS */ = {
+		2944F99670FE6A4C6784BD49E5DD78A1 /* Pods-VOKCoreDataManagerTests-tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				E13F3EDD2F47EF0B51BF6F98D0F0D66C /* Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.markdown */,
-				C726B5976E46922C44C8EFA843D7DDDA /* Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.plist */,
-				50A3B698A62926F6226DDBBAB560654C /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m */,
-				0A0DCF2DBCDE1AE8BF0E4D3AC368807C /* Pods-VOKCoreDataManagerTests-tvOS-frameworks.sh */,
-				435AE67FC30AD5773F7DF4D4A2A47516 /* Pods-VOKCoreDataManagerTests-tvOS-resources.sh */,
-				3A5F0559A548C85246C23DC7B387C289 /* Pods-VOKCoreDataManagerTests-tvOS.debug.xcconfig */,
-				083F6D58998BAB74E2A87D18C2293925 /* Pods-VOKCoreDataManagerTests-tvOS.release.xcconfig */,
+				7F654DD7B9B6C5F8A2D1B22E1FC39017 /* Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.markdown */,
+				897BD57F8A563D5FE8B40A0B7B3D48FC /* Pods-VOKCoreDataManagerTests-tvOS-acknowledgements.plist */,
+				86DB4D85A8C97A6DCDAF2D09923392DD /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m */,
+				3CC2041D7E575A04429B998BFEE9E6AD /* Pods-VOKCoreDataManagerTests-tvOS-frameworks.sh */,
+				80C67A00CBB4DB91E7F2B379001F2289 /* Pods-VOKCoreDataManagerTests-tvOS-resources.sh */,
+				9AF7275329537EADCF12B27F2EECBD8A /* Pods-VOKCoreDataManagerTests-tvOS.debug.xcconfig */,
+				23CF117C75623C0A52AF3966769DEAED /* Pods-VOKCoreDataManagerTests-tvOS.release.xcconfig */,
 			);
 			name = "Pods-VOKCoreDataManagerTests-tvOS";
 			path = "Target Support Files/Pods-VOKCoreDataManagerTests-tvOS";
 			sourceTree = "<group>";
 		};
-		BD69F150A8C2569270FC79BDA1504428 /* ILGDynamicObjC */ = {
+		2D1A3126489A6C3D23F36C8D3FECC598 /* ILGDynamicObjC */ = {
 			isa = PBXGroup;
 			children = (
-				C0EADA668804F57D6D9AA862CE8EF321 /* ILGClasses */,
-				F653198251905F2D19DBEA48B7F9A7DC /* Support Files */,
+				F22B9F9DE4BBA9C71A9C86D1389DEA52 /* ILGClasses */,
+				DA0893DA22AA39A7DE280E9A72774A52 /* Support Files */,
 			);
 			name = ILGDynamicObjC;
 			path = ILGDynamicObjC;
 			sourceTree = "<group>";
 		};
-		88624CD5FD99C8A7CBA4F1263EFF6000 /* Pods-WatchApp Extension */ = {
+		303BA5AC7A19CC2C1693320A2B99CCBC /* Pods-WatchApp Extension */ = {
 			isa = PBXGroup;
 			children = (
-				ADDCC00802B3ED1F8E1BE5631AF75BC4 /* Pods-WatchApp Extension-acknowledgements.markdown */,
-				971C8DEDE933277B3AE4E882338A8214 /* Pods-WatchApp Extension-acknowledgements.plist */,
-				B7E1436723B14D27E6BA24BED48AC926 /* Pods-WatchApp Extension-dummy.m */,
-				F9EA45BBC0D3AEFE43074A41F86C2A5E /* Pods-WatchApp Extension-frameworks.sh */,
-				777B0F79A65AFEF863579BE5646E1DF1 /* Pods-WatchApp Extension-resources.sh */,
-				701A7F006E59848A3FA96619714A2223 /* Pods-WatchApp Extension.debug.xcconfig */,
-				C094F1C98A2C41ACD73C6F158B47023F /* Pods-WatchApp Extension.release.xcconfig */,
+				45B6E117E8CDB8476988AE421220A1D0 /* Pods-WatchApp Extension-acknowledgements.markdown */,
+				77C2F18192329FDEB94436161E9CDF88 /* Pods-WatchApp Extension-acknowledgements.plist */,
+				DDA6FB76586271443E51CF241698D6DC /* Pods-WatchApp Extension-dummy.m */,
+				C87D8A69D8DB306B4C1B788C8A3DEEC5 /* Pods-WatchApp Extension-frameworks.sh */,
+				CD69CE6196BAE8CE0D0608DDBAAA020D /* Pods-WatchApp Extension-resources.sh */,
+				12178C220C625240393129263706C656 /* Pods-WatchApp Extension.debug.xcconfig */,
+				985003308B1C6CFEF05E5F64F040FC89 /* Pods-WatchApp Extension.release.xcconfig */,
 			);
 			name = "Pods-WatchApp Extension";
 			path = "Target Support Files/Pods-WatchApp Extension";
 			sourceTree = "<group>";
 		};
-		A2E8B182C95CCC90E71CF439B2F7E083 /* Classes */ = {
+		31124E211AD86AB41518DF0953C9582C /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				050D206B9AEB4DF87D322F72A840A0DE /* MapperMacros */,
+				7E6B2D0E9F5D829108218013D1E8A337 /* MapperMacros */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		0628D34B912C2431236471EF4C7720C0 /* VOKUtilities */ = {
+		317E4E68488687D4E8C71777164E3DF0 /* VOKUtilities */ = {
 			isa = PBXGroup;
 			children = (
-				FA69128BA538E22FB0AF31EEBAD8D0E8 /* Support Files */,
-				7A433FE6A343961BAD2B564426630D78 /* VOKKeyPathHelper */,
+				0850EFDAE6A5123D6AB6FDD9119F5FE9 /* Support Files */,
+				ECF61C54CFD6C18B15D3699D94B49C80 /* VOKKeyPathHelper */,
 			);
 			name = VOKUtilities;
 			path = VOKUtilities;
 			sourceTree = "<group>";
 		};
-		CA9F64BFACD9A6B9EFC6C13F107B6ABF /* Optional Data Sources */ = {
+		32874034339324736B8E2CC8AA033091 /* Optional Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */,
-				E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */,
+				A9E463A83ECB0D1A6746F8BF76439B2F /* VOKFetchedResultsDataSource.h */,
+				A2C0960CFA72441F03306FC9EC955F8C /* VOKFetchedResultsDataSource.m */,
 			);
 			name = "Optional Data Sources";
 			path = "Optional Data Sources";
 			sourceTree = "<group>";
 		};
-		8EB4618C736DD6BDEC8CFC9A74CBE387 /* FetchedResults */ = {
+		3FB3D8CAA9590496606125582660E8B6 /* FetchedResults */ = {
 			isa = PBXGroup;
 			children = (
-				478C110C179740FF4A342BF721CA277F /* Pod */,
+				829497AAD74ADF5CD87A555D4F3083AF /* Pod */,
 			);
 			name = FetchedResults;
 			sourceTree = "<group>";
 		};
-		B0C6FA9F81DEED3CCBCBB54E91A84885 /* Pods-VOKCoreDataManager Tests */ = {
+		5995A2BAAC6F302DFC91DDF3C6CC0FA1 /* Pods-VOKCoreDataManager Tests */ = {
 			isa = PBXGroup;
 			children = (
-				99DB30539EE330C93A159C435206F074 /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */,
-				4D5D60B13DF1C32B14FCB18E2F196EAA /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */,
-				82172DDFD8E6F88B65EEA9534A3D9C8F /* Pods-VOKCoreDataManager Tests-dummy.m */,
-				94FCD283DFD1D103959D5BE108B9B624 /* Pods-VOKCoreDataManager Tests-frameworks.sh */,
-				61C4E0677C83F766260DB28F176CC051 /* Pods-VOKCoreDataManager Tests-resources.sh */,
-				2E9BF54A9471DCEB8BF1280D47F24771 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */,
-				FBDE53507268195ABEBE26048C784F33 /* Pods-VOKCoreDataManager Tests.release.xcconfig */,
+				5F64AC3872552EEAC9BB4EBBC4A1C680 /* Pods-VOKCoreDataManager Tests-acknowledgements.markdown */,
+				FBC93AAC731F32F0D5EAA9C1EF1A977B /* Pods-VOKCoreDataManager Tests-acknowledgements.plist */,
+				77118E2573E1FBFEB6E82786750837EE /* Pods-VOKCoreDataManager Tests-dummy.m */,
+				64F005CCB40EDE27A2C7F87D947C147A /* Pods-VOKCoreDataManager Tests-frameworks.sh */,
+				944710C3649D0EDB774CD8EDC4DCC971 /* Pods-VOKCoreDataManager Tests-resources.sh */,
+				7352ED4444C19481CC17378C2FE27A19 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */,
+				C4453F87DEB288348F49730EEA8D995E /* Pods-VOKCoreDataManager Tests.release.xcconfig */,
 			);
 			name = "Pods-VOKCoreDataManager Tests";
 			path = "Target Support Files/Pods-VOKCoreDataManager Tests";
 			sourceTree = "<group>";
 		};
-		B66A8C3BFB903F77BEF8E93ACFB4C101 /* Pod */ = {
+		5A7EDD63C974321AEC3D6C697DE65029 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				A2E8B182C95CCC90E71CF439B2F7E083 /* Classes */,
+				31124E211AD86AB41518DF0953C9582C /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		61BB1467B6A83D6A6A4953981C7A0F3D /* Pod */ = {
+		64B8F5A4C698E3669638396B07E129DC /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				871C6B29616861FE22F20252EE41CB6B /* Classes */,
+				A31AB5E99550F71AD8354D93F08149E4 /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		E17B9A81EAC3695B5B2620896E5A9C97 /* Pods-VOKCoreDataManager */ = {
+		692DAF672ABBA698C829EB198CC08B8F /* Pods-VOKCoreDataManager */ = {
 			isa = PBXGroup;
 			children = (
-				9E19EE33BD8E73E19FF9CF2B455F8CF1 /* Pods-VOKCoreDataManager-acknowledgements.markdown */,
-				66438280191783D51E1F8CC0AA43700B /* Pods-VOKCoreDataManager-acknowledgements.plist */,
-				3C1EAC16934CC93F3643B1C1FEDFF267 /* Pods-VOKCoreDataManager-dummy.m */,
-				DEEB8C66CC5B1B7454B655E292186A1B /* Pods-VOKCoreDataManager-frameworks.sh */,
-				FCA7CA01E95D374CCBF80D4DC4F6D327 /* Pods-VOKCoreDataManager-resources.sh */,
-				4AEC4E19A44C1415B751DD9150E36B34 /* Pods-VOKCoreDataManager.debug.xcconfig */,
-				A1DBF133507242CA23B6647425441B66 /* Pods-VOKCoreDataManager.release.xcconfig */,
+				1FF2BA4CAB1FB2656362DEE994F1CAE1 /* Pods-VOKCoreDataManager-acknowledgements.markdown */,
+				E89B993C8180F85E9D8901BF9BAA393D /* Pods-VOKCoreDataManager-acknowledgements.plist */,
+				1EE9FA64AE5379867E8F4162B4D817A1 /* Pods-VOKCoreDataManager-dummy.m */,
+				D4BA686AE29FE18AA38F37E1001B693E /* Pods-VOKCoreDataManager-frameworks.sh */,
+				CDFFC814F1B01089D5B0D624B69FEBEE /* Pods-VOKCoreDataManager-resources.sh */,
+				8DB45E93EADED6344C252DD1FB4F2423 /* Pods-VOKCoreDataManager.debug.xcconfig */,
+				18F022ECB974D204BBFAF860AB26BE98 /* Pods-VOKCoreDataManager.release.xcconfig */,
 			);
 			name = "Pods-VOKCoreDataManager";
 			path = "Target Support Files/Pods-VOKCoreDataManager";
 			sourceTree = "<group>";
 		};
-		D1623DACC3E535903FFF1F09759DB50E /* Classes */ = {
+		6B8F7EFEDE628E7FECC725B2D6FF4A52 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				851707713AFD3E95A0F4A2181FE71857 /* Internal */,
-				563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */,
-				28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */,
-				58EC440D65C8C5AFCAF2334576861577 /* VOKCoreDataCollectionTypes.h */,
-				4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */,
-				7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */,
-				88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */,
-				F5EEBDA65B80BD740A41E4857A3FE6C3 /* VOKManagedObjectMap.m */,
-				0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */,
-				7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */,
-				E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */,
-				7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */,
-				311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */,
+				4109FF539D2341CA5287721D8D377E01 /* NSManagedObject+VOKManagedObjectAdditions.h */,
+				227F6BBE28D179CB31B4DF636979A543 /* NSManagedObject+VOKManagedObjectAdditions.m */,
+				D91D5E5463F76934D51AB2FFC59D546C /* VOKCoreDataCollectionTypes.h */,
+				48DA15F76198935F143046A92BF85D5D /* VOKCoreDataManager.h */,
+				C43930A300BDD6E51802E60CCCB0D0BA /* VOKCoreDataManager.m */,
+				310E3889F83DDE730396B90732C5C8B0 /* VOKManagedObjectMap.h */,
+				3EEA0A1935EF7399211A2BCD3991E752 /* VOKManagedObjectMap.m */,
+				2797C5EFB0D6E418F204877116937884 /* VOKManagedObjectMapper.h */,
+				039E65118EEA36942D15DABBB9EAACB4 /* VOKManagedObjectMapper.m */,
+				35D4814650D73EC866488F54A2D67E18 /* VOKMappableModel.h */,
+				0722BD137224E95065B72D89C2AFBCFD /* VOKNullabilityFeatures.h */,
+				0E11CB0B4AE91356599EC30A92B9972A /* Vokoder.h */,
+				CC01BD05D1E59F2EADDA7AFDEEC0F29F /* Internal */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		F2F2D4D887B872A3D0E6BEC830D25747 /* Pods-VOKCoreDataManager-OSX */ = {
+		6F58AB954B48974DCE1FFCFB453E99B4 /* Pods-VOKCoreDataManager-OSX */ = {
 			isa = PBXGroup;
 			children = (
-				B078387F629D340EBA92DD1FCD6A5250 /* Pods-VOKCoreDataManager-OSX-acknowledgements.markdown */,
-				97E69364E78828F1A5FB7744B844A007 /* Pods-VOKCoreDataManager-OSX-acknowledgements.plist */,
-				15E61F3ED71D4BB874AA0377FFD6913A /* Pods-VOKCoreDataManager-OSX-dummy.m */,
-				E8547EA323C1AA719A1FF131E70AEE1D /* Pods-VOKCoreDataManager-OSX-frameworks.sh */,
-				3F9C0F760326095547406F66F907A7CD /* Pods-VOKCoreDataManager-OSX-resources.sh */,
-				695A55226F1671D0C255C45400CC6E5E /* Pods-VOKCoreDataManager-OSX.debug.xcconfig */,
-				CEE5E57B0BBE5728330045505D55E11C /* Pods-VOKCoreDataManager-OSX.release.xcconfig */,
+				32280C1E9AA2275E2847AB485F7E3B3A /* Pods-VOKCoreDataManager-OSX-acknowledgements.markdown */,
+				BF859A556407AB3B779037550A73BD61 /* Pods-VOKCoreDataManager-OSX-acknowledgements.plist */,
+				C8FDBE7F424A75BC5CBA314BD5CE0DC3 /* Pods-VOKCoreDataManager-OSX-dummy.m */,
+				137CEBF5CEC0D192C01F155F008C1889 /* Pods-VOKCoreDataManager-OSX-frameworks.sh */,
+				AE5A89F0E56D4213B15C9B798CEAC9D3 /* Pods-VOKCoreDataManager-OSX-resources.sh */,
+				879EAB0203F40FAFEB5CFE9C736732B8 /* Pods-VOKCoreDataManager-OSX.debug.xcconfig */,
+				5A40B3D080F77790B09C44712042846D /* Pods-VOKCoreDataManager-OSX.release.xcconfig */,
 			);
 			name = "Pods-VOKCoreDataManager-OSX";
 			path = "Target Support Files/Pods-VOKCoreDataManager-OSX";
 			sourceTree = "<group>";
 		};
-		60D6CB7F77076E4DC87A8EFAD3FF2566 /* OS X */ = {
+		7A0BA3EACD2EA6A687ED77C08A7B41C8 /* OS X */ = {
 			isa = PBXGroup;
 			children = (
-				401D2715E3ECF45767B49F2CC295F881 /* Cocoa.framework */,
-				1BEF41F9488CF0AD0F1BEAB977EE1344 /* CoreData.framework */,
+				D425622BFD2229DC889BD761596FA01D /* Cocoa.framework */,
+				2F16018059E07FFE33BA6CAE4B20A3FE /* CoreData.framework */,
 			);
 			name = "OS X";
 			sourceTree = "<group>";
 		};
-		5DECD2D2DDBCF1DF25E1166EAF85634C = {
+		7DB346D0F39D3F0E887471402A8071AB = {
 			isa = PBXGroup;
 			children = (
-				6D1EB8A38E8CBA4A4B0D3C897A545D0A /* Development Pods */,
-				DC48BCE815EC154A59BCA69936CF7135 /* Frameworks */,
-				A38FF61C71733211E6DDB19385503404 /* Podfile */,
-				1432AA59D8B53139E350543A9C80D7F8 /* Pods */,
-				F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */,
-				27E772C472EE5BD87EA005C1E920FEC6 /* Targets Support Files */,
+				93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */,
+				7E71C6011E315543EE8E3F5A7D6652E5 /* Development Pods */,
+				D6503BFA5052BCA185B843B6853F0C4F /* Frameworks */,
+				23A1BCFAF0B252A99191D410D963BB63 /* Pods */,
+				F9829FEF1A805FAFB460D95D567A397F /* Products */,
+				D714410908F09C6798C34D80A57AC4A1 /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		050D206B9AEB4DF87D322F72A840A0DE /* MapperMacros */ = {
+		7E6B2D0E9F5D829108218013D1E8A337 /* MapperMacros */ = {
 			isa = PBXGroup;
 			children = (
-				9497B6EFC78CD210D29ABB109BB968BC /* VOKManagedObjectMapperMacros.h */,
+				CDAB26DA0FB2C2CF6F3E8B966842D337 /* VOKManagedObjectMapperMacros.h */,
 			);
 			name = MapperMacros;
 			path = MapperMacros;
 			sourceTree = "<group>";
 		};
-		6D1EB8A38E8CBA4A4B0D3C897A545D0A /* Development Pods */ = {
+		7E71C6011E315543EE8E3F5A7D6652E5 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2841E6A5AFA6C5740FA47D68784B43B8 /* Vokoder */,
+				08CFF4FA26003D3ED27349D856037083 /* Vokoder */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		2757FE2226489748E1B034F311E8325A /* Pod */ = {
+		8086D39D13590CFCBA7D9A4163F7369A /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				0D628D92F46B96670EB6FF1B86D31B39 /* Classes */,
+				A49F00F0B2CEABEE4B977D1FA6296378 /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		517BAE0EB2FC6EAB1D352BBA63C2E5FF /* MapperMacros */ = {
+		81220C977763C0D959F9B5D4FC7C3945 /* MapperMacros */ = {
 			isa = PBXGroup;
 			children = (
-				B66A8C3BFB903F77BEF8E93ACFB4C101 /* Pod */,
+				5A7EDD63C974321AEC3D6C697DE65029 /* Pod */,
 			);
 			name = MapperMacros;
 			sourceTree = "<group>";
 		};
-		478C110C179740FF4A342BF721CA277F /* Pod */ = {
+		829497AAD74ADF5CD87A555D4F3083AF /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				0BA6A3697D7736F3A930525826963BB3 /* Classes */,
+				1525D405FF372F872E9FE0F5F450642C /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		21C815DB339F7DD825A5E4CB08881309 /* Support Files */ = {
+		90430806155E78F98BCBF3F3AFA04E92 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				DEE627662872CB24AE24EF8A1B15A39E /* Vokoder-07029ee6-dummy.m */,
-				54467A35B42FBC45238FF67E4BF1B484 /* Vokoder-07029ee6-prefix.pch */,
-				9E22AD87D6173DD697749070C13776D0 /* Vokoder-07029ee6.xcconfig */,
-				82E3E7B746BAE97CD6D2774290142ED7 /* Vokoder-43a9e09e-dummy.m */,
-				5355D5F9014D0D3BB6BDA8CFF22AE9D4 /* Vokoder-43a9e09e-prefix.pch */,
-				C7FDB6DA1D9C8344F63ADE0BA56C55AC /* Vokoder-43a9e09e.xcconfig */,
-				1F90FCCF9E010C8FB81278273CB8C6BE /* Vokoder-fdc3d3be-dummy.m */,
-				D40257CD208964BCE78B70C34005C8C5 /* Vokoder-fdc3d3be-prefix.pch */,
-				9C82F70917641C70EE55D41167D7E59E /* Vokoder-fdc3d3be.xcconfig */,
-				2BA27034E65288609E599B4DA7D5DFC9 /* Vokoder.root-Core-MapperMacros-OSX-dummy.m */,
-				E9ED29E7E1F76D0FF99CF9DB16183B62 /* Vokoder.root-Core-MapperMacros-OSX-prefix.pch */,
-				CBD594A897BF2B25B03804CA7DF9BD39 /* Vokoder.root-Core-MapperMacros-OSX.xcconfig */,
-				41449AC4115C95FEE99A662AE575B165 /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m */,
-				5B90E32C0EF1EA42CACA2C9044DDACDF /* Vokoder.root-Core-MapperMacros-watchOS-prefix.pch */,
-				10CC226F117CBBB79BF03824AC645A56 /* Vokoder.root-Core-MapperMacros-watchOS.xcconfig */,
+				709585C36368811AC1D9697E5DBB5EF5 /* Vokoder-07029ee6.xcconfig */,
+				773655DAAEEFB626CDB5269FAB35E6A6 /* Vokoder-07029ee6-dummy.m */,
+				387F115E6362EADCAEFF6C411628107F /* Vokoder-07029ee6-prefix.pch */,
+				B4D70FC55279FF036ED49145ABFDB1EC /* Vokoder-43a9e09e.xcconfig */,
+				2626459696E3F30C9A8C3096568BF160 /* Vokoder-43a9e09e-dummy.m */,
+				B8EBE3D4A209FFE5CA056F1E82CA7365 /* Vokoder-43a9e09e-prefix.pch */,
+				E7568C58ACCAA3EDD1E4713AF3B81B0C /* Vokoder-fdc3d3be.xcconfig */,
+				9F89761EDFF3BC77C47475E71440A115 /* Vokoder-fdc3d3be-dummy.m */,
+				D1293E065D42D768205B207270C2356E /* Vokoder-fdc3d3be-prefix.pch */,
+				CB47F8B49375B3DB7D3EB7AA68DA9386 /* Vokoder.root-Core-MapperMacros-OSX.xcconfig */,
+				02EE4FC2B5A5C8BF8A41098711CFFB96 /* Vokoder.root-Core-MapperMacros-OSX-dummy.m */,
+				9BA6C7F8BFBB540D271B7C39AE4D8F56 /* Vokoder.root-Core-MapperMacros-OSX-prefix.pch */,
+				B90F4F8E35E9494213EE548E18CF4C60 /* Vokoder.root-Core-MapperMacros-watchOS.xcconfig */,
+				A537D9F722B61F040A86A633A1ADEB5C /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m */,
+				C788AC783CE6FEB20516FD5EB2848839 /* Vokoder.root-Core-MapperMacros-watchOS-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "SampleProject/Pods/Target Support Files/Vokoder-07029ee6";
 			sourceTree = "<group>";
 		};
-		A82DCA28FABF1F9080B1B2234FFB9045 /* iOS */ = {
+		929B04CE373E28921E2AF9EC0CCF0CDD /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */,
-				9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */,
+				0F2089D95BFC5705AD4E43E3CBDC443F /* CoreData.framework */,
+				524902846D8360EC90D2F6B4B5754178 /* Foundation.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		7CE701E3A9C078904348A225A86D8ED9 /* Pods-TodayWidget */ = {
+		9B060D31D586FF6D1DFF7CB76BE04316 /* Pods-TodayWidget */ = {
 			isa = PBXGroup;
 			children = (
-				D0ECBD75C14DE7E28A7EC77D2E000DE1 /* Pods-TodayWidget-acknowledgements.markdown */,
-				A1F1F957336FD448D73A0FA0BB334A2C /* Pods-TodayWidget-acknowledgements.plist */,
-				0F599B152C838E6E92557EDDA9F762C8 /* Pods-TodayWidget-dummy.m */,
-				6E32A138087D38C5B2F94CAD0BFCC341 /* Pods-TodayWidget-resources.sh */,
-				928F6652087C28B56E197BF3DE359403 /* Pods-TodayWidget.debug.xcconfig */,
-				121EEAB77CB65EEBC6F733CA71FC7FAB /* Pods-TodayWidget.release.xcconfig */,
+				8AC9E0102E8FE389921ADBDDC8FF49D8 /* Pods-TodayWidget-acknowledgements.markdown */,
+				DF5CDD4C869B4BEEF7CF3640366AEED0 /* Pods-TodayWidget-acknowledgements.plist */,
+				00B1C1D5AD6DEFA2EA6F7FC013F189BA /* Pods-TodayWidget-dummy.m */,
+				29B3979E5DCC7013963C33CC7603148A /* Pods-TodayWidget-resources.sh */,
+				64142C568D6CFA890CEDDA2E2DA3FCEF /* Pods-TodayWidget.debug.xcconfig */,
+				8DB738C95F2DE503CC441547763906D9 /* Pods-TodayWidget.release.xcconfig */,
 			);
 			name = "Pods-TodayWidget";
 			path = "Target Support Files/Pods-TodayWidget";
 			sourceTree = "<group>";
 		};
-		7B6B69F12063310EFEBC024790A2398E /* Pod */ = {
+		9BE99E297F45A7CA0E5F83B9D3F5E2D8 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				D1623DACC3E535903FFF1F09759DB50E /* Classes */,
+				6B8F7EFEDE628E7FECC725B2D6FF4A52 /* Classes */,
 			);
 			name = Pod;
 			path = Pod;
 			sourceTree = "<group>";
 		};
-		871C6B29616861FE22F20252EE41CB6B /* Classes */ = {
+		A31AB5E99550F71AD8354D93F08149E4 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				6E64A72C77FF954E0048EEA6218BA40E /* Optional Data Sources */,
+				E87FECFBB4DFC41802A32928607C0664 /* Optional Data Sources */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		0D628D92F46B96670EB6FF1B86D31B39 /* Classes */ = {
+		A49F00F0B2CEABEE4B977D1FA6296378 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				6871642A62DD48369704DBF18892621C /* Optional Data Sources */,
+				C88F559449300E373999C903D15E277A /* Optional Data Sources */,
 			);
 			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		B421555D5801CF0B580826D5CFF3E0D9 /* Pods-VOKCoreDataManager-tvOS */ = {
+		A5B3E5D0F363DEC06EA2B83D6E9F76F0 /* Pods-VOKCoreDataManager-tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				C931D38FC2455FFC3D8D9F69DA9F8276 /* Pods-VOKCoreDataManager-tvOS-acknowledgements.markdown */,
-				2502BE013CCA309B25AD12C6FBC86067 /* Pods-VOKCoreDataManager-tvOS-acknowledgements.plist */,
-				6D027326B67067ACEBDBE37DB79F7385 /* Pods-VOKCoreDataManager-tvOS-dummy.m */,
-				5B3804CD0525DB45033DD1C9F0EE7EE1 /* Pods-VOKCoreDataManager-tvOS-frameworks.sh */,
-				0B18AA4C6F3810B63A758E6F55368A51 /* Pods-VOKCoreDataManager-tvOS-resources.sh */,
-				816CFB2F4CCA32B132D3140C7EB26A61 /* Pods-VOKCoreDataManager-tvOS.debug.xcconfig */,
-				0F8E0E10BEABF0C6573568FE8E546BA0 /* Pods-VOKCoreDataManager-tvOS.release.xcconfig */,
+				DCE46F0FA451203C4B177CB97185B36B /* Pods-VOKCoreDataManager-tvOS-acknowledgements.markdown */,
+				553549EFA679B8A59F83573CB40F58FF /* Pods-VOKCoreDataManager-tvOS-acknowledgements.plist */,
+				7CE3519B3FC051821FEC2239CA22B0E3 /* Pods-VOKCoreDataManager-tvOS-dummy.m */,
+				175B97ED97FF11884C8CA8C5716833D9 /* Pods-VOKCoreDataManager-tvOS-frameworks.sh */,
+				1BE54F210803C0119522666D4C3789E4 /* Pods-VOKCoreDataManager-tvOS-resources.sh */,
+				4432D8541F20799C23DEE42D5CCEDBFF /* Pods-VOKCoreDataManager-tvOS.debug.xcconfig */,
+				8C30D8E728A343D3553ECAD52DD15F5B /* Pods-VOKCoreDataManager-tvOS.release.xcconfig */,
 			);
 			name = "Pods-VOKCoreDataManager-tvOS";
 			path = "Target Support Files/Pods-VOKCoreDataManager-tvOS";
 			sourceTree = "<group>";
 		};
-		D291960F19FD2FE625E66028614C79A8 /* DataSources */ = {
+		A7C2917B05B67317F295B13F0A392BC1 /* DataSources */ = {
 			isa = PBXGroup;
 			children = (
-				62478C4BCC083549B2675083D4CE14F0 /* Collection */,
-				8EB4618C736DD6BDEC8CFC9A74CBE387 /* FetchedResults */,
-				DC922EC5F6A4C858F3D3657B1D19245D /* PagingFetchedResults */,
+				F205A1AA8E8C9B6E083C3E14EFBB9BFC /* Collection */,
+				3FB3D8CAA9590496606125582660E8B6 /* FetchedResults */,
+				1449D0254E1393CB9050F3943C3C6D28 /* PagingFetchedResults */,
 			);
 			name = DataSources;
 			sourceTree = "<group>";
 		};
-		75BC6119506601D366948633F44BFDA3 /* Pods-VOKCoreDataManagerTests-OSX */ = {
+		B14E367FAF719FD88893107F77BCB204 /* Pods-VOKCoreDataManagerTests-OSX */ = {
 			isa = PBXGroup;
 			children = (
-				C4C644F3188FDA12FA9970CC24FF7F91 /* Pods-VOKCoreDataManagerTests-OSX-acknowledgements.markdown */,
-				5B73B757A70916AA67D68FF84EA2BF50 /* Pods-VOKCoreDataManagerTests-OSX-acknowledgements.plist */,
-				BAD21DFB02DACBE61BE0CD79929B2470 /* Pods-VOKCoreDataManagerTests-OSX-dummy.m */,
-				7C45AB067EA884E144C2DB09417ACAD4 /* Pods-VOKCoreDataManagerTests-OSX-frameworks.sh */,
-				68B1BD5126083CABD8F9C6E59EBAF3E7 /* Pods-VOKCoreDataManagerTests-OSX-resources.sh */,
-				A2487DEB43122640319AB8CEE6B754F0 /* Pods-VOKCoreDataManagerTests-OSX.debug.xcconfig */,
-				F81B0DE028348E52206FD42D4DC16375 /* Pods-VOKCoreDataManagerTests-OSX.release.xcconfig */,
+				BED15F08A06BAA2A3BB8DE826104D4D1 /* Pods-VOKCoreDataManagerTests-OSX-acknowledgements.markdown */,
+				AAE3F3A1C8CF402CEB9FB0A16E937B4E /* Pods-VOKCoreDataManagerTests-OSX-acknowledgements.plist */,
+				B35AEEFA32F827F824257B551216CA40 /* Pods-VOKCoreDataManagerTests-OSX-dummy.m */,
+				5B56A6ABEF8F00FDAE2581F8373C1F20 /* Pods-VOKCoreDataManagerTests-OSX-frameworks.sh */,
+				27BEF371CA71482BA0F90C63244554D2 /* Pods-VOKCoreDataManagerTests-OSX-resources.sh */,
+				8877FAEF7810195BFDC5E166FD00BC5C /* Pods-VOKCoreDataManagerTests-OSX.debug.xcconfig */,
+				242689EB3526057D02B5839C6FE129F2 /* Pods-VOKCoreDataManagerTests-OSX.release.xcconfig */,
 			);
 			name = "Pods-VOKCoreDataManagerTests-OSX";
 			path = "Target Support Files/Pods-VOKCoreDataManagerTests-OSX";
 			sourceTree = "<group>";
 		};
-		6871642A62DD48369704DBF18892621C /* Optional Data Sources */ = {
+		C88F559449300E373999C903D15E277A /* Optional Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */,
-				CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */,
-				E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */,
-				78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */,
+				521A958366FF5BF44A89EC736B34CFB9 /* VOKDefaultPagingAccessory.h */,
+				BBC4DD83586D3E0AFB4994434004972E /* VOKDefaultPagingAccessory.m */,
+				8C482370A22662EBCBDABF143AE65DA1 /* VOKPagingFetchedResultsDataSource.h */,
+				EF2F5E5AD6B5231F5D7DA2650C39E582 /* VOKPagingFetchedResultsDataSource.m */,
 			);
 			name = "Optional Data Sources";
 			path = "Optional Data Sources";
 			sourceTree = "<group>";
 		};
-		851707713AFD3E95A0F4A2181FE71857 /* Internal */ = {
+		CC01BD05D1E59F2EADDA7AFDEEC0F29F /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */,
+				2C80C1AF1B4A51B665AC7646313D71FA /* VOKCoreDataManagerInternalMacros.h */,
 			);
 			name = Internal;
 			path = Internal;
 			sourceTree = "<group>";
 		};
-		BAA688C2DBC8F07DD6C0A263A3CED132 /* watchOS */ = {
+		D294040FA01A47753CC3900723653154 /* watchOS */ = {
 			isa = PBXGroup;
 			children = (
-				A9A34B73FE8744709086EEDE7B8E260E /* CoreData.framework */,
-				3EFCE4C7258AA749F7C0C8C56D0A0238 /* Foundation.framework */,
+				BCC0FF64C3F3E287CEAECA22685202E8 /* CoreData.framework */,
+				91DC91E6AC68D30020C930507DB0AA6B /* Foundation.framework */,
 			);
 			name = watchOS;
 			sourceTree = "<group>";
 		};
-		DC48BCE815EC154A59BCA69936CF7135 /* Frameworks */ = {
+		D6503BFA5052BCA185B843B6853F0C4F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				60D6CB7F77076E4DC87A8EFAD3FF2566 /* OS X */,
-				A82DCA28FABF1F9080B1B2234FFB9045 /* iOS */,
-				9F13F589B0EAC0C9A4E03BAED2800F3F /* tvOS */,
-				BAA688C2DBC8F07DD6C0A263A3CED132 /* watchOS */,
+				929B04CE373E28921E2AF9EC0CCF0CDD /* iOS */,
+				7A0BA3EACD2EA6A687ED77C08A7B41C8 /* OS X */,
+				1610FCFFC518173F5A896A3818D1A756 /* tvOS */,
+				D294040FA01A47753CC3900723653154 /* watchOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		27E772C472EE5BD87EA005C1E920FEC6 /* Targets Support Files */ = {
+		D714410908F09C6798C34D80A57AC4A1 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				7CE701E3A9C078904348A225A86D8ED9 /* Pods-TodayWidget */,
-				E17B9A81EAC3695B5B2620896E5A9C97 /* Pods-VOKCoreDataManager */,
-				B0C6FA9F81DEED3CCBCBB54E91A84885 /* Pods-VOKCoreDataManager Tests */,
-				F2F2D4D887B872A3D0E6BEC830D25747 /* Pods-VOKCoreDataManager-OSX */,
-				B421555D5801CF0B580826D5CFF3E0D9 /* Pods-VOKCoreDataManager-tvOS */,
-				75BC6119506601D366948633F44BFDA3 /* Pods-VOKCoreDataManagerTests-OSX */,
-				17B48808F3947CFF29A731689991D883 /* Pods-VOKCoreDataManagerTests-tvOS */,
-				88624CD5FD99C8A7CBA4F1263EFF6000 /* Pods-WatchApp Extension */,
+				9B060D31D586FF6D1DFF7CB76BE04316 /* Pods-TodayWidget */,
+				692DAF672ABBA698C829EB198CC08B8F /* Pods-VOKCoreDataManager */,
+				5995A2BAAC6F302DFC91DDF3C6CC0FA1 /* Pods-VOKCoreDataManager Tests */,
+				6F58AB954B48974DCE1FFCFB453E99B4 /* Pods-VOKCoreDataManager-OSX */,
+				A5B3E5D0F363DEC06EA2B83D6E9F76F0 /* Pods-VOKCoreDataManager-tvOS */,
+				B14E367FAF719FD88893107F77BCB204 /* Pods-VOKCoreDataManagerTests-OSX */,
+				2944F99670FE6A4C6784BD49E5DD78A1 /* Pods-VOKCoreDataManagerTests-tvOS */,
+				303BA5AC7A19CC2C1693320A2B99CCBC /* Pods-WatchApp Extension */,
 			);
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		F653198251905F2D19DBEA48B7F9A7DC /* Support Files */ = {
+		DA0893DA22AA39A7DE280E9A72774A52 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				C9E87A90A0263D062114FF0A770907E3 /* ILGDynamicObjC-OSX10.9-dummy.m */,
-				06CE61B68B80F3DAE49A85578C5902D9 /* ILGDynamicObjC-OSX10.9-prefix.pch */,
-				9E63444472FADBEC7159920FEBA28A00 /* ILGDynamicObjC-OSX10.9.xcconfig */,
-				DA0098176104446F883E6B65527B8A0A /* ILGDynamicObjC-iOS10.0-dummy.m */,
-				2E4D5215C4C2D177AA6A0B6E2D1BAB00 /* ILGDynamicObjC-iOS10.0-prefix.pch */,
-				2579DB4632D3A27C34327639D85722C9 /* ILGDynamicObjC-iOS10.0.xcconfig */,
-				7D13E5AD07A409EAF8DC80F587980045 /* ILGDynamicObjC-iOS8.0-dummy.m */,
-				2B3D364944B60CF2A35EC743DF304EE9 /* ILGDynamicObjC-iOS8.0-prefix.pch */,
-				CDB20D673EC26CEAA279E49DCA096F01 /* ILGDynamicObjC-iOS8.0.xcconfig */,
-				B508BB2C656A01663ED09C2BD6DBF60D /* ILGDynamicObjC-tvOS9.0-dummy.m */,
-				EBEA8207C0D661ACB025E6D82502CA38 /* ILGDynamicObjC-tvOS9.0-prefix.pch */,
-				F5BC8660565E6934A19C07FB2098C015 /* ILGDynamicObjC-tvOS9.0.xcconfig */,
-				E646F53576D2B76A6A6E9AD7DF6C4B29 /* ILGDynamicObjC-watchOS3.0-dummy.m */,
-				94233026138E58D9784E48FD9C11030D /* ILGDynamicObjC-watchOS3.0-prefix.pch */,
-				6746A42342EC06B188B85B914FDC4796 /* ILGDynamicObjC-watchOS3.0.xcconfig */,
+				D18623CBBFD7CD618675FBAC976D3742 /* ILGDynamicObjC-iOS10.0.xcconfig */,
+				3307A89E8353106F38E6D722FD9F2AAC /* ILGDynamicObjC-iOS10.0-dummy.m */,
+				DDA71DEC128940B8DAB0A12B04263CFC /* ILGDynamicObjC-iOS10.0-prefix.pch */,
+				6DF3D76A0E74B3FE12499AF2CDBB3B46 /* ILGDynamicObjC-iOS8.0.xcconfig */,
+				6EC1B0A9236F356043741C189C734487 /* ILGDynamicObjC-iOS8.0-dummy.m */,
+				B856F3CFBAE274FF48463610B4D47431 /* ILGDynamicObjC-iOS8.0-prefix.pch */,
+				123BB9266A782F96C3F82E512E8891DB /* ILGDynamicObjC-OSX10.9.xcconfig */,
+				BF62C8810B96ED634A2FCBF9C13300DD /* ILGDynamicObjC-OSX10.9-dummy.m */,
+				DF04FC76E417F688040F041EEA262C6F /* ILGDynamicObjC-OSX10.9-prefix.pch */,
+				7639258F331D52B880154D63E782D7A6 /* ILGDynamicObjC-tvOS9.0.xcconfig */,
+				5F329743F37B90C2ACD5BCFCEC97DFC8 /* ILGDynamicObjC-tvOS9.0-dummy.m */,
+				9E162345569AC2BF6551C77E0431969D /* ILGDynamicObjC-tvOS9.0-prefix.pch */,
+				0822D55044354A39166D9FB00608562A /* ILGDynamicObjC-watchOS3.0.xcconfig */,
+				18BBC67C0C118607A919DCEFF329F696 /* ILGDynamicObjC-watchOS3.0-dummy.m */,
+				1E78DEB2F932136C3E98D48AD1ABD656 /* ILGDynamicObjC-watchOS3.0-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/ILGDynamicObjC-OSX10.9";
 			sourceTree = "<group>";
 		};
-		6E64A72C77FF954E0048EEA6218BA40E /* Optional Data Sources */ = {
+		E87FECFBB4DFC41802A32928607C0664 /* Optional Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */,
-				809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */,
+				D9D0CC5720AA3DAAC9C766E45CF5AC6C /* VOKCollectionDataSource.h */,
+				A83571761A3EC64BB78549810DA2558F /* VOKCollectionDataSource.m */,
 			);
 			name = "Optional Data Sources";
 			path = "Optional Data Sources";
 			sourceTree = "<group>";
 		};
-		7A433FE6A343961BAD2B564426630D78 /* VOKKeyPathHelper */ = {
+		ECF61C54CFD6C18B15D3699D94B49C80 /* VOKKeyPathHelper */ = {
 			isa = PBXGroup;
 			children = (
-				F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */,
-				2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */,
+				83A5210A54A780630BFCCE098510222D /* VOKKeyPathHelper.h */,
+				3DEE798B4DA83762C29CD7D8D3730B0E /* VOKKeyPathHelper.m */,
 			);
 			name = VOKKeyPathHelper;
 			sourceTree = "<group>";
 		};
-		62478C4BCC083549B2675083D4CE14F0 /* Collection */ = {
+		F205A1AA8E8C9B6E083C3E14EFBB9BFC /* Collection */ = {
 			isa = PBXGroup;
 			children = (
-				61BB1467B6A83D6A6A4953981C7A0F3D /* Pod */,
+				64B8F5A4C698E3669638396B07E129DC /* Pod */,
 			);
 			name = Collection;
 			sourceTree = "<group>";
 		};
-		C0EADA668804F57D6D9AA862CE8EF321 /* ILGClasses */ = {
+		F22B9F9DE4BBA9C71A9C86D1389DEA52 /* ILGClasses */ = {
 			isa = PBXGroup;
 			children = (
-				869B5154502141C012BA472A1C847BDE /* ILGClasses.h */,
-				AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */,
+				A51D6B1CB24680567D407CAA0F7A1ACE /* ILGClasses.h */,
+				BDDF3ADA1E4AEB030434A241FD4B8B8E /* ILGClasses.m */,
 			);
 			name = ILGClasses;
 			sourceTree = "<group>";
 		};
-		F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */ = {
+		F9829FEF1A805FAFB460D95D567A397F /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				F9A0609938E5CA1367E1F89470849D81 /* libILGDynamicObjC-OSX10.9.a */,
-				BABD7645020D9F8280BB1EF781091F4C /* libILGDynamicObjC-iOS10.0.a */,
-				9C03B3C5377C15525FE5987D4D450838 /* libILGDynamicObjC-iOS8.0.a */,
-				FCCC98393094B15D22C29F6DF6BD111D /* libILGDynamicObjC-tvOS9.0.a */,
-				2C05BF495E3C46D0AA1D04F61CD06BAB /* libILGDynamicObjC-watchOS3.0.a */,
-				4441C392D8828C60F1289E860A23C911 /* libPods-TodayWidget.a */,
-				CF9ED222207E10F412CE86CA603947AD /* libPods-VOKCoreDataManager Tests.a */,
-				63C3F1515EF08D989ADD8EAB39DD4E9E /* libPods-VOKCoreDataManager-OSX.a */,
-				A0BC3E14560091A93BC0EF4B3C3FB875 /* libPods-VOKCoreDataManager-tvOS.a */,
-				9DA9C1C60E4F548C3D7AE3E5A9DDC1EA /* libPods-VOKCoreDataManager.a */,
-				73831ABF987475486391C975F9F05112 /* libPods-VOKCoreDataManagerTests-OSX.a */,
-				1006E061CE81334B5F18D76F03E84A1A /* libPods-VOKCoreDataManagerTests-tvOS.a */,
-				21FF87D5FB7B4CFBC516A866A43B700A /* libPods-WatchApp Extension.a */,
-				60BABD577094FC9C8A9957F04FCFF967 /* libVOKUtilities-OSX10.9.a */,
-				474BBE2194A46BC7E8A348CFC9D76E77 /* libVOKUtilities-iOS10.0.a */,
-				2DDE38143B617CB415B17CDC63D5B998 /* libVOKUtilities-iOS8.0.a */,
-				091B0FE63D6828648A4E44A2FB793E5E /* libVOKUtilities-tvOS9.0.a */,
-				012F0A9F9A7CDBE88D70A160CAF549B0 /* libVOKUtilities-watchOS3.0.a */,
-				066C285FCB8B5E8BA0EBCC8F740081AD /* libVokoder-07029ee6.a */,
-				6F9487FE2E21E990EF6C666989C34D01 /* libVokoder-43a9e09e.a */,
-				AB9B7E1C33A0AC0AEC39367FE1B2753C /* libVokoder-fdc3d3be.a */,
-				775D86E87223CD14F633CCDF0C3A2B79 /* libVokoder.root-Core-MapperMacros-OSX.a */,
-				91BDAD172EE3777442B5BBB4E49FFAF5 /* libVokoder.root-Core-MapperMacros-watchOS.a */,
+				9F031FFF1DE23E344F2DF5B559741D35 /* libILGDynamicObjC-iOS10.0.a */,
+				BE0E8BA9D1D2B080C2BEA9741E7ED987 /* libILGDynamicObjC-iOS8.0.a */,
+				3E7731EED349F4BAA86AD357B9D186F5 /* libILGDynamicObjC-OSX10.9.a */,
+				89C28DEC52743FA31E609674BE81B735 /* libILGDynamicObjC-tvOS9.0.a */,
+				75FF86E0104378C3A12B5AC1D933BF7A /* libILGDynamicObjC-watchOS3.0.a */,
+				B669B29C55DF73AE4CCA35D1DBFA0FBA /* libPods-TodayWidget.a */,
+				3C61847DB7A6DA88D9BC36D1749F02D4 /* libPods-VOKCoreDataManager.a */,
+				95AB9EE21EB6A93107C55C85E236B4BF /* libPods-VOKCoreDataManager Tests.a */,
+				7BC95B5FA7DD23673D1DC56B026A8A8C /* libPods-VOKCoreDataManager-OSX.a */,
+				C2AF078AB0B6B0EA905EA98ECAD81F57 /* libPods-VOKCoreDataManager-tvOS.a */,
+				C47D0C3C9C886EB71766440D090D84F4 /* libPods-VOKCoreDataManagerTests-OSX.a */,
+				3CE037145D600CAE7611AAAD52F11819 /* libPods-VOKCoreDataManagerTests-tvOS.a */,
+				9DDBA1D4CA1F7F7B54DE18C40A053415 /* libPods-WatchApp Extension.a */,
+				943322D0A26187E027E2764D4EC85A77 /* libVokoder-07029ee6.a */,
+				384263883049C22706A76345B43FDDE4 /* libVokoder-43a9e09e.a */,
+				A6E740100759BC1AEB864C35081CB978 /* libVokoder-fdc3d3be.a */,
+				085798873D67A80FB040EA3B6A743517 /* libVokoder.root-Core-MapperMacros-OSX.a */,
+				530A969A524869B061EB8E86836D66D4 /* libVokoder.root-Core-MapperMacros-watchOS.a */,
+				834DCAF6A2F5FBE14EA7AC3A00C677A9 /* libVOKUtilities-iOS10.0.a */,
+				ED3CE8BE75D7D627CE0B3DFBE8241DC1 /* libVOKUtilities-iOS8.0.a */,
+				1AE9A2733CEB631B9297DF5ED0D30AEC /* libVOKUtilities-OSX10.9.a */,
+				25CA4DC541F4315641B27252789BC11E /* libVOKUtilities-tvOS9.0.a */,
+				0D930BD0A47458465742C522AB38F134 /* libVOKUtilities-watchOS3.0.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1279,212 +1279,212 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		D75E048099D93508DFAF7E510BCE8AF2 /* Headers */ = {
+		19599078729ED6E0712AE5F9C7E95869 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				88F1AF7CBF905B732BE982C0D9CEB776 /* VOKKeyPathHelper.h in Headers */,
+				C40624EAA1EDDA49941552C1C27D5DCD /* VOKKeyPathHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BD9A9990D25307C6492544DE93E9D9E3 /* Headers */ = {
+		1ABDCA8DAAD4EF24A87FA297165F616C /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E357EDDBD070B2292E1604F0B471F8BC /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				23A3F749BC20D5AAFC7473C690FEC1DB /* VOKCollectionDataSource.h in Headers */,
-				CF754E7FE7B0B17866101A901249CA5F /* VOKCoreDataCollectionTypes.h in Headers */,
-				404F5F1A6209F7ABC31638636519FDFC /* VOKCoreDataManager.h in Headers */,
-				2AC32D5CD6EECA4FDF09E97E71B2E7E3 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				43340EBBBA56CF713DE87D4A27A70260 /* VOKDefaultPagingAccessory.h in Headers */,
-				B880CE05CBF6CB5787D15CC4C1279BED /* VOKFetchedResultsDataSource.h in Headers */,
-				136A13665F8140A0E702D36C3ACE10F0 /* VOKManagedObjectMap.h in Headers */,
-				7E73528BC9653F858835FC74B8E93063 /* VOKManagedObjectMapper.h in Headers */,
-				AABD791CF6702F076ECD3048EF012B5A /* VOKManagedObjectMapperMacros.h in Headers */,
-				433EC4F0966D6AF0E2678002DC4DF599 /* VOKMappableModel.h in Headers */,
-				35E439CDE0EA2E8D8CA03208A4322FE6 /* VOKNullabilityFeatures.h in Headers */,
-				6A94241FDA929C3910C83340DBA1FFB7 /* VOKPagingFetchedResultsDataSource.h in Headers */,
-				30A87AFCB2D8E58514FF3A19FDF2DACD /* Vokoder.h in Headers */,
+				18FF370C45EB051762823DCA194535E8 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				7436CC78E0A2854FBDC008B94A0D2BF9 /* VOKCollectionDataSource.h in Headers */,
+				05903515DA8BF3144444CE0344774AA3 /* VOKCoreDataCollectionTypes.h in Headers */,
+				DCF8F205C4F25D6F238DD2745040DE79 /* VOKCoreDataManager.h in Headers */,
+				64231A44EC55F800F7E2FA8CB43F2586 /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				758B13B8BFA8406B2932EBE6E50BE2CD /* VOKDefaultPagingAccessory.h in Headers */,
+				CA1254081353C93B20714D57F78CB920 /* VOKFetchedResultsDataSource.h in Headers */,
+				3421361269D50A7C604C1C97131722FF /* VOKManagedObjectMap.h in Headers */,
+				1A0F635AAAF25DAD5ED50BCDFC593017 /* VOKManagedObjectMapper.h in Headers */,
+				F16026F46C399EF77212CC0E0AEFE8D2 /* VOKManagedObjectMapperMacros.h in Headers */,
+				365F7E4646F2CB26AF7B47DC37AA007C /* VOKMappableModel.h in Headers */,
+				181B1103B946F695FEEB82B144459C43 /* VOKNullabilityFeatures.h in Headers */,
+				F4E748713C20596DF44E84DE4FAA69E6 /* Vokoder.h in Headers */,
+				FEFDA0128F05DB6F9625CBB4FAADF6F0 /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		89A02D872FAEF49BF73C714C9F54174D /* Headers */ = {
+		5025987FCED443F3C09FA7E0684BC2BC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EC7F497C62BBB4BE68D4DEF68E2AD775 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				52A56FC44DCDCE5B2608F03C08A550AA /* VOKCollectionDataSource.h in Headers */,
-				16C1BECEE727060D40104163A5DBA865 /* VOKCoreDataCollectionTypes.h in Headers */,
-				49E7BEAE60F1613EF5BABD50C4519B32 /* VOKCoreDataManager.h in Headers */,
-				7DA51D377B082021229C4E59AD384750 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				102913FD8409E29E0857C47DC3FE6CC6 /* VOKDefaultPagingAccessory.h in Headers */,
-				C10529D65C356EE3CD99FA101CF447F9 /* VOKFetchedResultsDataSource.h in Headers */,
-				0B8E8252A6484F5339CE6F6436FBD788 /* VOKManagedObjectMap.h in Headers */,
-				4239E3D796DBEB48EC3ADFF756E05681 /* VOKManagedObjectMapper.h in Headers */,
-				4BB8B30D2384397342319A5697096481 /* VOKManagedObjectMapperMacros.h in Headers */,
-				982646390A255AAB33BBCB49BF88037E /* VOKMappableModel.h in Headers */,
-				580ABAC13B4E0CEB6442AD966649F566 /* VOKNullabilityFeatures.h in Headers */,
-				A627DE01714BC5F9572E3B77355FB1DD /* VOKPagingFetchedResultsDataSource.h in Headers */,
-				51D9BFAC3685013BA5B9634B41F0F0B1 /* Vokoder.h in Headers */,
+				8E1F46B65CDCC70DB338081C9437EB3A /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				B98CD530764ABAA87671B18F6CFEA741 /* VOKCollectionDataSource.h in Headers */,
+				D8EDA3D717CC05288F05FB34DED12970 /* VOKCoreDataCollectionTypes.h in Headers */,
+				19DA9D8F384558D4199EFDE072150B2E /* VOKCoreDataManager.h in Headers */,
+				7062D29519B52F0E344E3E28D7A8B1ED /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				3067BD2FA5D93D794C60CAC9512AFCBB /* VOKDefaultPagingAccessory.h in Headers */,
+				79E85C6C3B5541601E4DD86439282ED2 /* VOKFetchedResultsDataSource.h in Headers */,
+				0E5FD0E8D0F597F599EEE9927A095A85 /* VOKManagedObjectMap.h in Headers */,
+				CDB6B58939B6AFA9C7D2A4C8A9CFE93E /* VOKManagedObjectMapper.h in Headers */,
+				96FB2676B809AEA2D73DCDBD184CF485 /* VOKManagedObjectMapperMacros.h in Headers */,
+				055381161947320FF982032C6901FAD2 /* VOKMappableModel.h in Headers */,
+				0614BE18B71FDC76A97372A209182A8E /* VOKNullabilityFeatures.h in Headers */,
+				480A9D9EEF9011CCE25D1ABCC25B1391 /* Vokoder.h in Headers */,
+				0B7E0EF27CD0C885C9E76EF954C0404A /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		49006B7584DDCD992B0CE4A834BA1FD3 /* Headers */ = {
+		503A8971233E93BB8A4BAB331E106546 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E42DD2BCC077F4FF1ABAE9BC8B740D63 /* ILGClasses.h in Headers */,
+				87338CDCB89F6E5D8655E0B800CC6D46 /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BEA7127E0A5C15E6E350FCC47D7B11D4 /* Headers */ = {
+		5147B0043CA2620D52B94C398070C7A1 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F192D20C860B1FA484395CE0837B1A3 /* ILGClasses.h in Headers */,
+				E4D74D1CE5D7BCF3C09452F0B2D5DB06 /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FB53A0F2302C3B8AB0C4010C0AE0F1DC /* Headers */ = {
+		8D87CBFBBB7B988FA7175781C4A60D9E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6C572325A94536A585E7F47782D128D3 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				6082D08DD0989F4878E96EDBAEB58D75 /* VOKCoreDataCollectionTypes.h in Headers */,
-				82972C8DF6F0563ABDDB62132CF36A74 /* VOKCoreDataManager.h in Headers */,
-				5FA9D810CBA6CB60F9CFF263537BE456 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				82CB600A6F80FBF198559733390B7A68 /* VOKManagedObjectMap.h in Headers */,
-				5F64111A607C3D3BCE72102ECA78A186 /* VOKManagedObjectMapper.h in Headers */,
-				4D7C401D667BC2094B0EA7EB3DFAE62D /* VOKManagedObjectMapperMacros.h in Headers */,
-				8CE2D0975555809CBEF58B9A53FBBFEE /* VOKMappableModel.h in Headers */,
-				BC3D524F479824F5723A9C436E28048C /* VOKNullabilityFeatures.h in Headers */,
-				6BC44C54E5C93449DCB60B431603D2C3 /* Vokoder.h in Headers */,
+				A7F8350ED882D789F247C2A2BFC14AC0 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				55CD6D29D095E527CCE91BD47B76370D /* VOKCoreDataCollectionTypes.h in Headers */,
+				0708A9547A437E1C1DE62A0FC7EEC188 /* VOKCoreDataManager.h in Headers */,
+				075E3DB64E8F1E44279EB9885FA4C4FD /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				AFE5AAB8731020BF47620BFA1CB1449D /* VOKManagedObjectMap.h in Headers */,
+				27ED44F8CB5177E06D40ABEB98DB9344 /* VOKManagedObjectMapper.h in Headers */,
+				4C5706B51658C650212796AA4751CDF7 /* VOKManagedObjectMapperMacros.h in Headers */,
+				0F5E25E490B231D230E46DD857414BE4 /* VOKMappableModel.h in Headers */,
+				69F2BD91B541DC66470D45FD52AFB143 /* VOKNullabilityFeatures.h in Headers */,
+				D70E383B955AF3132141702C51A4156D /* Vokoder.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9D3C7EE5B8C34D011387F90D69728F02 /* Headers */ = {
+		B691BCA40CD5B2DBA82D3BF1705F8071 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3683D33FADF42CDF5DAF4DF8704A65E2 /* VOKKeyPathHelper.h in Headers */,
+				062132CC3C87B3DF9F0F432E53C6913A /* VOKKeyPathHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A93FE136139C4EC8B642DDF47678F063 /* Headers */ = {
+		B9949A19E56942ED9D08FD8179623AA5 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A336E042B5EC6EF76642EA16D66CC52C /* VOKKeyPathHelper.h in Headers */,
+				197758005952E38D8ABD8781B3AA73CB /* VOKKeyPathHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A80B2DC18A326D9E41921549775B33B0 /* Headers */ = {
+		BD7D2264425B607B200B8369D90B67F4 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5B3BD49B499D9E3E6199D637EFF7951 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				6BFB756F3ED0144E84460516CB9F2284 /* VOKCollectionDataSource.h in Headers */,
-				19C6F9213120B51921B2001439610850 /* VOKCoreDataCollectionTypes.h in Headers */,
-				990EF069A00A89658C3E15A51F6B89BB /* VOKCoreDataManager.h in Headers */,
-				EB4EF7DBB9AC285B1AFEC184281D3275 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				73B495A12E1D082D07127884FE661CC0 /* VOKDefaultPagingAccessory.h in Headers */,
-				9B1BC00446877E2EBABDAF764C3DD74C /* VOKFetchedResultsDataSource.h in Headers */,
-				AB7DB2BBA5BE2D21A21BC6E4B8250F57 /* VOKManagedObjectMap.h in Headers */,
-				E3979A80852AD1EEFC4E5A7D3C6AA3A7 /* VOKManagedObjectMapper.h in Headers */,
-				25A26D9A0D6EFC10694241426DC0340B /* VOKManagedObjectMapperMacros.h in Headers */,
-				6D66700B3B5B4A7EFB769D3E32840214 /* VOKMappableModel.h in Headers */,
-				51F1C73A6185E598217E542E7B966858 /* VOKNullabilityFeatures.h in Headers */,
-				D44AF48CA0114A2575C23316F4A3224A /* VOKPagingFetchedResultsDataSource.h in Headers */,
-				661AA59429E5B2429E31E1F3C8922F62 /* Vokoder.h in Headers */,
+				9F11E2522A81A7954E8350C695C8839A /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				F2576B72388B748DBD9DBEF4BA59D12E /* VOKCollectionDataSource.h in Headers */,
+				3C8181EA60CA01A9B891CC07714CD65D /* VOKCoreDataCollectionTypes.h in Headers */,
+				C19713830E5C6F269FBC7D0B0DA8A3EB /* VOKCoreDataManager.h in Headers */,
+				0F1E4FF3C5CFE7758201499C49DE7353 /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				D23BC18771BD805135335CE68965F93E /* VOKDefaultPagingAccessory.h in Headers */,
+				DBE0D515A2AF19B3C14494BBA1EDED5C /* VOKFetchedResultsDataSource.h in Headers */,
+				9791D1ADCAD055CA5A3FCDEC39A0C80E /* VOKManagedObjectMap.h in Headers */,
+				B7A83FFDE42EE3B7EFBCF551DF783C58 /* VOKManagedObjectMapper.h in Headers */,
+				B9664DBC20AD20340C9C56C827223331 /* VOKManagedObjectMapperMacros.h in Headers */,
+				427CC9F51B4BC30F06148398B96BD0EC /* VOKMappableModel.h in Headers */,
+				114C8C290140EACA1E13689FE841EB7A /* VOKNullabilityFeatures.h in Headers */,
+				1F91350CA25BCF86BB981C41C563A117 /* Vokoder.h in Headers */,
+				C9C9F981F61CB574580B9BD26F1913B5 /* VOKPagingFetchedResultsDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B58DBA55186E27ED740C1CB50C843A95 /* Headers */ = {
+		BE2E0BDD96716D29327D15532F5AB901 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3DF21D53EC610FE5B6DF93359FDEBCF /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				97CD56264D4CD533431CCAE366E2D8A5 /* VOKCoreDataCollectionTypes.h in Headers */,
-				EA8404FBB154BDD8AD3291C091219768 /* VOKCoreDataManager.h in Headers */,
-				8DC8CFF0376475766C1ACD8FDF349B85 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				BFFC6F2B83E4C3F7EF1C36C2D16963D3 /* VOKManagedObjectMap.h in Headers */,
-				8AB1E0FA4075C8EA532569E104BE907F /* VOKManagedObjectMapper.h in Headers */,
-				C7D068D4C3096A23658D151F27585D53 /* VOKManagedObjectMapperMacros.h in Headers */,
-				CF06EAB5B6A9FBA5DA323D9463DA8402 /* VOKMappableModel.h in Headers */,
-				DA7F7DC776B03695CC8379939C5650DB /* VOKNullabilityFeatures.h in Headers */,
-				8DC9917D6046F9F367ED866AA41974F6 /* Vokoder.h in Headers */,
+				F588666174877E1EB64EDB1CE7563126 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				28D90A83F48C78266B3D16B6AD7B7D6E /* VOKCoreDataCollectionTypes.h in Headers */,
+				16262B39AA2AA453DCBB2FD9B53678ED /* VOKCoreDataManager.h in Headers */,
+				CB7C7721CA6DECFE06DFA87EE1DEA341 /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				2C9B869BC7B4B6354C249A113052AF0E /* VOKManagedObjectMap.h in Headers */,
+				9F3D25892079C89F92D2F9FD4190D7DE /* VOKManagedObjectMapper.h in Headers */,
+				283AAF6F553CFEFA0CF98CC97F3FC0A1 /* VOKManagedObjectMapperMacros.h in Headers */,
+				572E1E5F7165FB09587BE2213561CC7C /* VOKMappableModel.h in Headers */,
+				4FD52C961B0424802F6F5FD7EFD2D545 /* VOKNullabilityFeatures.h in Headers */,
+				D431EF7448393C5B9DA92071BEEDC8A4 /* Vokoder.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBE25EC0A2132AE908EF6D01962DDD1B /* Headers */ = {
+		BE8EC159AEDF593F478BE1ED86F7C1D4 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				764C6548E7C26D41B6A1AA84C02E733E /* ILGClasses.h in Headers */,
+				2CAB3BA54169F354B75C445E00DC15F0 /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		94B8B2390CA3FBA24E80314903DD5640 /* Headers */ = {
+		BFFE3730B6C98C1728E8155F6A0FE977 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D43A99C4866F631713F400CA853E0E38 /* VOKKeyPathHelper.h in Headers */,
+				DB8D436A6E007C50BE090D9489B7657E /* VOKKeyPathHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EDC6D7991906058BC2C36EBAE7125035 /* Headers */ = {
+		CD0473E81489D428A9CD5E6882F8ECAF /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				105324934B4128CE7CBC26B7FB46BDE7 /* ILGClasses.h in Headers */,
+				A84D346F6FAD676FAD74B8DB50323438 /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		278DF8BD716D9EE95E2102B9125544F3 /* Headers */ = {
+		DBF98F7328AC68E377262551A3D3A995 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				47AF74A30219D8E2076AA00A4E56ECF4 /* ILGClasses.h in Headers */,
+				185687C1B9E198D61705197900787A55 /* ILGClasses.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		233268FD92FD61C74974EBE82CC182C3 /* Headers */ = {
+		E26931463919EAEDA98E8DABF9C1B0EB /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6A7F88E8EB4CAF611479203471DCCEC /* VOKKeyPathHelper.h in Headers */,
+				31144D7C864E9C71A1AE05520A41EABF /* VOKKeyPathHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		70775B0E02B3EE5B5AA0DEA0293807A6 /* Pods-TodayWidget */ = {
+		059D807EA1E6A20AD48CB3E031062F5C /* Pods-TodayWidget */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F0BE19AE6ECA63EA4BC205828D01014C /* Build configuration list for PBXNativeTarget "Pods-TodayWidget" */;
+			buildConfigurationList = AC64C7A066A995344DCC0B0E982051EF /* Build configuration list for PBXNativeTarget "Pods-TodayWidget" */;
 			buildPhases = (
-				8322FDAB48382A200C29FAE303AAAB8A /* Sources */,
-				C892977BEF1C9F4CEC43EDE0D1F40FB6 /* Frameworks */,
+				F9D572A6302442AF5B4B289809389F07 /* Sources */,
+				10902616494876AF49A0543E2CC817BC /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				F536239C0B77D4E3F72243D70A73B071 /* PBXTargetDependency */,
-				5FEC91C67E67FBE7F2E2A86AE31D5131 /* PBXTargetDependency */,
-				87C960534278204A820BF1D64B1C143A /* PBXTargetDependency */,
+				12D78BCC1B38F936A172E953B3C3955F /* PBXTargetDependency */,
+				B89F0DC42F703001FCC402F411AB7B2C /* PBXTargetDependency */,
+				6A98BDB1EC96E349640CB59C1D23A704 /* PBXTargetDependency */,
 			);
 			name = "Pods-TodayWidget";
 			productName = "Pods-TodayWidget";
-			productReference = 4441C392D8828C60F1289E860A23C911 /* libPods-TodayWidget.a */;
+			productReference = B669B29C55DF73AE4CCA35D1DBFA0FBA /* libPods-TodayWidget.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		2A008476970576E0B5C78E2BFDF0C345 /* ILGDynamicObjC-tvOS9.0 */ = {
+		0A234DB0827360575AE0E68781ED3E5B /* ILGDynamicObjC-tvOS9.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7C44297BB4409ECBD2621CDF4A65D323 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-tvOS9.0" */;
+			buildConfigurationList = B58E5E4865C5D0135206C5A015565F70 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-tvOS9.0" */;
 			buildPhases = (
-				619C235C889A57656611E08C84331852 /* Sources */,
-				E2BBA8E0FEA1A74D432CD3E12690C43E /* Frameworks */,
-				BEA7127E0A5C15E6E350FCC47D7B11D4 /* Headers */,
+				AE97FF34978B8129FA3DD0E77E27F12E /* Sources */,
+				1AB91CBCF57970C0E0B5078E297B4723 /* Frameworks */,
+				5147B0043CA2620D52B94C398070C7A1 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1492,16 +1492,16 @@
 			);
 			name = "ILGDynamicObjC-tvOS9.0";
 			productName = "ILGDynamicObjC-tvOS9.0";
-			productReference = FCCC98393094B15D22C29F6DF6BD111D /* libILGDynamicObjC-tvOS9.0.a */;
+			productReference = 89C28DEC52743FA31E609674BE81B735 /* libILGDynamicObjC-tvOS9.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		4AB6E6A867E0C03192F04753BCC56DB2 /* ILGDynamicObjC-iOS8.0 */ = {
+		0C115C45E7548BE6DB46198B1EDEE9C9 /* ILGDynamicObjC-iOS8.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4E05AD4F33B9D47A962DEA3AC133F23B /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-iOS8.0" */;
+			buildConfigurationList = 7B569FC69578A7C73F8632746265BFAB /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-iOS8.0" */;
 			buildPhases = (
-				03ED01FC6945479915F9295336E74015 /* Sources */,
-				DA0E5D65344A5E149D9FA9010C4533C0 /* Frameworks */,
-				278DF8BD716D9EE95E2102B9125544F3 /* Headers */,
+				4EFFD3F0D888ECA7FDE767A07491B432 /* Sources */,
+				64FE22A5308BF1171E6B0AF8E535C214 /* Frameworks */,
+				DBF98F7328AC68E377262551A3D3A995 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1509,35 +1509,35 @@
 			);
 			name = "ILGDynamicObjC-iOS8.0";
 			productName = "ILGDynamicObjC-iOS8.0";
-			productReference = 9C03B3C5377C15525FE5987D4D450838 /* libILGDynamicObjC-iOS8.0.a */;
+			productReference = BE0E8BA9D1D2B080C2BEA9741E7ED987 /* libILGDynamicObjC-iOS8.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		6B0B6527EDA229236DF3F914B7DD8D1E /* Pods-VOKCoreDataManager */ = {
+		114588872928DF3E6652444B21069081 /* Pods-VOKCoreDataManager */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C473BD9CD0AE43CD7A719CAFD9D60E3E /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager" */;
+			buildConfigurationList = F4E51430E7F4B2C74C6BCD3ED56BBCBB /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager" */;
 			buildPhases = (
-				E5FA3C81100A5E4073A0B241D942880F /* Sources */,
-				D9C6784E5CA0DE435F9022A5BD1BE1AD /* Frameworks */,
+				AC7DE41C0D99BC2B2BC181D256FA7E88 /* Sources */,
+				792FDE4052A094713E2C42AC5D3AF39F /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				D60EC64EA28FCD7778F70BB308DE3B16 /* PBXTargetDependency */,
-				D79E5F2BBAA5712AECBE737244B81FEF /* PBXTargetDependency */,
-				8EF37CEC4A035A06BAEF33609727C7FB /* PBXTargetDependency */,
+				DD642C64B14AEC14E2DDC7CDCBEC5EEC /* PBXTargetDependency */,
+				88A2D68791E39D84C41CEB68A21C19BF /* PBXTargetDependency */,
+				2099DA11F47CACB77B5A9B7347F3CF9D /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKCoreDataManager";
 			productName = "Pods-VOKCoreDataManager";
-			productReference = 9DA9C1C60E4F548C3D7AE3E5A9DDC1EA /* libPods-VOKCoreDataManager.a */;
+			productReference = 3C61847DB7A6DA88D9BC36D1749F02D4 /* libPods-VOKCoreDataManager.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		82F6302EC5FDB383B400D97DB43ABF03 /* VOKUtilities-tvOS9.0 */ = {
+		2F7F0943C23BC0F4C0133529464D5DC0 /* VOKUtilities-tvOS9.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2908F09150E62FD0D2F370CF842734A0 /* Build configuration list for PBXNativeTarget "VOKUtilities-tvOS9.0" */;
+			buildConfigurationList = 73CA1AEC4FFA78EAF49A1AF980A86CB3 /* Build configuration list for PBXNativeTarget "VOKUtilities-tvOS9.0" */;
 			buildPhases = (
-				6911096A8EDF5A1FA8B9653072EEB00E /* Sources */,
-				B5C67F9E32BC71528FC0169332D88E19 /* Frameworks */,
-				233268FD92FD61C74974EBE82CC182C3 /* Headers */,
+				910D6AD3C9E2DF4EAE7906F54B1A9584 /* Sources */,
+				4B92A6F10C1BC3A54B2DB79524937D7D /* Frameworks */,
+				E26931463919EAEDA98E8DABF9C1B0EB /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1545,35 +1545,35 @@
 			);
 			name = "VOKUtilities-tvOS9.0";
 			productName = "VOKUtilities-tvOS9.0";
-			productReference = 091B0FE63D6828648A4E44A2FB793E5E /* libVOKUtilities-tvOS9.0.a */;
+			productReference = 25CA4DC541F4315641B27252789BC11E /* libVOKUtilities-tvOS9.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		6B0D563CAD5EA3257860C73C8A622E25 /* Vokoder-fdc3d3be */ = {
+		3F0FAB9F1B7683284CB9673A8D392DD3 /* Vokoder-fdc3d3be */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 9D4AF939A6E6DA33916659AF10052103 /* Build configuration list for PBXNativeTarget "Vokoder-fdc3d3be" */;
+			buildConfigurationList = 41BB3A576D5055C9947630B81E7D6DC2 /* Build configuration list for PBXNativeTarget "Vokoder-fdc3d3be" */;
 			buildPhases = (
-				C62CC2B1FB4AABC1F8BAACD2F0E374E8 /* Sources */,
-				C3E5A285980D6BA2FF9238B573470C95 /* Frameworks */,
-				89A02D872FAEF49BF73C714C9F54174D /* Headers */,
+				522AAAA72335BEE6937F278AFB10653F /* Sources */,
+				915918B96A0A163C62FABDA6BC0004FA /* Frameworks */,
+				5025987FCED443F3C09FA7E0684BC2BC /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				E61F53953EC3087C64E9AC6E22CA4A81 /* PBXTargetDependency */,
-				160D1E81D3312961561F80BE87F582E9 /* PBXTargetDependency */,
+				EB37999961960DCCA583BB98BF70EFA9 /* PBXTargetDependency */,
+				667FC90C0B8D28798431791B60A9DD27 /* PBXTargetDependency */,
 			);
 			name = "Vokoder-fdc3d3be";
 			productName = "Vokoder-fdc3d3be";
-			productReference = AB9B7E1C33A0AC0AEC39367FE1B2753C /* libVokoder-fdc3d3be.a */;
+			productReference = A6E740100759BC1AEB864C35081CB978 /* libVokoder-fdc3d3be.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		830608453A64AF3F5591F52ED368B223 /* VOKUtilities-OSX10.9 */ = {
+		47DD822514431098BFCCFDCC6E07F4D2 /* VOKUtilities-OSX10.9 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 00C0CE07F3FDC06879C92DC6A179C9B5 /* Build configuration list for PBXNativeTarget "VOKUtilities-OSX10.9" */;
+			buildConfigurationList = D71A3738B4311064A0B9331B6907FC4C /* Build configuration list for PBXNativeTarget "VOKUtilities-OSX10.9" */;
 			buildPhases = (
-				32A35A52C2F024137F2FF2E7D4669E44 /* Sources */,
-				B3F3DA62DED8E6D96C31A22FA58B690B /* Frameworks */,
-				D75E048099D93508DFAF7E510BCE8AF2 /* Headers */,
+				1F131C8C95803C9DE266B07FBBE00658 /* Sources */,
+				8EAC365920410C7FBE56B121F93B1363 /* Frameworks */,
+				19599078729ED6E0712AE5F9C7E95869 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1581,73 +1581,73 @@
 			);
 			name = "VOKUtilities-OSX10.9";
 			productName = "VOKUtilities-OSX10.9";
-			productReference = 60BABD577094FC9C8A9957F04FCFF967 /* libVOKUtilities-OSX10.9.a */;
+			productReference = 1AE9A2733CEB631B9297DF5ED0D30AEC /* libVOKUtilities-OSX10.9.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		A86E6132E337186EFFC6D495AFCB1C66 /* Vokoder-07029ee6 */ = {
+		5473A142FC5A8D0C655B183280456A06 /* Vokoder-07029ee6 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D5E432436DF3B54BBD2A754AB66AAFDF /* Build configuration list for PBXNativeTarget "Vokoder-07029ee6" */;
+			buildConfigurationList = 359BA7A7F14BB385AF7AEFA6506CB9A0 /* Build configuration list for PBXNativeTarget "Vokoder-07029ee6" */;
 			buildPhases = (
-				4C33840B8064D0551734502AE68D7D20 /* Sources */,
-				D7BC2912A05C8F68194FF8AC7A9CC89F /* Frameworks */,
-				BD9A9990D25307C6492544DE93E9D9E3 /* Headers */,
+				F1BD34CA4F0E7BD2741A9F4F8CFE6F7E /* Sources */,
+				CDD39C24292C1A0E4AB34F3558EE5978 /* Frameworks */,
+				1ABDCA8DAAD4EF24A87FA297165F616C /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				B226444A4B91E34B753D5DCAF5C737B7 /* PBXTargetDependency */,
-				5EF8EDB2E3374D2C66E2F9B9B4DD8D6A /* PBXTargetDependency */,
+				3806B07B09464C8493458D3424CCC864 /* PBXTargetDependency */,
+				AB1F1D77295F06C92303D1B058DEE830 /* PBXTargetDependency */,
 			);
 			name = "Vokoder-07029ee6";
 			productName = "Vokoder-07029ee6";
-			productReference = 066C285FCB8B5E8BA0EBCC8F740081AD /* libVokoder-07029ee6.a */;
+			productReference = 943322D0A26187E027E2764D4EC85A77 /* libVokoder-07029ee6.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		F3ED9EB0D8820EDD316FA12CC95EDEAF /* Pods-VOKCoreDataManager-tvOS */ = {
+		5C35D6A96B43A680C08BDC7554701EF7 /* Pods-VOKCoreDataManager-tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = ECDF0EC2AC12985912E46ED93F200C42 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-tvOS" */;
+			buildConfigurationList = E4D95A5EABB37DC56D7DFDB728076BE7 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-tvOS" */;
 			buildPhases = (
-				8286E271153EE75BAE0D47A37FE411A9 /* Sources */,
-				DAC065575638A31C0EB8030CD2BF58AE /* Frameworks */,
+				54BDAC92DF2EA8F9A0AAC687A5641656 /* Sources */,
+				F429E9C77E5AAC43A8582E2D2F873889 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				1FFF8DB338A0C07A5EFAE251C8614F4F /* PBXTargetDependency */,
-				3432A5D7CB49B47F275F3322C4C48829 /* PBXTargetDependency */,
-				5297DB25EDC0BA70F9BC331D8AFFE33A /* PBXTargetDependency */,
+				9C00BA0DCEB10DCAE9D5DAA8F7B1E25A /* PBXTargetDependency */,
+				816D889138F67580C9609A83CC8F3121 /* PBXTargetDependency */,
+				FE59EF51D4F241D1C6CD6D52D4E9A7CE /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKCoreDataManager-tvOS";
 			productName = "Pods-VOKCoreDataManager-tvOS";
-			productReference = A0BC3E14560091A93BC0EF4B3C3FB875 /* libPods-VOKCoreDataManager-tvOS.a */;
+			productReference = C2AF078AB0B6B0EA905EA98ECAD81F57 /* libPods-VOKCoreDataManager-tvOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		07866B96FFB4DAB28C80B31CE4B720BD /* Pods-VOKCoreDataManager-OSX */ = {
+		8CCA24D7237486997759BAD00AB91517 /* Pods-VOKCoreDataManager-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7D67DE34CC36058521895BA9FE7752E9 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-OSX" */;
+			buildConfigurationList = 4593BC577505254D3FA9124E5497A884 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-OSX" */;
 			buildPhases = (
-				96987D3979F48BBDB1F1B8216CB385BA /* Sources */,
-				F9BA38C67260C6ED66E32CB07929B991 /* Frameworks */,
+				46B2A5CF99DA87D50CD15156A0A2E59F /* Sources */,
+				0A2623FD3FEA4D41EB286193E13B4C19 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				336DBF21D38759B57E9CCA44CE693623 /* PBXTargetDependency */,
-				DE8F1EBFD2BF2A62D1E7AF72318B1D44 /* PBXTargetDependency */,
-				E84D7B6685FFC812E974DFA515942B4C /* PBXTargetDependency */,
+				7C52148B0019A2F69689A508627A3A44 /* PBXTargetDependency */,
+				F3913978D5EDCFDC2B3FCE0866CB5D56 /* PBXTargetDependency */,
+				0BA884BE0A32507159DEC85F918C18E5 /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKCoreDataManager-OSX";
 			productName = "Pods-VOKCoreDataManager-OSX";
-			productReference = 63C3F1515EF08D989ADD8EAB39DD4E9E /* libPods-VOKCoreDataManager-OSX.a */;
+			productReference = 7BC95B5FA7DD23673D1DC56B026A8A8C /* libPods-VOKCoreDataManager-OSX.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		772F82B4B45005A2B8D72A61BE1BFC27 /* VOKUtilities-iOS10.0 */ = {
+		909EE1A623E69E268090F6690431EDAB /* VOKUtilities-iOS10.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A1775DB7741425333C73CECE600A5C0A /* Build configuration list for PBXNativeTarget "VOKUtilities-iOS10.0" */;
+			buildConfigurationList = E53D4B1EDA84FB1B08D637DF1B0D94D9 /* Build configuration list for PBXNativeTarget "VOKUtilities-iOS10.0" */;
 			buildPhases = (
-				6DF1CC918C25B37DF3B50FA65661DDEC /* Sources */,
-				F256554D282483F25C4B318B383E2ED6 /* Frameworks */,
-				A93FE136139C4EC8B642DDF47678F063 /* Headers */,
+				27330A217CF48079505FBA4C8D119FF8 /* Sources */,
+				C8C676AB8424039AB9F8C4B02708CF0E /* Frameworks */,
+				B9949A19E56942ED9D08FD8179623AA5 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1655,15 +1655,15 @@
 			);
 			name = "VOKUtilities-iOS10.0";
 			productName = "VOKUtilities-iOS10.0";
-			productReference = 474BBE2194A46BC7E8A348CFC9D76E77 /* libVOKUtilities-iOS10.0.a */;
+			productReference = 834DCAF6A2F5FBE14EA7AC3A00C677A9 /* libVOKUtilities-iOS10.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		D8381DFBDBD5ECD6EE5233A890A6597E /* Pods-VOKCoreDataManagerTests-OSX */ = {
+		A3B70E31CB300B2BBC3037900BBCB8AB /* Pods-VOKCoreDataManagerTests-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8E9B0F49C86521A2475BA3439DC673A2 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManagerTests-OSX" */;
+			buildConfigurationList = C672001D8C6EC04797B2791EFA6158BF /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManagerTests-OSX" */;
 			buildPhases = (
-				72900FD12409AE9717D49D7220407BCB /* Sources */,
-				F45E34859BC913A0A1BCE49E84469D8E /* Frameworks */,
+				5E94EF09EADF432839FD8AA03D2888B7 /* Sources */,
+				9FC3CEFC721D6E782B42FB79514F80AD /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1671,16 +1671,16 @@
 			);
 			name = "Pods-VOKCoreDataManagerTests-OSX";
 			productName = "Pods-VOKCoreDataManagerTests-OSX";
-			productReference = 73831ABF987475486391C975F9F05112 /* libPods-VOKCoreDataManagerTests-OSX.a */;
+			productReference = C47D0C3C9C886EB71766440D090D84F4 /* libPods-VOKCoreDataManagerTests-OSX.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		3F19AA1185A08DA68DF49A63F2775D46 /* ILGDynamicObjC-iOS10.0 */ = {
+		A7515B1D5B3879EF823CC72A4F4CBFCC /* ILGDynamicObjC-iOS10.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 08ECEFFBA0ED222BA652ACAC7B493A5D /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-iOS10.0" */;
+			buildConfigurationList = D5778E346FE65FA755BC3D9BB10FF6CE /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-iOS10.0" */;
 			buildPhases = (
-				41E647EFD1F47B80FEEF34C346429130 /* Sources */,
-				54559F7DB17C4EFC7473F3BF28CB5E6D /* Frameworks */,
-				49006B7584DDCD992B0CE4A834BA1FD3 /* Headers */,
+				4E975182758659E8FE3EB3A1382E1341 /* Sources */,
+				A834C341F3F51A30B348F29306FB29F2 /* Frameworks */,
+				503A8971233E93BB8A4BAB331E106546 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1688,16 +1688,16 @@
 			);
 			name = "ILGDynamicObjC-iOS10.0";
 			productName = "ILGDynamicObjC-iOS10.0";
-			productReference = BABD7645020D9F8280BB1EF781091F4C /* libILGDynamicObjC-iOS10.0.a */;
+			productReference = 9F031FFF1DE23E344F2DF5B559741D35 /* libILGDynamicObjC-iOS10.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		7A0A41400F1B71C96AAB4C1E0230F110 /* VOKUtilities-watchOS3.0 */ = {
+		AA75B5AC10E44233A4C5AB7C8278A16A /* VOKUtilities-watchOS3.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7870541348C0CB4241F54434A4988AB7 /* Build configuration list for PBXNativeTarget "VOKUtilities-watchOS3.0" */;
+			buildConfigurationList = FB0D60C2F1723A1254AE87478178C6ED /* Build configuration list for PBXNativeTarget "VOKUtilities-watchOS3.0" */;
 			buildPhases = (
-				7DC0786761BE760BBBCBB553E998324C /* Sources */,
-				EF18044A09514CD811257A1D01E8208C /* Frameworks */,
-				94B8B2390CA3FBA24E80314903DD5640 /* Headers */,
+				2D27EC7A8740C0A088140F24AE0CAD39 /* Sources */,
+				40AAF9A3BC5E671040EA47286DC80290 /* Frameworks */,
+				BFFE3730B6C98C1728E8155F6A0FE977 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1705,16 +1705,16 @@
 			);
 			name = "VOKUtilities-watchOS3.0";
 			productName = "VOKUtilities-watchOS3.0";
-			productReference = 012F0A9F9A7CDBE88D70A160CAF549B0 /* libVOKUtilities-watchOS3.0.a */;
+			productReference = 0D930BD0A47458465742C522AB38F134 /* libVOKUtilities-watchOS3.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		5DBFB1D6ADE4C2238F5889A1EAB945CE /* VOKUtilities-iOS8.0 */ = {
+		AE27C772C4215696CDDD8372D69BAF5D /* VOKUtilities-iOS8.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 5E82F482207912533DDA66CD2B795957 /* Build configuration list for PBXNativeTarget "VOKUtilities-iOS8.0" */;
+			buildConfigurationList = AB970B0D8A11CCE9AAD7CB5BEFCFF638 /* Build configuration list for PBXNativeTarget "VOKUtilities-iOS8.0" */;
 			buildPhases = (
-				10EF26EE86B178B3A76D7D5377724B90 /* Sources */,
-				9705A6FECE3EA790824536A67108E916 /* Frameworks */,
-				9D3C7EE5B8C34D011387F90D69728F02 /* Headers */,
+				958F1F91CB464006F9503981769165D8 /* Sources */,
+				017B6ED21EDBA580593C392B20A59AE7 /* Frameworks */,
+				B691BCA40CD5B2DBA82D3BF1705F8071 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1722,35 +1722,35 @@
 			);
 			name = "VOKUtilities-iOS8.0";
 			productName = "VOKUtilities-iOS8.0";
-			productReference = 2DDE38143B617CB415B17CDC63D5B998 /* libVOKUtilities-iOS8.0.a */;
+			productReference = ED3CE8BE75D7D627CE0B3DFBE8241DC1 /* libVOKUtilities-iOS8.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		7563863CEAB51B07E9E8D87776F044CC /* Vokoder.root-Core-MapperMacros-watchOS */ = {
+		B3CE1BF250548E4A5C0984BF85E3FCA1 /* Vokoder.root-Core-MapperMacros-watchOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B58BA56853A2C3714E91F0E4230337BF /* Build configuration list for PBXNativeTarget "Vokoder.root-Core-MapperMacros-watchOS" */;
+			buildConfigurationList = 2C36428ED42922E02877ADCF66E2BD01 /* Build configuration list for PBXNativeTarget "Vokoder.root-Core-MapperMacros-watchOS" */;
 			buildPhases = (
-				9073D35CAC365C03E4CA7E726A49453C /* Sources */,
-				ED65389C15181290EEB875DDF5AD9B07 /* Frameworks */,
-				B58DBA55186E27ED740C1CB50C843A95 /* Headers */,
+				9C1A88EC3DFA4E2A6A70896E42B33E6A /* Sources */,
+				AE82542A92BDBFB6F667BE6BE1C897AA /* Frameworks */,
+				BE2E0BDD96716D29327D15532F5AB901 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				5E07A905460CCF44BB9FE7797A530367 /* PBXTargetDependency */,
-				67271FBD998D9AA97E79D3D116F94B9E /* PBXTargetDependency */,
+				6499AE559EDB827C05DE414181A05F0F /* PBXTargetDependency */,
+				C57F5C91516C60CBBB11015590B4E30E /* PBXTargetDependency */,
 			);
 			name = "Vokoder.root-Core-MapperMacros-watchOS";
 			productName = "Vokoder.root-Core-MapperMacros-watchOS";
-			productReference = 91BDAD172EE3777442B5BBB4E49FFAF5 /* libVokoder.root-Core-MapperMacros-watchOS.a */;
+			productReference = 530A969A524869B061EB8E86836D66D4 /* libVokoder.root-Core-MapperMacros-watchOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		B055242C128EDCCF53DC7C1592181C09 /* ILGDynamicObjC-watchOS3.0 */ = {
+		B6C9639C211DF9E8E72302FD37DDA5AE /* ILGDynamicObjC-watchOS3.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 04F6BD7BD49CC5A702D74146B10EDC66 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-watchOS3.0" */;
+			buildConfigurationList = F7BB2C691D05F5A123D7465954664E0A /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-watchOS3.0" */;
 			buildPhases = (
-				C58E51EB5B24B13C31E0BEEFDC95EBFE /* Sources */,
-				63130B3F7ED5E693AC24DDA5AC693817 /* Frameworks */,
-				FBE25EC0A2132AE908EF6D01962DDD1B /* Headers */,
+				C0C3C7256389BD2017D6067A8E00D29F /* Sources */,
+				870C9A19B5B0396E96B391037A3C4C02 /* Frameworks */,
+				BE8EC159AEDF593F478BE1ED86F7C1D4 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1758,35 +1758,35 @@
 			);
 			name = "ILGDynamicObjC-watchOS3.0";
 			productName = "ILGDynamicObjC-watchOS3.0";
-			productReference = 2C05BF495E3C46D0AA1D04F61CD06BAB /* libILGDynamicObjC-watchOS3.0.a */;
+			productReference = 75FF86E0104378C3A12B5AC1D933BF7A /* libILGDynamicObjC-watchOS3.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		B869DEF6943F6AFE83461209440D7E0D /* Pods-WatchApp Extension */ = {
+		CC2B4D674640F6EB6E202F7C76D9A7F1 /* Pods-WatchApp Extension */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = ECDF551D9414891B248F23BC3265F5C0 /* Build configuration list for PBXNativeTarget "Pods-WatchApp Extension" */;
+			buildConfigurationList = DE4AFF0E53A788087E0281B9AB219F2A /* Build configuration list for PBXNativeTarget "Pods-WatchApp Extension" */;
 			buildPhases = (
-				8E46BD82B1FBD12485FEA53B543BA8BE /* Sources */,
-				C8147EE810BFF6D3979BE9457FC7E754 /* Frameworks */,
+				8DB92D20A9ADBD3F3D042E465DCAAAFC /* Sources */,
+				993736DF3ACEBE8D478446A54DD11BD8 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				6CA38A320AB6698F53F148206A2C7FD0 /* PBXTargetDependency */,
-				839B81892320319DF1F8241434DE8D0A /* PBXTargetDependency */,
-				AAD857A7E8B58F6981D561B32D380FB9 /* PBXTargetDependency */,
+				99388BA1375D9C192C7590CFFE6C1738 /* PBXTargetDependency */,
+				BDF0A6981BBF1F72B94F12095A622215 /* PBXTargetDependency */,
+				18C459D616C6EB1E39B1676D973811B8 /* PBXTargetDependency */,
 			);
 			name = "Pods-WatchApp Extension";
 			productName = "Pods-WatchApp Extension";
-			productReference = 21FF87D5FB7B4CFBC516A866A43B700A /* libPods-WatchApp Extension.a */;
+			productReference = 9DDBA1D4CA1F7F7B54DE18C40A053415 /* libPods-WatchApp Extension.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		FADC2218D666458DFB6C017FE59277E6 /* ILGDynamicObjC-OSX10.9 */ = {
+		CCCF7217FD9C2EFDF11F0E0BE1388F3B /* ILGDynamicObjC-OSX10.9 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 56787BDBF12439322DD306BC4A106AA3 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-OSX10.9" */;
+			buildConfigurationList = D3003EDC6E321A667FA6EC8DBB540C55 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-OSX10.9" */;
 			buildPhases = (
-				E1FDC1F4AE2769879C39319C10712E42 /* Sources */,
-				F93A5DF5D5D3A9FC8F058C69737801C2 /* Frameworks */,
-				EDC6D7991906058BC2C36EBAE7125035 /* Headers */,
+				0148FCF5A448799558740632561736B7 /* Sources */,
+				8617A12C2A24565823C9881D9F69EFDE /* Frameworks */,
+				CD0473E81489D428A9CD5E6882F8ECAF /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1794,15 +1794,15 @@
 			);
 			name = "ILGDynamicObjC-OSX10.9";
 			productName = "ILGDynamicObjC-OSX10.9";
-			productReference = F9A0609938E5CA1367E1F89470849D81 /* libILGDynamicObjC-OSX10.9.a */;
+			productReference = 3E7731EED349F4BAA86AD357B9D186F5 /* libILGDynamicObjC-OSX10.9.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		C96C19937BD2C54B484651D4BF7A52E0 /* Pods-VOKCoreDataManagerTests-tvOS */ = {
+		CCE64B9FBA8C338B1CC0588931DE3548 /* Pods-VOKCoreDataManagerTests-tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B22B62311604CFECA70CA23602291B68 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManagerTests-tvOS" */;
+			buildConfigurationList = AE1716C003EC4BD1FF51B6700F5322D1 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManagerTests-tvOS" */;
 			buildPhases = (
-				657DED765400B9A1DC4EF5C3A4960141 /* Sources */,
-				C5F028CC333FB54921DC558268C2460B /* Frameworks */,
+				D7B3E26B27225792976B77BF8A954BC5 /* Sources */,
+				0C5A8FF94918E3D91D56609D4F12DEC5 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1810,34 +1810,34 @@
 			);
 			name = "Pods-VOKCoreDataManagerTests-tvOS";
 			productName = "Pods-VOKCoreDataManagerTests-tvOS";
-			productReference = 1006E061CE81334B5F18D76F03E84A1A /* libPods-VOKCoreDataManagerTests-tvOS.a */;
+			productReference = 3CE037145D600CAE7611AAAD52F11819 /* libPods-VOKCoreDataManagerTests-tvOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		039B93451C7F51D385086191C304EEF3 /* Vokoder.root-Core-MapperMacros-OSX */ = {
+		D1FC04FA1915305A1DE087E1A3FFB6FD /* Vokoder.root-Core-MapperMacros-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 3A74B6A977C3BA59B315FC722112BBF6 /* Build configuration list for PBXNativeTarget "Vokoder.root-Core-MapperMacros-OSX" */;
+			buildConfigurationList = C8571229CD897A6EB95626F327D35D60 /* Build configuration list for PBXNativeTarget "Vokoder.root-Core-MapperMacros-OSX" */;
 			buildPhases = (
-				224D709709DD2D0F6C82A115DF835BF7 /* Sources */,
-				3637DF4BAB4DF16A93E8A1163D59077C /* Frameworks */,
-				FB53A0F2302C3B8AB0C4010C0AE0F1DC /* Headers */,
+				528454BB3C558700AE42019E0285F510 /* Sources */,
+				3B593D9ABD41F094C991309D2F114552 /* Frameworks */,
+				8D87CBFBBB7B988FA7175781C4A60D9E /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				62236EB4DF161C97C7098B6C44957787 /* PBXTargetDependency */,
-				D6EBF3C1D3DEF21A8DE6AA4B8E8F3F42 /* PBXTargetDependency */,
+				87CAE518200C7EFEC13581E220724E53 /* PBXTargetDependency */,
+				0CA37D72163E01637959C7CB8D85B557 /* PBXTargetDependency */,
 			);
 			name = "Vokoder.root-Core-MapperMacros-OSX";
 			productName = "Vokoder.root-Core-MapperMacros-OSX";
-			productReference = 775D86E87223CD14F633CCDF0C3A2B79 /* libVokoder.root-Core-MapperMacros-OSX.a */;
+			productReference = 085798873D67A80FB040EA3B6A743517 /* libVokoder.root-Core-MapperMacros-OSX.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		88F8112292AC6530D48CAAAB5ABC5160 /* Pods-VOKCoreDataManager Tests */ = {
+		E2DC4753ED177DC36898BCB2072C6D35 /* Pods-VOKCoreDataManager Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = EAE90995CF11A722D072116D2DCAE030 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests" */;
+			buildConfigurationList = 2BD2F3230CD6A587AEA2A3021D18FACE /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests" */;
 			buildPhases = (
-				AAE2C77E0DC42C0609EB0EF7EB47D049 /* Sources */,
-				6D0766FE9B9B89DEAD6EA3CD4903305F /* Frameworks */,
+				2AFF0790EDEE93BECE4CA6BFE1A6E439 /* Sources */,
+				FA6C637DC7469BFF03423B36DE0F9082 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1845,462 +1845,462 @@
 			);
 			name = "Pods-VOKCoreDataManager Tests";
 			productName = "Pods-VOKCoreDataManager Tests";
-			productReference = CF9ED222207E10F412CE86CA603947AD /* libPods-VOKCoreDataManager Tests.a */;
+			productReference = 95AB9EE21EB6A93107C55C85E236B4BF /* libPods-VOKCoreDataManager Tests.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		A9C28832CA7ABDF5308A8697E2AD5CC1 /* Vokoder-43a9e09e */ = {
+		F10CB8AE3F4245CEA38EC599242D3FEC /* Vokoder-43a9e09e */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 63D1FDEDF4FE692715E76337DC1EF66A /* Build configuration list for PBXNativeTarget "Vokoder-43a9e09e" */;
+			buildConfigurationList = 2A5810ABCB03EFC7555AD8367A6DD40D /* Build configuration list for PBXNativeTarget "Vokoder-43a9e09e" */;
 			buildPhases = (
-				055C4FE88A4DE6507A584CB2DA9CBD32 /* Sources */,
-				C560D008759515ED9B8054B8A567DE21 /* Frameworks */,
-				A80B2DC18A326D9E41921549775B33B0 /* Headers */,
+				3D08D36AFF8A41D1BB60499FC94B31B3 /* Sources */,
+				EA453B9A51CC86C82101FC51765AD965 /* Frameworks */,
+				BD7D2264425B607B200B8369D90B67F4 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				05B3651388146A677D6E05BE9B87DB52 /* PBXTargetDependency */,
-				B70FA18770A9A68F244699EC138676E7 /* PBXTargetDependency */,
+				1F6DB5100F0E71F1EBC65DC55C73D22C /* PBXTargetDependency */,
+				D859A86481F88F5D4BD32EB54DD182A1 /* PBXTargetDependency */,
 			);
 			name = "Vokoder-43a9e09e";
 			productName = "Vokoder-43a9e09e";
-			productReference = 6F9487FE2E21E990EF6C666989C34D01 /* libVokoder-43a9e09e.a */;
+			productReference = 384263883049C22706A76345B43FDDE4 /* libVokoder-43a9e09e.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
 			};
-			buildConfigurationList = FC02AE59B0DCC1367E03651BD0868F72 /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 5DECD2D2DDBCF1DF25E1166EAF85634C;
-			productRefGroup = F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */;
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = F9829FEF1A805FAFB460D95D567A397F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				3F19AA1185A08DA68DF49A63F2775D46 /* ILGDynamicObjC-iOS10.0 */,
-				4AB6E6A867E0C03192F04753BCC56DB2 /* ILGDynamicObjC-iOS8.0 */,
-				FADC2218D666458DFB6C017FE59277E6 /* ILGDynamicObjC-OSX10.9 */,
-				2A008476970576E0B5C78E2BFDF0C345 /* ILGDynamicObjC-tvOS9.0 */,
-				B055242C128EDCCF53DC7C1592181C09 /* ILGDynamicObjC-watchOS3.0 */,
-				70775B0E02B3EE5B5AA0DEA0293807A6 /* Pods-TodayWidget */,
-				6B0B6527EDA229236DF3F914B7DD8D1E /* Pods-VOKCoreDataManager */,
-				88F8112292AC6530D48CAAAB5ABC5160 /* Pods-VOKCoreDataManager Tests */,
-				07866B96FFB4DAB28C80B31CE4B720BD /* Pods-VOKCoreDataManager-OSX */,
-				F3ED9EB0D8820EDD316FA12CC95EDEAF /* Pods-VOKCoreDataManager-tvOS */,
-				D8381DFBDBD5ECD6EE5233A890A6597E /* Pods-VOKCoreDataManagerTests-OSX */,
-				C96C19937BD2C54B484651D4BF7A52E0 /* Pods-VOKCoreDataManagerTests-tvOS */,
-				B869DEF6943F6AFE83461209440D7E0D /* Pods-WatchApp Extension */,
-				A86E6132E337186EFFC6D495AFCB1C66 /* Vokoder-07029ee6 */,
-				A9C28832CA7ABDF5308A8697E2AD5CC1 /* Vokoder-43a9e09e */,
-				6B0D563CAD5EA3257860C73C8A622E25 /* Vokoder-fdc3d3be */,
-				039B93451C7F51D385086191C304EEF3 /* Vokoder.root-Core-MapperMacros-OSX */,
-				7563863CEAB51B07E9E8D87776F044CC /* Vokoder.root-Core-MapperMacros-watchOS */,
-				772F82B4B45005A2B8D72A61BE1BFC27 /* VOKUtilities-iOS10.0 */,
-				5DBFB1D6ADE4C2238F5889A1EAB945CE /* VOKUtilities-iOS8.0 */,
-				830608453A64AF3F5591F52ED368B223 /* VOKUtilities-OSX10.9 */,
-				82F6302EC5FDB383B400D97DB43ABF03 /* VOKUtilities-tvOS9.0 */,
-				7A0A41400F1B71C96AAB4C1E0230F110 /* VOKUtilities-watchOS3.0 */,
+				A7515B1D5B3879EF823CC72A4F4CBFCC /* ILGDynamicObjC-iOS10.0 */,
+				0C115C45E7548BE6DB46198B1EDEE9C9 /* ILGDynamicObjC-iOS8.0 */,
+				CCCF7217FD9C2EFDF11F0E0BE1388F3B /* ILGDynamicObjC-OSX10.9 */,
+				0A234DB0827360575AE0E68781ED3E5B /* ILGDynamicObjC-tvOS9.0 */,
+				B6C9639C211DF9E8E72302FD37DDA5AE /* ILGDynamicObjC-watchOS3.0 */,
+				059D807EA1E6A20AD48CB3E031062F5C /* Pods-TodayWidget */,
+				114588872928DF3E6652444B21069081 /* Pods-VOKCoreDataManager */,
+				E2DC4753ED177DC36898BCB2072C6D35 /* Pods-VOKCoreDataManager Tests */,
+				8CCA24D7237486997759BAD00AB91517 /* Pods-VOKCoreDataManager-OSX */,
+				5C35D6A96B43A680C08BDC7554701EF7 /* Pods-VOKCoreDataManager-tvOS */,
+				A3B70E31CB300B2BBC3037900BBCB8AB /* Pods-VOKCoreDataManagerTests-OSX */,
+				CCE64B9FBA8C338B1CC0588931DE3548 /* Pods-VOKCoreDataManagerTests-tvOS */,
+				CC2B4D674640F6EB6E202F7C76D9A7F1 /* Pods-WatchApp Extension */,
+				5473A142FC5A8D0C655B183280456A06 /* Vokoder-07029ee6 */,
+				F10CB8AE3F4245CEA38EC599242D3FEC /* Vokoder-43a9e09e */,
+				3F0FAB9F1B7683284CB9673A8D392DD3 /* Vokoder-fdc3d3be */,
+				D1FC04FA1915305A1DE087E1A3FFB6FD /* Vokoder.root-Core-MapperMacros-OSX */,
+				B3CE1BF250548E4A5C0984BF85E3FCA1 /* Vokoder.root-Core-MapperMacros-watchOS */,
+				909EE1A623E69E268090F6690431EDAB /* VOKUtilities-iOS10.0 */,
+				AE27C772C4215696CDDD8372D69BAF5D /* VOKUtilities-iOS8.0 */,
+				47DD822514431098BFCCFDCC6E07F4D2 /* VOKUtilities-OSX10.9 */,
+				2F7F0943C23BC0F4C0133529464D5DC0 /* VOKUtilities-tvOS9.0 */,
+				AA75B5AC10E44233A4C5AB7C8278A16A /* VOKUtilities-watchOS3.0 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		E1FDC1F4AE2769879C39319C10712E42 /* Sources */ = {
+		0148FCF5A448799558740632561736B7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				54D25B7DEDC9EEDD0E0447751BADCD9D /* ILGClasses.m in Sources */,
-				CDF0D559D34D81876583BE5BFE7A0855 /* ILGDynamicObjC-OSX10.9-dummy.m in Sources */,
+				EBAAF0200310330FBB4DEAF06A37B8C4 /* ILGClasses.m in Sources */,
+				75E7A87043A39F634673D9060B7935BC /* ILGDynamicObjC-OSX10.9-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		32A35A52C2F024137F2FF2E7D4669E44 /* Sources */ = {
+		1F131C8C95803C9DE266B07FBBE00658 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3F141B0753647F2470E96894D689ED6 /* VOKKeyPathHelper.m in Sources */,
-				D5EC9CB32DBB33F12D67FFE4A3CAB139 /* VOKUtilities-OSX10.9-dummy.m in Sources */,
+				2884EF1D66ADBA9A5E55A302560743F1 /* VOKKeyPathHelper.m in Sources */,
+				09A2D5475AB84629A5759CB402C103DE /* VOKUtilities-OSX10.9-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6DF1CC918C25B37DF3B50FA65661DDEC /* Sources */ = {
+		27330A217CF48079505FBA4C8D119FF8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8E2A4AC0207764AF17B9A5A1C780C924 /* VOKKeyPathHelper.m in Sources */,
-				015BBE42BFA94926F1821BFC2A834CCB /* VOKUtilities-iOS10.0-dummy.m in Sources */,
+				EA28A2E8787CE8FD59C9BA29E5A9C219 /* VOKKeyPathHelper.m in Sources */,
+				6A612F0D5B91883C22C141D936ED151B /* VOKUtilities-iOS10.0-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AAE2C77E0DC42C0609EB0EF7EB47D049 /* Sources */ = {
+		2AFF0790EDEE93BECE4CA6BFE1A6E439 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				192827E20FC8446D657674ECE07A2278 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */,
+				22FEFFCBA024BDABCB4A81B643D5E9F0 /* Pods-VOKCoreDataManager Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7DC0786761BE760BBBCBB553E998324C /* Sources */ = {
+		2D27EC7A8740C0A088140F24AE0CAD39 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F5082391EE2F2C0236D080F3858FD701 /* VOKKeyPathHelper.m in Sources */,
-				E497F680C4A49AE22A92AE5CBC8645F3 /* VOKUtilities-watchOS3.0-dummy.m in Sources */,
+				F34A95F183925AC036BBA149C842EEB4 /* VOKKeyPathHelper.m in Sources */,
+				FD30CE8DD912972639389E526590DE2A /* VOKUtilities-watchOS3.0-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		055C4FE88A4DE6507A584CB2DA9CBD32 /* Sources */ = {
+		3D08D36AFF8A41D1BB60499FC94B31B3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AC04F0E852D7B83913B858685460647D /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				737E72C5560B397AFE2854856EDE2F00 /* VOKCollectionDataSource.m in Sources */,
-				D0B168BA95EA50F98E6E19D52907AA11 /* VOKCoreDataManager.m in Sources */,
-				AA44657EBC16F5C70D8D07D1462943F1 /* VOKDefaultPagingAccessory.m in Sources */,
-				EC7F3ECA4D305DECC73D835A569716A9 /* VOKFetchedResultsDataSource.m in Sources */,
-				C612D5C5557BEA33C16C7860EAC6D4F1 /* VOKManagedObjectMap.m in Sources */,
-				F45762EBBE9E98DAC699E0C2F5990295 /* VOKManagedObjectMapper.m in Sources */,
-				BFA780DB964CC6548028BC651EBDBAD7 /* VOKPagingFetchedResultsDataSource.m in Sources */,
-				3C27EA94898EEFB47778570C486D5B35 /* Vokoder-43a9e09e-dummy.m in Sources */,
+				41AC1C753734F5ACB72BE76EEC9715BD /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				E0F2EBEDE75F30A435171819397848DB /* VOKCollectionDataSource.m in Sources */,
+				020A36006AD71205E39454FEBD88FC3A /* VOKCoreDataManager.m in Sources */,
+				A46A11C143A02621A86B092896E3E74A /* VOKDefaultPagingAccessory.m in Sources */,
+				826F2C17C0F41916B7B6B607427532A0 /* VOKFetchedResultsDataSource.m in Sources */,
+				7CFB444BAF463DF47127AEA9F38C1B86 /* VOKManagedObjectMap.m in Sources */,
+				78601D6FAAE96FB8B1307D98B8341A40 /* VOKManagedObjectMapper.m in Sources */,
+				941BCA3A7AD57B838F0F1F571D38B030 /* Vokoder-43a9e09e-dummy.m in Sources */,
+				102521CC5059C5AAA27EC264AA2DEBF5 /* VOKPagingFetchedResultsDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		96987D3979F48BBDB1F1B8216CB385BA /* Sources */ = {
+		46B2A5CF99DA87D50CD15156A0A2E59F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B497BC62DCD171CDC0C409B13953DAA6 /* Pods-VOKCoreDataManager-OSX-dummy.m in Sources */,
+				574A172674FB9A472877A19C1D558C72 /* Pods-VOKCoreDataManager-OSX-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		41E647EFD1F47B80FEEF34C346429130 /* Sources */ = {
+		4E975182758659E8FE3EB3A1382E1341 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2AE16A81FDE3E16BA4D57DC7888E73DE /* ILGClasses.m in Sources */,
-				450496251A7BA2B3D37F34CD778C15DD /* ILGDynamicObjC-iOS10.0-dummy.m in Sources */,
+				55F39C4D60B566DC7E925D7859A9D9E7 /* ILGClasses.m in Sources */,
+				5F9574C31868350D970B5FADE3FAE082 /* ILGDynamicObjC-iOS10.0-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		03ED01FC6945479915F9295336E74015 /* Sources */ = {
+		4EFFD3F0D888ECA7FDE767A07491B432 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CBE797E25E2F634657C2CAAAA417E47B /* ILGClasses.m in Sources */,
-				8C3697DC2708F6A9515D10821A9BFD6A /* ILGDynamicObjC-iOS8.0-dummy.m in Sources */,
+				ED44FA9C9CACCD25E9408DB9239815BD /* ILGClasses.m in Sources */,
+				B60FB7F147ACB0DFD00511D9A54270CA /* ILGDynamicObjC-iOS8.0-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C62CC2B1FB4AABC1F8BAACD2F0E374E8 /* Sources */ = {
+		522AAAA72335BEE6937F278AFB10653F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B13D10AF163463F562D484379EF34F55 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				3DAFA123AB6A7D1605F576918F8C34A4 /* VOKCollectionDataSource.m in Sources */,
-				6F7EA85D6C7B663B30B1A68F13CFBC91 /* VOKCoreDataManager.m in Sources */,
-				D75303B44B7B76E232F84677347B76D0 /* VOKDefaultPagingAccessory.m in Sources */,
-				D3AA6E8F956F717D5784C2830AFF84CF /* VOKFetchedResultsDataSource.m in Sources */,
-				1F446BC724AA574735515ABA0A62BD3B /* VOKManagedObjectMap.m in Sources */,
-				8CAEDA327441BF6F947A05F997561523 /* VOKManagedObjectMapper.m in Sources */,
-				C4E230C6A457F5D7E9D9926EA4CFE4AC /* VOKPagingFetchedResultsDataSource.m in Sources */,
-				FECC27CF48BAFBF6963E3758318D97B3 /* Vokoder-fdc3d3be-dummy.m in Sources */,
+				C2F4701759C4A60265C9BD79A45B4D31 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				92FB112C6EBBC197C94736137B1C4D5E /* VOKCollectionDataSource.m in Sources */,
+				092F5C8938E1FED36CE9F9EE0F700B22 /* VOKCoreDataManager.m in Sources */,
+				4D7EC6BDD1B548A7C597667B24173EB7 /* VOKDefaultPagingAccessory.m in Sources */,
+				9AB20636B56FB96E445AD9B9E6B3A1DE /* VOKFetchedResultsDataSource.m in Sources */,
+				DE2CEFD4C08C5809A68FCFBB7F7B8D37 /* VOKManagedObjectMap.m in Sources */,
+				D9D0B4E0CF1D9351F523C52A58EB382A /* VOKManagedObjectMapper.m in Sources */,
+				99BA021E3B693786CD9BE02BF1C83B5C /* Vokoder-fdc3d3be-dummy.m in Sources */,
+				E0059C3E528A2DF55E41F11BBD9FFF27 /* VOKPagingFetchedResultsDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		224D709709DD2D0F6C82A115DF835BF7 /* Sources */ = {
+		528454BB3C558700AE42019E0285F510 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				646185927EEADF2E613EC05CE8427C3C /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				2AFED2B8BD3BE82221630075961A8D76 /* VOKCoreDataManager.m in Sources */,
-				24899E5C7C373E520C5A2A2226B2CEDE /* VOKManagedObjectMap.m in Sources */,
-				63C2DFA4D17315DA6C2F184BBFE01E68 /* VOKManagedObjectMapper.m in Sources */,
-				F4678503D054BDFB079984BC0AC40797 /* Vokoder.root-Core-MapperMacros-OSX-dummy.m in Sources */,
+				4261FB58BBD05574EFE10742F6E9F019 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				CD06AC2CCC6ABC284693A5ACEC2BEAD1 /* VOKCoreDataManager.m in Sources */,
+				E77012EC2873B09EE7575D713C2CD038 /* VOKManagedObjectMap.m in Sources */,
+				F1656458D3208691FDAAF26BCAE49229 /* VOKManagedObjectMapper.m in Sources */,
+				152BE1FFA7D8E4E3E33678B5BEEAABDC /* Vokoder.root-Core-MapperMacros-OSX-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8286E271153EE75BAE0D47A37FE411A9 /* Sources */ = {
+		54BDAC92DF2EA8F9A0AAC687A5641656 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E357871430EED2E5414653E43C632156 /* Pods-VOKCoreDataManager-tvOS-dummy.m in Sources */,
+				A959E6D250E9CA1161673D596D0B07DA /* Pods-VOKCoreDataManager-tvOS-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		72900FD12409AE9717D49D7220407BCB /* Sources */ = {
+		5E94EF09EADF432839FD8AA03D2888B7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1FCBC3AD47AD6DA601E7AD4A30B72C4F /* Pods-VOKCoreDataManagerTests-OSX-dummy.m in Sources */,
+				0D99D3E84C86BA048BA1E87D94682495 /* Pods-VOKCoreDataManagerTests-OSX-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8E46BD82B1FBD12485FEA53B543BA8BE /* Sources */ = {
+		8DB92D20A9ADBD3F3D042E465DCAAAFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CFD75FEDECEF49045B045B57312E9A39 /* Pods-WatchApp Extension-dummy.m in Sources */,
+				6A7A0050CE415CBC9D12B22471E3937D /* Pods-WatchApp Extension-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6911096A8EDF5A1FA8B9653072EEB00E /* Sources */ = {
+		910D6AD3C9E2DF4EAE7906F54B1A9584 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				743A42FB1870BBCDE66EA244C6D2B81A /* VOKKeyPathHelper.m in Sources */,
-				0D633BB1E4976903E38F8E0EC784F61C /* VOKUtilities-tvOS9.0-dummy.m in Sources */,
+				4FFA3BFBCBDEF88E8799354FAFAA0E0F /* VOKKeyPathHelper.m in Sources */,
+				8F9D0B19A50267017931BC62EB6F4416 /* VOKUtilities-tvOS9.0-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		10EF26EE86B178B3A76D7D5377724B90 /* Sources */ = {
+		958F1F91CB464006F9503981769165D8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1E8FE3F1ACB7EFA1F57408FA4C8035A4 /* VOKKeyPathHelper.m in Sources */,
-				ECE9BEE23769E966643C8CFF01F092A6 /* VOKUtilities-iOS8.0-dummy.m in Sources */,
+				38E957667B2456F7B44001810C03D386 /* VOKKeyPathHelper.m in Sources */,
+				4442A6241A5019972E93609DBEB0AFDD /* VOKUtilities-iOS8.0-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9073D35CAC365C03E4CA7E726A49453C /* Sources */ = {
+		9C1A88EC3DFA4E2A6A70896E42B33E6A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AE70C3C7996645F4117D2CEAE4D04C51 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				B391D74BB0D53B921FB76F6BEB0BF9D9 /* VOKCoreDataManager.m in Sources */,
-				93B5712DEEAFDA5F6AAD1601B3B573D6 /* VOKManagedObjectMap.m in Sources */,
-				0D6D534E3C9B6A84580A6D6BFEEE81E2 /* VOKManagedObjectMapper.m in Sources */,
-				214F4C2D6C242E0E441A192C815B3F3B /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m in Sources */,
+				DACBF60E6E29FC7A0F183AAE7F50A643 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				0043FE7AD08748391DC5DFB5C41D37B3 /* VOKCoreDataManager.m in Sources */,
+				84305DB0EC41237DF19AFD4887C381D7 /* VOKManagedObjectMap.m in Sources */,
+				272BF390524C5F027ED7A56AA4E8AECB /* VOKManagedObjectMapper.m in Sources */,
+				3B871640BF0C077EC885436F77B78A4C /* Vokoder.root-Core-MapperMacros-watchOS-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E5FA3C81100A5E4073A0B241D942880F /* Sources */ = {
+		AC7DE41C0D99BC2B2BC181D256FA7E88 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				368E58C6248101C84FE13EBBE8B6014F /* Pods-VOKCoreDataManager-dummy.m in Sources */,
+				706161E9B1E67A30338B9D7031AF22A6 /* Pods-VOKCoreDataManager-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		619C235C889A57656611E08C84331852 /* Sources */ = {
+		AE97FF34978B8129FA3DD0E77E27F12E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C7F5A068F59705FB447E5800A18B060F /* ILGClasses.m in Sources */,
-				02C17E48E81042FF7E0CDC7A0044B8DD /* ILGDynamicObjC-tvOS9.0-dummy.m in Sources */,
+				89E324ADD21F715E143A2EEA6F2A3F32 /* ILGClasses.m in Sources */,
+				AB4B6B3176D4E157FE83F035FA6B78AE /* ILGDynamicObjC-tvOS9.0-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C58E51EB5B24B13C31E0BEEFDC95EBFE /* Sources */ = {
+		C0C3C7256389BD2017D6067A8E00D29F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2695889BADE02B8AC583B63359F06683 /* ILGClasses.m in Sources */,
-				BD4C0158BCDF677CA84DAA2E53A014FB /* ILGDynamicObjC-watchOS3.0-dummy.m in Sources */,
+				2545C926DC79561CFC8F96C3C3375B35 /* ILGClasses.m in Sources */,
+				F4BD871333AE5E366931E1B5A3418E1E /* ILGDynamicObjC-watchOS3.0-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		657DED765400B9A1DC4EF5C3A4960141 /* Sources */ = {
+		D7B3E26B27225792976B77BF8A954BC5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				957A152E45E1CDDB3B74699DD166448A /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m in Sources */,
+				6955CB54A2648577F22F39F2B2B028C4 /* Pods-VOKCoreDataManagerTests-tvOS-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4C33840B8064D0551734502AE68D7D20 /* Sources */ = {
+		F1BD34CA4F0E7BD2741A9F4F8CFE6F7E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3FC971C123FD795E6A6D3C84F84C09FF /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				1D1C379F62C74BF3030BF8A98437E23F /* VOKCollectionDataSource.m in Sources */,
-				328D82E9C9E74292D46425A8900AA83F /* VOKCoreDataManager.m in Sources */,
-				E2906A391168DB65AA73E4991C4B823D /* VOKDefaultPagingAccessory.m in Sources */,
-				3527695D7B12A691EC1AEFC11738A11C /* VOKFetchedResultsDataSource.m in Sources */,
-				3D0F4F8AFA033477C7F49C19EB71A3C1 /* VOKManagedObjectMap.m in Sources */,
-				87CF3DA899E4ED32C2217846DA0940BC /* VOKManagedObjectMapper.m in Sources */,
-				CC8BEC105AB9F9D7E46AC59F3869E9FC /* VOKPagingFetchedResultsDataSource.m in Sources */,
-				C160E43F9E41DBFA0084624063595E9F /* Vokoder-07029ee6-dummy.m in Sources */,
+				D3241F7829CC022BF4C19FB2B9210609 /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				6F1F8F4108B4205BCCA46805D5F51814 /* VOKCollectionDataSource.m in Sources */,
+				2A2B5DD963AAA6A719405BE367E273DF /* VOKCoreDataManager.m in Sources */,
+				22044B2E84C5C08AA2B0EEC6739E2CDF /* VOKDefaultPagingAccessory.m in Sources */,
+				427330AE02FEEF4CC0F4576238A8CEC5 /* VOKFetchedResultsDataSource.m in Sources */,
+				D46C5E611B79ADBD8F0797BD0AFBE378 /* VOKManagedObjectMap.m in Sources */,
+				262656E6C44D5BF8ED537569C0485A8E /* VOKManagedObjectMapper.m in Sources */,
+				CC8363CCBB16D7AEEA804AA0D9B304C0 /* Vokoder-07029ee6-dummy.m in Sources */,
+				4562A8D722C9120C7C11815DED286ED5 /* VOKPagingFetchedResultsDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8322FDAB48382A200C29FAE303AAAB8A /* Sources */ = {
+		F9D572A6302442AF5B4B289809389F07 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A6B2315F61D59B21A1D49241A8D822B7 /* Pods-TodayWidget-dummy.m in Sources */,
+				CEA2E028834C16198D782211E25E146F /* Pods-TodayWidget-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		E84D7B6685FFC812E974DFA515942B4C /* PBXTargetDependency */ = {
+		0BA884BE0A32507159DEC85F918C18E5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Vokoder.root-Core-MapperMacros-OSX";
-			target = 039B93451C7F51D385086191C304EEF3 /* Vokoder.root-Core-MapperMacros-OSX */;
-			targetProxy = 68F9855C89B0441B6E4554B54CA780BC /* PBXContainerItemProxy */;
+			target = D1FC04FA1915305A1DE087E1A3FFB6FD /* Vokoder.root-Core-MapperMacros-OSX */;
+			targetProxy = 36D206E8ED7FB0B47AC46EB00D367606 /* PBXContainerItemProxy */;
 		};
-		D6EBF3C1D3DEF21A8DE6AA4B8E8F3F42 /* PBXTargetDependency */ = {
+		0CA37D72163E01637959C7CB8D85B557 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-OSX10.9";
-			target = 830608453A64AF3F5591F52ED368B223 /* VOKUtilities-OSX10.9 */;
-			targetProxy = 37E21C9F9A8789BA6DD166589EC96AD2 /* PBXContainerItemProxy */;
+			target = 47DD822514431098BFCCFDCC6E07F4D2 /* VOKUtilities-OSX10.9 */;
+			targetProxy = A9302D9DE9ECF4D095C78BF77F81CFAB /* PBXContainerItemProxy */;
 		};
-		F536239C0B77D4E3F72243D70A73B071 /* PBXTargetDependency */ = {
+		12D78BCC1B38F936A172E953B3C3955F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-iOS10.0";
-			target = 3F19AA1185A08DA68DF49A63F2775D46 /* ILGDynamicObjC-iOS10.0 */;
-			targetProxy = D0C8D0C2D31DF142CF872599D66C5378 /* PBXContainerItemProxy */;
+			target = A7515B1D5B3879EF823CC72A4F4CBFCC /* ILGDynamicObjC-iOS10.0 */;
+			targetProxy = F344A23A067040597C2DE05491ACA3FA /* PBXContainerItemProxy */;
 		};
-		AAD857A7E8B58F6981D561B32D380FB9 /* PBXTargetDependency */ = {
+		18C459D616C6EB1E39B1676D973811B8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Vokoder.root-Core-MapperMacros-watchOS";
-			target = 7563863CEAB51B07E9E8D87776F044CC /* Vokoder.root-Core-MapperMacros-watchOS */;
-			targetProxy = C1EE3FDB414D73D3ED9AF4F38AF6314D /* PBXContainerItemProxy */;
+			target = B3CE1BF250548E4A5C0984BF85E3FCA1 /* Vokoder.root-Core-MapperMacros-watchOS */;
+			targetProxy = B42A991951D63240AF35D174769CC975 /* PBXContainerItemProxy */;
 		};
-		05B3651388146A677D6E05BE9B87DB52 /* PBXTargetDependency */ = {
+		1F6DB5100F0E71F1EBC65DC55C73D22C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-tvOS9.0";
-			target = 2A008476970576E0B5C78E2BFDF0C345 /* ILGDynamicObjC-tvOS9.0 */;
-			targetProxy = 4280A94A0AB72B030F5A87164A31490E /* PBXContainerItemProxy */;
+			target = 0A234DB0827360575AE0E68781ED3E5B /* ILGDynamicObjC-tvOS9.0 */;
+			targetProxy = D6ECBC6D09EDEA7AE683DFE5DEAF0427 /* PBXContainerItemProxy */;
 		};
-		8EF37CEC4A035A06BAEF33609727C7FB /* PBXTargetDependency */ = {
+		2099DA11F47CACB77B5A9B7347F3CF9D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Vokoder-fdc3d3be";
-			target = 6B0D563CAD5EA3257860C73C8A622E25 /* Vokoder-fdc3d3be */;
-			targetProxy = CA7A14CB0EA7172870B7CF17CDAC7107 /* PBXContainerItemProxy */;
+			target = 3F0FAB9F1B7683284CB9673A8D392DD3 /* Vokoder-fdc3d3be */;
+			targetProxy = 0AC54013DD2B84DE184E637FCFCEA853 /* PBXContainerItemProxy */;
 		};
-		B226444A4B91E34B753D5DCAF5C737B7 /* PBXTargetDependency */ = {
+		3806B07B09464C8493458D3424CCC864 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-iOS8.0";
-			target = 4AB6E6A867E0C03192F04753BCC56DB2 /* ILGDynamicObjC-iOS8.0 */;
-			targetProxy = EC18ECEC0DABE2B60EC4B7BB2914EF53 /* PBXContainerItemProxy */;
+			target = 0C115C45E7548BE6DB46198B1EDEE9C9 /* ILGDynamicObjC-iOS8.0 */;
+			targetProxy = 52228221B375F0D36830B83D3ECCE64D /* PBXContainerItemProxy */;
 		};
-		5E07A905460CCF44BB9FE7797A530367 /* PBXTargetDependency */ = {
+		6499AE559EDB827C05DE414181A05F0F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-watchOS3.0";
-			target = B055242C128EDCCF53DC7C1592181C09 /* ILGDynamicObjC-watchOS3.0 */;
-			targetProxy = F88DBB7E48C753114167CD8136C8210E /* PBXContainerItemProxy */;
+			target = B6C9639C211DF9E8E72302FD37DDA5AE /* ILGDynamicObjC-watchOS3.0 */;
+			targetProxy = 2E5A7CFE5FB73DB052C3C19102D3C3D9 /* PBXContainerItemProxy */;
 		};
-		160D1E81D3312961561F80BE87F582E9 /* PBXTargetDependency */ = {
+		667FC90C0B8D28798431791B60A9DD27 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-iOS8.0";
-			target = 5DBFB1D6ADE4C2238F5889A1EAB945CE /* VOKUtilities-iOS8.0 */;
-			targetProxy = FB9A841F3621D647A57FED3DDF78738C /* PBXContainerItemProxy */;
+			target = AE27C772C4215696CDDD8372D69BAF5D /* VOKUtilities-iOS8.0 */;
+			targetProxy = 60C2DC3F11F14BDABA5F7C7AD5872DB5 /* PBXContainerItemProxy */;
 		};
-		87C960534278204A820BF1D64B1C143A /* PBXTargetDependency */ = {
+		6A98BDB1EC96E349640CB59C1D23A704 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Vokoder-07029ee6";
-			target = A86E6132E337186EFFC6D495AFCB1C66 /* Vokoder-07029ee6 */;
-			targetProxy = 9B85C8CFA7D8FEAD0915D1AD43B4DB9B /* PBXContainerItemProxy */;
+			target = 5473A142FC5A8D0C655B183280456A06 /* Vokoder-07029ee6 */;
+			targetProxy = A1C099A2D46F6ACC827FF618237A4700 /* PBXContainerItemProxy */;
 		};
-		336DBF21D38759B57E9CCA44CE693623 /* PBXTargetDependency */ = {
+		7C52148B0019A2F69689A508627A3A44 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-OSX10.9";
-			target = FADC2218D666458DFB6C017FE59277E6 /* ILGDynamicObjC-OSX10.9 */;
-			targetProxy = 1CCC5674CE8ECC9BD450174839953315 /* PBXContainerItemProxy */;
+			target = CCCF7217FD9C2EFDF11F0E0BE1388F3B /* ILGDynamicObjC-OSX10.9 */;
+			targetProxy = 463D8C0EAB2ADC84930A415CADED1989 /* PBXContainerItemProxy */;
 		};
-		3432A5D7CB49B47F275F3322C4C48829 /* PBXTargetDependency */ = {
+		816D889138F67580C9609A83CC8F3121 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-tvOS9.0";
-			target = 82F6302EC5FDB383B400D97DB43ABF03 /* VOKUtilities-tvOS9.0 */;
-			targetProxy = F295BB55395E1CED4D2E32BC67F8C5E4 /* PBXContainerItemProxy */;
+			target = 2F7F0943C23BC0F4C0133529464D5DC0 /* VOKUtilities-tvOS9.0 */;
+			targetProxy = 2A16A673925C08E46DFBC2EE79ADEA22 /* PBXContainerItemProxy */;
 		};
-		62236EB4DF161C97C7098B6C44957787 /* PBXTargetDependency */ = {
+		87CAE518200C7EFEC13581E220724E53 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-OSX10.9";
-			target = FADC2218D666458DFB6C017FE59277E6 /* ILGDynamicObjC-OSX10.9 */;
-			targetProxy = 96E04CCEBBCB7451A07E00FC0E4E2531 /* PBXContainerItemProxy */;
+			target = CCCF7217FD9C2EFDF11F0E0BE1388F3B /* ILGDynamicObjC-OSX10.9 */;
+			targetProxy = EC9C56D3F361077CA6F23E143C7D91F4 /* PBXContainerItemProxy */;
 		};
-		D79E5F2BBAA5712AECBE737244B81FEF /* PBXTargetDependency */ = {
+		88A2D68791E39D84C41CEB68A21C19BF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-iOS8.0";
-			target = 5DBFB1D6ADE4C2238F5889A1EAB945CE /* VOKUtilities-iOS8.0 */;
-			targetProxy = D565656D99625BB98E55330592E592EC /* PBXContainerItemProxy */;
+			target = AE27C772C4215696CDDD8372D69BAF5D /* VOKUtilities-iOS8.0 */;
+			targetProxy = 869694DF9604E7A29B649FF00B4769AA /* PBXContainerItemProxy */;
 		};
-		6CA38A320AB6698F53F148206A2C7FD0 /* PBXTargetDependency */ = {
+		99388BA1375D9C192C7590CFFE6C1738 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-watchOS3.0";
-			target = B055242C128EDCCF53DC7C1592181C09 /* ILGDynamicObjC-watchOS3.0 */;
-			targetProxy = 220D9F07E32430ECFDC5C18CCEEE67F5 /* PBXContainerItemProxy */;
+			target = B6C9639C211DF9E8E72302FD37DDA5AE /* ILGDynamicObjC-watchOS3.0 */;
+			targetProxy = 39A38F2D05256C3D277AFF36D58D5133 /* PBXContainerItemProxy */;
 		};
-		1FFF8DB338A0C07A5EFAE251C8614F4F /* PBXTargetDependency */ = {
+		9C00BA0DCEB10DCAE9D5DAA8F7B1E25A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-tvOS9.0";
-			target = 2A008476970576E0B5C78E2BFDF0C345 /* ILGDynamicObjC-tvOS9.0 */;
-			targetProxy = 767E7C0E7A983EC52082AEB0F039AC48 /* PBXContainerItemProxy */;
+			target = 0A234DB0827360575AE0E68781ED3E5B /* ILGDynamicObjC-tvOS9.0 */;
+			targetProxy = BCD6EAD5FF1796DB15A2BE70048ADBAE /* PBXContainerItemProxy */;
 		};
-		5EF8EDB2E3374D2C66E2F9B9B4DD8D6A /* PBXTargetDependency */ = {
+		AB1F1D77295F06C92303D1B058DEE830 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-iOS8.0";
-			target = 5DBFB1D6ADE4C2238F5889A1EAB945CE /* VOKUtilities-iOS8.0 */;
-			targetProxy = 6CA6DB0D716AC53C1F8D1D4DFB84D830 /* PBXContainerItemProxy */;
+			target = AE27C772C4215696CDDD8372D69BAF5D /* VOKUtilities-iOS8.0 */;
+			targetProxy = B6EBC1CAB71A2440DEF53AA47ECEACE6 /* PBXContainerItemProxy */;
 		};
-		5FEC91C67E67FBE7F2E2A86AE31D5131 /* PBXTargetDependency */ = {
+		B89F0DC42F703001FCC402F411AB7B2C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-iOS10.0";
-			target = 772F82B4B45005A2B8D72A61BE1BFC27 /* VOKUtilities-iOS10.0 */;
-			targetProxy = 04B38CC960DCAD33857CDDA3070B2825 /* PBXContainerItemProxy */;
+			target = 909EE1A623E69E268090F6690431EDAB /* VOKUtilities-iOS10.0 */;
+			targetProxy = 198DB9635A23B1788685C39696798A8E /* PBXContainerItemProxy */;
 		};
-		839B81892320319DF1F8241434DE8D0A /* PBXTargetDependency */ = {
+		BDF0A6981BBF1F72B94F12095A622215 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-watchOS3.0";
-			target = 7A0A41400F1B71C96AAB4C1E0230F110 /* VOKUtilities-watchOS3.0 */;
-			targetProxy = B1390FF671658A221CA6DB949BADEA97 /* PBXContainerItemProxy */;
+			target = AA75B5AC10E44233A4C5AB7C8278A16A /* VOKUtilities-watchOS3.0 */;
+			targetProxy = EBAF0571A93386A0C67397551630AE40 /* PBXContainerItemProxy */;
 		};
-		67271FBD998D9AA97E79D3D116F94B9E /* PBXTargetDependency */ = {
+		C57F5C91516C60CBBB11015590B4E30E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-watchOS3.0";
-			target = 7A0A41400F1B71C96AAB4C1E0230F110 /* VOKUtilities-watchOS3.0 */;
-			targetProxy = 5CA71C13B1F090E4E9EEDAF5609A481F /* PBXContainerItemProxy */;
+			target = AA75B5AC10E44233A4C5AB7C8278A16A /* VOKUtilities-watchOS3.0 */;
+			targetProxy = 58FF2F566A56A1F12AD3FA85A2940D3E /* PBXContainerItemProxy */;
 		};
-		B70FA18770A9A68F244699EC138676E7 /* PBXTargetDependency */ = {
+		D859A86481F88F5D4BD32EB54DD182A1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-tvOS9.0";
-			target = 82F6302EC5FDB383B400D97DB43ABF03 /* VOKUtilities-tvOS9.0 */;
-			targetProxy = 27F177D70259459837D40F47B9420649 /* PBXContainerItemProxy */;
+			target = 2F7F0943C23BC0F4C0133529464D5DC0 /* VOKUtilities-tvOS9.0 */;
+			targetProxy = 6FA28D4AB7A3B56EF843DB16CD1CC5CB /* PBXContainerItemProxy */;
 		};
-		D60EC64EA28FCD7778F70BB308DE3B16 /* PBXTargetDependency */ = {
+		DD642C64B14AEC14E2DDC7CDCBEC5EEC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-iOS8.0";
-			target = 4AB6E6A867E0C03192F04753BCC56DB2 /* ILGDynamicObjC-iOS8.0 */;
-			targetProxy = 345F54ACDE52ECA0ED54E06941D1A28B /* PBXContainerItemProxy */;
+			target = 0C115C45E7548BE6DB46198B1EDEE9C9 /* ILGDynamicObjC-iOS8.0 */;
+			targetProxy = 258B0B073CF4EDBC553F862173BE5939 /* PBXContainerItemProxy */;
 		};
-		E61F53953EC3087C64E9AC6E22CA4A81 /* PBXTargetDependency */ = {
+		EB37999961960DCCA583BB98BF70EFA9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "ILGDynamicObjC-iOS8.0";
-			target = 4AB6E6A867E0C03192F04753BCC56DB2 /* ILGDynamicObjC-iOS8.0 */;
-			targetProxy = E59E23FA60162D2A74806B081F33BD3D /* PBXContainerItemProxy */;
+			target = 0C115C45E7548BE6DB46198B1EDEE9C9 /* ILGDynamicObjC-iOS8.0 */;
+			targetProxy = C161B722D5DA89A04DFD608855DFC010 /* PBXContainerItemProxy */;
 		};
-		DE8F1EBFD2BF2A62D1E7AF72318B1D44 /* PBXTargetDependency */ = {
+		F3913978D5EDCFDC2B3FCE0866CB5D56 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-OSX10.9";
-			target = 830608453A64AF3F5591F52ED368B223 /* VOKUtilities-OSX10.9 */;
-			targetProxy = A30B0A48B06411D6C1CAFF1A6B28CB90 /* PBXContainerItemProxy */;
+			target = 47DD822514431098BFCCFDCC6E07F4D2 /* VOKUtilities-OSX10.9 */;
+			targetProxy = FBACF01101E92DD9294FD26933EFD4BD /* PBXContainerItemProxy */;
 		};
-		5297DB25EDC0BA70F9BC331D8AFFE33A /* PBXTargetDependency */ = {
+		FE59EF51D4F241D1C6CD6D52D4E9A7CE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Vokoder-43a9e09e";
-			target = A9C28832CA7ABDF5308A8697E2AD5CC1 /* Vokoder-43a9e09e */;
-			targetProxy = AED3134F3F7D764F3B0A212FF6A68488 /* PBXContainerItemProxy */;
+			target = F10CB8AE3F4245CEA38EC599242D3FEC /* Vokoder-43a9e09e */;
+			targetProxy = 51250E911A6914DEB2A3836BD5C2FF2C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		DBDA34FD52CF2FD09E992A2B1AE643F1 /* Release */ = {
+		083BB3AD2027048C8ECADE6DBD9284FD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2579DB4632D3A27C34327639D85722C9 /* ILGDynamicObjC-iOS10.0.xcconfig */;
+			baseConfigurationReference = D18623CBBFD7CD618675FBAC976D3742 /* ILGDynamicObjC-iOS10.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2322,9 +2322,9 @@
 			};
 			name = Release;
 		};
-		013CC9C77AFB358B607ACE6CEAEAD908 /* Release */ = {
+		15CC2166A449846B906870B55ABB8FC3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 083F6D58998BAB74E2A87D18C2293925 /* Pods-VOKCoreDataManagerTests-tvOS.release.xcconfig */;
+			baseConfigurationReference = 23CF117C75623C0A52AF3966769DEAED /* Pods-VOKCoreDataManagerTests-tvOS.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2345,9 +2345,9 @@
 			};
 			name = Release;
 		};
-		18E3763D02456D826FA903F6A0CC3A34 /* Release */ = {
+		16FA9AB9474623C573B0D91B33272B5C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 10CC226F117CBBB79BF03824AC645A56 /* Vokoder.root-Core-MapperMacros-watchOS.xcconfig */;
+			baseConfigurationReference = B90F4F8E35E9494213EE548E18CF4C60 /* Vokoder.root-Core-MapperMacros-watchOS.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2369,9 +2369,9 @@
 			};
 			name = Release;
 		};
-		295DB9A24AA0BE984BB1342FD1A76096 /* Debug */ = {
+		1EE54482F5FAA03EF66F550A67CCEC31 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3EC12C7CE4C91B4DDCDED5DE9018057A /* VOKUtilities-OSX10.9.xcconfig */;
+			baseConfigurationReference = 339398E133813BCE26F4E531B62ED799 /* VOKUtilities-OSX10.9.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2393,9 +2393,9 @@
 			};
 			name = Debug;
 		};
-		75D1A7A39E9F938C16476EC758E77775 /* Release */ = {
+		2B9DAECCDEE612EFFD2D559D9B1EC735 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6746A42342EC06B188B85B914FDC4796 /* ILGDynamicObjC-watchOS3.0.xcconfig */;
+			baseConfigurationReference = 0822D55044354A39166D9FB00608562A /* ILGDynamicObjC-watchOS3.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2417,9 +2417,9 @@
 			};
 			name = Release;
 		};
-		9C20C986E8D87BF73D274C05A1ECEC3A /* Release */ = {
+		3044312644AFC30AEB23FC99E0E5898A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A35665478787B839BD2D1E47D2B76BDD /* VOKUtilities-watchOS3.0.xcconfig */;
+			baseConfigurationReference = C2319594E52947BD6FFA07571BAAF4F7 /* VOKUtilities-watchOS3.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2441,9 +2441,9 @@
 			};
 			name = Release;
 		};
-		CC98C61AC83AF4607760969F4D476ED9 /* Debug */ = {
+		354D1CAA716705B55559FE598DDF5CAC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBD594A897BF2B25B03804CA7DF9BD39 /* Vokoder.root-Core-MapperMacros-OSX.xcconfig */;
+			baseConfigurationReference = CB47F8B49375B3DB7D3EB7AA68DA9386 /* Vokoder.root-Core-MapperMacros-OSX.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2465,9 +2465,9 @@
 			};
 			name = Debug;
 		};
-		7106BC7AD9A042C55E4910DAFBADE772 /* Release */ = {
+		38A770F485241813B2CCABA51C786244 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E22AD87D6173DD697749070C13776D0 /* Vokoder-07029ee6.xcconfig */;
+			baseConfigurationReference = 709585C36368811AC1D9697E5DBB5EF5 /* Vokoder-07029ee6.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2489,9 +2489,9 @@
 			};
 			name = Release;
 		};
-		60C3FC59A3699A68C41F439AD767B067 /* Debug */ = {
+		3CEFC48610B4C545F7CFFD9F1B07198E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E63444472FADBEC7159920FEBA28A00 /* ILGDynamicObjC-OSX10.9.xcconfig */;
+			baseConfigurationReference = 123BB9266A782F96C3F82E512E8891DB /* ILGDynamicObjC-OSX10.9.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2513,7 +2513,7 @@
 			};
 			name = Debug;
 		};
-		78F0498F2AF1B86F8B7B7477CD49552F /* Debug */ = {
+		3F1EA6497DBDDAAE006DECDB0C206D34 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2560,9 +2560,9 @@
 			};
 			name = Debug;
 		};
-		1964CC0D5B9CB3C500A2F7F039CE2346 /* Release */ = {
+		42D41D9DCB11032855A8A0D32C687AE1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CEE5E57B0BBE5728330045505D55E11C /* Pods-VOKCoreDataManager-OSX.release.xcconfig */;
+			baseConfigurationReference = 5A40B3D080F77790B09C44712042846D /* Pods-VOKCoreDataManager-OSX.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2585,9 +2585,9 @@
 			};
 			name = Release;
 		};
-		46704E5F9E0A1D129AB23B4BF0B56DA8 /* Debug */ = {
+		433CF913DCBF54C8A319FE8FE37DBD41 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3A5F0559A548C85246C23DC7B387C289 /* Pods-VOKCoreDataManagerTests-tvOS.debug.xcconfig */;
+			baseConfigurationReference = 9AF7275329537EADCF12B27F2EECBD8A /* Pods-VOKCoreDataManagerTests-tvOS.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2608,9 +2608,9 @@
 			};
 			name = Debug;
 		};
-		E5C6F88E3F2C29E7C1E04646D44D3ADA /* Release */ = {
+		4FC91CA2A56B12F3CE24B3DAF5DE9464 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C094F1C98A2C41ACD73C6F158B47023F /* Pods-WatchApp Extension.release.xcconfig */;
+			baseConfigurationReference = 985003308B1C6CFEF05E5F64F040FC89 /* Pods-WatchApp Extension.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2632,9 +2632,9 @@
 			};
 			name = Release;
 		};
-		E3F05354D2D577E86537ACCB2C3FDD89 /* Release */ = {
+		509930E3353A21567B6CB503F4A4EE34 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FBDE53507268195ABEBE26048C784F33 /* Pods-VOKCoreDataManager Tests.release.xcconfig */;
+			baseConfigurationReference = C4453F87DEB288348F49730EEA8D995E /* Pods-VOKCoreDataManager Tests.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2655,9 +2655,9 @@
 			};
 			name = Release;
 		};
-		F8D58224C2705AA2EE922E046686335F /* Release */ = {
+		579A5F9EA294F429DAEA054D02B7907D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E63444472FADBEC7159920FEBA28A00 /* ILGDynamicObjC-OSX10.9.xcconfig */;
+			baseConfigurationReference = 123BB9266A782F96C3F82E512E8891DB /* ILGDynamicObjC-OSX10.9.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2679,9 +2679,9 @@
 			};
 			name = Release;
 		};
-		12783DE9FAB2DF0980AE3FD39873FEED /* Release */ = {
+		5F6D88BC6D098561B55FAD7226E4645B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 121EEAB77CB65EEBC6F733CA71FC7FAB /* Pods-TodayWidget.release.xcconfig */;
+			baseConfigurationReference = 8DB738C95F2DE503CC441547763906D9 /* Pods-TodayWidget.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2703,9 +2703,9 @@
 			};
 			name = Release;
 		};
-		E9D2E1EB5BDB802F719F2A2AC2826A0C /* Debug */ = {
+		6283A32A2125315370BE4AA2EC4FA5E5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 816CFB2F4CCA32B132D3140C7EB26A61 /* Pods-VOKCoreDataManager-tvOS.debug.xcconfig */;
+			baseConfigurationReference = 4432D8541F20799C23DEE42D5CCEDBFF /* Pods-VOKCoreDataManager-tvOS.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2726,9 +2726,9 @@
 			};
 			name = Debug;
 		};
-		D5E5DE921EE3F0D6E5730BEAFE9323FA /* Debug */ = {
+		672EB2B1C7EDE7A3F2A5FCC4531E1C9B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6746A42342EC06B188B85B914FDC4796 /* ILGDynamicObjC-watchOS3.0.xcconfig */;
+			baseConfigurationReference = 0822D55044354A39166D9FB00608562A /* ILGDynamicObjC-watchOS3.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2750,9 +2750,9 @@
 			};
 			name = Debug;
 		};
-		2FAEE4B53B40BDD705157885AE684940 /* Debug */ = {
+		67C9DC28515664D75BD79F8308377E92 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 928F6652087C28B56E197BF3DE359403 /* Pods-TodayWidget.debug.xcconfig */;
+			baseConfigurationReference = 64142C568D6CFA890CEDDA2E2DA3FCEF /* Pods-TodayWidget.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2774,9 +2774,9 @@
 			};
 			name = Debug;
 		};
-		743D049605599ED828E30CA4D29294C5 /* Debug */ = {
+		6BFE66DDBB9847FD83826855E61E28ED /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 10CC226F117CBBB79BF03824AC645A56 /* Vokoder.root-Core-MapperMacros-watchOS.xcconfig */;
+			baseConfigurationReference = B90F4F8E35E9494213EE548E18CF4C60 /* Vokoder.root-Core-MapperMacros-watchOS.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2798,9 +2798,9 @@
 			};
 			name = Debug;
 		};
-		456051E3342428DD6EE831EEC3AF3E3D /* Release */ = {
+		6F47C80433F1343B332B07D025244CD8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9700B3DB8E75CDDF195B88F098F05B98 /* VOKUtilities-tvOS9.0.xcconfig */;
+			baseConfigurationReference = 62DA861B7AADDD554BA6787E4FC5CC3F /* VOKUtilities-tvOS9.0.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2821,9 +2821,9 @@
 			};
 			name = Release;
 		};
-		9838C2F84F1C0283EF3158D6E9E00F41 /* Release */ = {
+		73C315F6B0DB1C085DF47E9C06A141A1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CDB20D673EC26CEAA279E49DCA096F01 /* ILGDynamicObjC-iOS8.0.xcconfig */;
+			baseConfigurationReference = 6DF3D76A0E74B3FE12499AF2CDBB3B46 /* ILGDynamicObjC-iOS8.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2845,9 +2845,9 @@
 			};
 			name = Release;
 		};
-		AF96BCF9E3CF40A910887EDC31FB3BA8 /* Release */ = {
+		74BAE436E6252B275BD24B2629AE19B5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C7FDB6DA1D9C8344F63ADE0BA56C55AC /* Vokoder-43a9e09e.xcconfig */;
+			baseConfigurationReference = B4D70FC55279FF036ED49145ABFDB1EC /* Vokoder-43a9e09e.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2868,9 +2868,9 @@
 			};
 			name = Release;
 		};
-		1631775464C1CF0B6550CBC239E689B5 /* Debug */ = {
+		7589CA21005E9672640201BF8CC3082E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 695A55226F1671D0C255C45400CC6E5E /* Pods-VOKCoreDataManager-OSX.debug.xcconfig */;
+			baseConfigurationReference = 879EAB0203F40FAFEB5CFE9C736732B8 /* Pods-VOKCoreDataManager-OSX.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2893,9 +2893,9 @@
 			};
 			name = Debug;
 		};
-		04EE05BDD7025B01838497E75D4828DE /* Release */ = {
+		79847D3CF4A701A83BBDA9695DC879C0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3EC12C7CE4C91B4DDCDED5DE9018057A /* VOKUtilities-OSX10.9.xcconfig */;
+			baseConfigurationReference = 339398E133813BCE26F4E531B62ED799 /* VOKUtilities-OSX10.9.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2917,9 +2917,9 @@
 			};
 			name = Release;
 		};
-		B7F48B104F8464735BEBCA776BFB2444 /* Debug */ = {
+		7BF55DD19320B017AC924E6B5D3DADA3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 701A7F006E59848A3FA96619714A2223 /* Pods-WatchApp Extension.debug.xcconfig */;
+			baseConfigurationReference = 12178C220C625240393129263706C656 /* Pods-WatchApp Extension.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2941,9 +2941,9 @@
 			};
 			name = Debug;
 		};
-		B55A6EA547712101AE9ED370A0F96ACC /* Release */ = {
+		7E694ECBDE35C4AC4103C665BDE29113 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 042F42430627771693D1FDFB00E94309 /* VOKUtilities-iOS8.0.xcconfig */;
+			baseConfigurationReference = 201D9EB35DF7F2E4F51395D95D807000 /* VOKUtilities-iOS8.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2965,9 +2965,9 @@
 			};
 			name = Release;
 		};
-		E6B7B0700ACEBCC134A001E32FF71D2E /* Release */ = {
+		95AC4ACC470596989C19E4B20C699541 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E6F54BB5AB37176AAA83A49176FA0059 /* VOKUtilities-iOS10.0.xcconfig */;
+			baseConfigurationReference = 12C49CD1056AAD495FDA5BF1EA384CE9 /* VOKUtilities-iOS10.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2989,9 +2989,9 @@
 			};
 			name = Release;
 		};
-		8765BB89E0AA6AF36DA62C0DBFA92CCF /* Release */ = {
+		97C25DA9E783BC1A0E86477795A389AB /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0F8E0E10BEABF0C6573568FE8E546BA0 /* Pods-VOKCoreDataManager-tvOS.release.xcconfig */;
+			baseConfigurationReference = 8C30D8E728A343D3553ECAD52DD15F5B /* Pods-VOKCoreDataManager-tvOS.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3012,9 +3012,9 @@
 			};
 			name = Release;
 		};
-		898EB74D252753FCC8AE6C0A8C2D6625 /* Debug */ = {
+		9822F7A621148618BAAD5FA97C7CB703 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A2487DEB43122640319AB8CEE6B754F0 /* Pods-VOKCoreDataManagerTests-OSX.debug.xcconfig */;
+			baseConfigurationReference = 8877FAEF7810195BFDC5E166FD00BC5C /* Pods-VOKCoreDataManagerTests-OSX.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3037,9 +3037,9 @@
 			};
 			name = Debug;
 		};
-		C37DE804B0A7D4B61AA90B17E4B868C5 /* Debug */ = {
+		9A8BA8F51490012854BCA3ECB13F5044 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F5BC8660565E6934A19C07FB2098C015 /* ILGDynamicObjC-tvOS9.0.xcconfig */;
+			baseConfigurationReference = 7639258F331D52B880154D63E782D7A6 /* ILGDynamicObjC-tvOS9.0.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3060,9 +3060,9 @@
 			};
 			name = Debug;
 		};
-		0C5834B63C2CAB2CF7BB533911BC27D3 /* Release */ = {
+		9B3B3B827620711657C57AE8EF8B4745 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9C82F70917641C70EE55D41167D7E59E /* Vokoder-fdc3d3be.xcconfig */;
+			baseConfigurationReference = E7568C58ACCAA3EDD1E4713AF3B81B0C /* Vokoder-fdc3d3be.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3083,9 +3083,9 @@
 			};
 			name = Release;
 		};
-		B36A21F6701F9D5845A29EE65C1D1171 /* Debug */ = {
+		9D502C0BAB1E17CB1A218E58E63382CC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2E9BF54A9471DCEB8BF1280D47F24771 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */;
+			baseConfigurationReference = 7352ED4444C19481CC17378C2FE27A19 /* Pods-VOKCoreDataManager Tests.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3106,9 +3106,9 @@
 			};
 			name = Debug;
 		};
-		17BDDF0C1421909F0350D53EDDB435CA /* Release */ = {
+		A30A0E93BD9DFEC5451B401085139AE4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F81B0DE028348E52206FD42D4DC16375 /* Pods-VOKCoreDataManagerTests-OSX.release.xcconfig */;
+			baseConfigurationReference = 242689EB3526057D02B5839C6FE129F2 /* Pods-VOKCoreDataManagerTests-OSX.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3131,9 +3131,9 @@
 			};
 			name = Release;
 		};
-		A3B22FB0177E91C701660AB8A1BD04D6 /* Debug */ = {
+		A527C379D40B9DBF1DE2363599292046 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E6F54BB5AB37176AAA83A49176FA0059 /* VOKUtilities-iOS10.0.xcconfig */;
+			baseConfigurationReference = 12C49CD1056AAD495FDA5BF1EA384CE9 /* VOKUtilities-iOS10.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3155,9 +3155,9 @@
 			};
 			name = Debug;
 		};
-		AC59F201F05DACB2DE78FBFB603B1EF0 /* Debug */ = {
+		B3E52FF164902B114D0AEB3EFE3EFA2A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CDB20D673EC26CEAA279E49DCA096F01 /* ILGDynamicObjC-iOS8.0.xcconfig */;
+			baseConfigurationReference = 6DF3D76A0E74B3FE12499AF2CDBB3B46 /* ILGDynamicObjC-iOS8.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3179,9 +3179,9 @@
 			};
 			name = Debug;
 		};
-		47F5AD7CE45EE9CFE89E270A604291EA /* Debug */ = {
+		CCE8119D0F5DB3F718FDEEABBB20979E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C7FDB6DA1D9C8344F63ADE0BA56C55AC /* Vokoder-43a9e09e.xcconfig */;
+			baseConfigurationReference = B4D70FC55279FF036ED49145ABFDB1EC /* Vokoder-43a9e09e.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3202,9 +3202,9 @@
 			};
 			name = Debug;
 		};
-		296706A2AE5EC7A2C7F3CDC145B20F35 /* Debug */ = {
+		CF64948A3AA81FF14B68024CA404305A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 042F42430627771693D1FDFB00E94309 /* VOKUtilities-iOS8.0.xcconfig */;
+			baseConfigurationReference = 201D9EB35DF7F2E4F51395D95D807000 /* VOKUtilities-iOS8.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3226,9 +3226,9 @@
 			};
 			name = Debug;
 		};
-		728B1CD66899D2BCC256AD26D28A4014 /* Debug */ = {
+		D58618134F47755178043F7B85501902 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9C82F70917641C70EE55D41167D7E59E /* Vokoder-fdc3d3be.xcconfig */;
+			baseConfigurationReference = E7568C58ACCAA3EDD1E4713AF3B81B0C /* Vokoder-fdc3d3be.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3249,9 +3249,9 @@
 			};
 			name = Debug;
 		};
-		D3C612E967EB15DF7BA75473A5DB09B1 /* Debug */ = {
+		D5B12452D9CA509979F0A0CF112B262E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A35665478787B839BD2D1E47D2B76BDD /* VOKUtilities-watchOS3.0.xcconfig */;
+			baseConfigurationReference = C2319594E52947BD6FFA07571BAAF4F7 /* VOKUtilities-watchOS3.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3273,9 +3273,9 @@
 			};
 			name = Debug;
 		};
-		123A08AC08285B6D01CBB8BE4F964C90 /* Debug */ = {
+		DF45F889A2D47793136E09A8E5B32F52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2579DB4632D3A27C34327639D85722C9 /* ILGDynamicObjC-iOS10.0.xcconfig */;
+			baseConfigurationReference = D18623CBBFD7CD618675FBAC976D3742 /* ILGDynamicObjC-iOS10.0.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3297,9 +3297,9 @@
 			};
 			name = Debug;
 		};
-		94DA53DEF4C8F52137B3A333A0C7AEBB /* Debug */ = {
+		E5C9761BDCD16ABDBB3AB515153C7C4A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9700B3DB8E75CDDF195B88F098F05B98 /* VOKUtilities-tvOS9.0.xcconfig */;
+			baseConfigurationReference = 62DA861B7AADDD554BA6787E4FC5CC3F /* VOKUtilities-tvOS9.0.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3320,7 +3320,7 @@
 			};
 			name = Debug;
 		};
-		29915A707A12A2C46DAA846C396CAB6F /* Release */ = {
+		E729E9D0D0736D67D35385CEF1156BA9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -3363,9 +3363,9 @@
 			};
 			name = Release;
 		};
-		03E334B236B22E54B5A80576EC3E88CE /* Debug */ = {
+		E837A7394780A9059B46ABA5FB629985 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E22AD87D6173DD697749070C13776D0 /* Vokoder-07029ee6.xcconfig */;
+			baseConfigurationReference = 709585C36368811AC1D9697E5DBB5EF5 /* Vokoder-07029ee6.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3387,9 +3387,9 @@
 			};
 			name = Debug;
 		};
-		23623DFD57B51CA73F341E1A37582F18 /* Release */ = {
+		EF13A36897B024FA0B072B1396288E59 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F5BC8660565E6934A19C07FB2098C015 /* ILGDynamicObjC-tvOS9.0.xcconfig */;
+			baseConfigurationReference = 7639258F331D52B880154D63E782D7A6 /* ILGDynamicObjC-tvOS9.0.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3410,9 +3410,9 @@
 			};
 			name = Release;
 		};
-		BC19938048C88C1DE61E498CAB5B5288 /* Release */ = {
+		EFB44EE58962CBA9773F41F564A4DB9F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBD594A897BF2B25B03804CA7DF9BD39 /* Vokoder.root-Core-MapperMacros-OSX.xcconfig */;
+			baseConfigurationReference = CB47F8B49375B3DB7D3EB7AA68DA9386 /* Vokoder.root-Core-MapperMacros-OSX.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3434,9 +3434,9 @@
 			};
 			name = Release;
 		};
-		9196CC5B534B0BDCF160FA16DE078B28 /* Debug */ = {
+		F0DD4656D31D1DA609CEE3D8835A10FB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4AEC4E19A44C1415B751DD9150E36B34 /* Pods-VOKCoreDataManager.debug.xcconfig */;
+			baseConfigurationReference = 8DB45E93EADED6344C252DD1FB4F2423 /* Pods-VOKCoreDataManager.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3457,9 +3457,9 @@
 			};
 			name = Debug;
 		};
-		7A66C3B529E8249BF5AF09908F06AB5A /* Release */ = {
+		F68FCE1C7A31E4E42D8A7999E89A4B2E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1DBF133507242CA23B6647425441B66 /* Pods-VOKCoreDataManager.release.xcconfig */;
+			baseConfigurationReference = 18F022ECB974D204BBFAF860AB26BE98 /* Pods-VOKCoreDataManager.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -3483,223 +3483,223 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		63D1FDEDF4FE692715E76337DC1EF66A /* Build configuration list for PBXNativeTarget "Vokoder-43a9e09e" */ = {
+		2A5810ABCB03EFC7555AD8367A6DD40D /* Build configuration list for PBXNativeTarget "Vokoder-43a9e09e" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				47F5AD7CE45EE9CFE89E270A604291EA /* Debug */,
-				AF96BCF9E3CF40A910887EDC31FB3BA8 /* Release */,
+				CCE8119D0F5DB3F718FDEEABBB20979E /* Debug */,
+				74BAE436E6252B275BD24B2629AE19B5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		EAE90995CF11A722D072116D2DCAE030 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests" */ = {
+		2BD2F3230CD6A587AEA2A3021D18FACE /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B36A21F6701F9D5845A29EE65C1D1171 /* Debug */,
-				E3F05354D2D577E86537ACCB2C3FDD89 /* Release */,
+				9D502C0BAB1E17CB1A218E58E63382CC /* Debug */,
+				509930E3353A21567B6CB503F4A4EE34 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B58BA56853A2C3714E91F0E4230337BF /* Build configuration list for PBXNativeTarget "Vokoder.root-Core-MapperMacros-watchOS" */ = {
+		2C36428ED42922E02877ADCF66E2BD01 /* Build configuration list for PBXNativeTarget "Vokoder.root-Core-MapperMacros-watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				743D049605599ED828E30CA4D29294C5 /* Debug */,
-				18E3763D02456D826FA903F6A0CC3A34 /* Release */,
+				6BFE66DDBB9847FD83826855E61E28ED /* Debug */,
+				16FA9AB9474623C573B0D91B33272B5C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		FC02AE59B0DCC1367E03651BD0868F72 /* Build configuration list for PBXProject "Pods" */ = {
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				78F0498F2AF1B86F8B7B7477CD49552F /* Debug */,
-				29915A707A12A2C46DAA846C396CAB6F /* Release */,
+				3F1EA6497DBDDAAE006DECDB0C206D34 /* Debug */,
+				E729E9D0D0736D67D35385CEF1156BA9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D5E432436DF3B54BBD2A754AB66AAFDF /* Build configuration list for PBXNativeTarget "Vokoder-07029ee6" */ = {
+		359BA7A7F14BB385AF7AEFA6506CB9A0 /* Build configuration list for PBXNativeTarget "Vokoder-07029ee6" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				03E334B236B22E54B5A80576EC3E88CE /* Debug */,
-				7106BC7AD9A042C55E4910DAFBADE772 /* Release */,
+				E837A7394780A9059B46ABA5FB629985 /* Debug */,
+				38A770F485241813B2CCABA51C786244 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		9D4AF939A6E6DA33916659AF10052103 /* Build configuration list for PBXNativeTarget "Vokoder-fdc3d3be" */ = {
+		41BB3A576D5055C9947630B81E7D6DC2 /* Build configuration list for PBXNativeTarget "Vokoder-fdc3d3be" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				728B1CD66899D2BCC256AD26D28A4014 /* Debug */,
-				0C5834B63C2CAB2CF7BB533911BC27D3 /* Release */,
+				D58618134F47755178043F7B85501902 /* Debug */,
+				9B3B3B827620711657C57AE8EF8B4745 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7D67DE34CC36058521895BA9FE7752E9 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-OSX" */ = {
+		4593BC577505254D3FA9124E5497A884 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1631775464C1CF0B6550CBC239E689B5 /* Debug */,
-				1964CC0D5B9CB3C500A2F7F039CE2346 /* Release */,
+				7589CA21005E9672640201BF8CC3082E /* Debug */,
+				42D41D9DCB11032855A8A0D32C687AE1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2908F09150E62FD0D2F370CF842734A0 /* Build configuration list for PBXNativeTarget "VOKUtilities-tvOS9.0" */ = {
+		73CA1AEC4FFA78EAF49A1AF980A86CB3 /* Build configuration list for PBXNativeTarget "VOKUtilities-tvOS9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				94DA53DEF4C8F52137B3A333A0C7AEBB /* Debug */,
-				456051E3342428DD6EE831EEC3AF3E3D /* Release */,
+				E5C9761BDCD16ABDBB3AB515153C7C4A /* Debug */,
+				6F47C80433F1343B332B07D025244CD8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4E05AD4F33B9D47A962DEA3AC133F23B /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-iOS8.0" */ = {
+		7B569FC69578A7C73F8632746265BFAB /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-iOS8.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				AC59F201F05DACB2DE78FBFB603B1EF0 /* Debug */,
-				9838C2F84F1C0283EF3158D6E9E00F41 /* Release */,
+				B3E52FF164902B114D0AEB3EFE3EFA2A /* Debug */,
+				73C315F6B0DB1C085DF47E9C06A141A1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5E82F482207912533DDA66CD2B795957 /* Build configuration list for PBXNativeTarget "VOKUtilities-iOS8.0" */ = {
+		AB970B0D8A11CCE9AAD7CB5BEFCFF638 /* Build configuration list for PBXNativeTarget "VOKUtilities-iOS8.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				296706A2AE5EC7A2C7F3CDC145B20F35 /* Debug */,
-				B55A6EA547712101AE9ED370A0F96ACC /* Release */,
+				CF64948A3AA81FF14B68024CA404305A /* Debug */,
+				7E694ECBDE35C4AC4103C665BDE29113 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F0BE19AE6ECA63EA4BC205828D01014C /* Build configuration list for PBXNativeTarget "Pods-TodayWidget" */ = {
+		AC64C7A066A995344DCC0B0E982051EF /* Build configuration list for PBXNativeTarget "Pods-TodayWidget" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2FAEE4B53B40BDD705157885AE684940 /* Debug */,
-				12783DE9FAB2DF0980AE3FD39873FEED /* Release */,
+				67C9DC28515664D75BD79F8308377E92 /* Debug */,
+				5F6D88BC6D098561B55FAD7226E4645B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B22B62311604CFECA70CA23602291B68 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManagerTests-tvOS" */ = {
+		AE1716C003EC4BD1FF51B6700F5322D1 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManagerTests-tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				46704E5F9E0A1D129AB23B4BF0B56DA8 /* Debug */,
-				013CC9C77AFB358B607ACE6CEAEAD908 /* Release */,
+				433CF913DCBF54C8A319FE8FE37DBD41 /* Debug */,
+				15CC2166A449846B906870B55ABB8FC3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7C44297BB4409ECBD2621CDF4A65D323 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-tvOS9.0" */ = {
+		B58E5E4865C5D0135206C5A015565F70 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-tvOS9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C37DE804B0A7D4B61AA90B17E4B868C5 /* Debug */,
-				23623DFD57B51CA73F341E1A37582F18 /* Release */,
+				9A8BA8F51490012854BCA3ECB13F5044 /* Debug */,
+				EF13A36897B024FA0B072B1396288E59 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8E9B0F49C86521A2475BA3439DC673A2 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManagerTests-OSX" */ = {
+		C672001D8C6EC04797B2791EFA6158BF /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManagerTests-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				898EB74D252753FCC8AE6C0A8C2D6625 /* Debug */,
-				17BDDF0C1421909F0350D53EDDB435CA /* Release */,
+				9822F7A621148618BAAD5FA97C7CB703 /* Debug */,
+				A30A0E93BD9DFEC5451B401085139AE4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3A74B6A977C3BA59B315FC722112BBF6 /* Build configuration list for PBXNativeTarget "Vokoder.root-Core-MapperMacros-OSX" */ = {
+		C8571229CD897A6EB95626F327D35D60 /* Build configuration list for PBXNativeTarget "Vokoder.root-Core-MapperMacros-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CC98C61AC83AF4607760969F4D476ED9 /* Debug */,
-				BC19938048C88C1DE61E498CAB5B5288 /* Release */,
+				354D1CAA716705B55559FE598DDF5CAC /* Debug */,
+				EFB44EE58962CBA9773F41F564A4DB9F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		56787BDBF12439322DD306BC4A106AA3 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-OSX10.9" */ = {
+		D3003EDC6E321A667FA6EC8DBB540C55 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-OSX10.9" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				60C3FC59A3699A68C41F439AD767B067 /* Debug */,
-				F8D58224C2705AA2EE922E046686335F /* Release */,
+				3CEFC48610B4C545F7CFFD9F1B07198E /* Debug */,
+				579A5F9EA294F429DAEA054D02B7907D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		08ECEFFBA0ED222BA652ACAC7B493A5D /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-iOS10.0" */ = {
+		D5778E346FE65FA755BC3D9BB10FF6CE /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-iOS10.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				123A08AC08285B6D01CBB8BE4F964C90 /* Debug */,
-				DBDA34FD52CF2FD09E992A2B1AE643F1 /* Release */,
+				DF45F889A2D47793136E09A8E5B32F52 /* Debug */,
+				083BB3AD2027048C8ECADE6DBD9284FD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		00C0CE07F3FDC06879C92DC6A179C9B5 /* Build configuration list for PBXNativeTarget "VOKUtilities-OSX10.9" */ = {
+		D71A3738B4311064A0B9331B6907FC4C /* Build configuration list for PBXNativeTarget "VOKUtilities-OSX10.9" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				295DB9A24AA0BE984BB1342FD1A76096 /* Debug */,
-				04EE05BDD7025B01838497E75D4828DE /* Release */,
+				1EE54482F5FAA03EF66F550A67CCEC31 /* Debug */,
+				79847D3CF4A701A83BBDA9695DC879C0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		ECDF551D9414891B248F23BC3265F5C0 /* Build configuration list for PBXNativeTarget "Pods-WatchApp Extension" */ = {
+		DE4AFF0E53A788087E0281B9AB219F2A /* Build configuration list for PBXNativeTarget "Pods-WatchApp Extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B7F48B104F8464735BEBCA776BFB2444 /* Debug */,
-				E5C6F88E3F2C29E7C1E04646D44D3ADA /* Release */,
+				7BF55DD19320B017AC924E6B5D3DADA3 /* Debug */,
+				4FC91CA2A56B12F3CE24B3DAF5DE9464 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		ECDF0EC2AC12985912E46ED93F200C42 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-tvOS" */ = {
+		E4D95A5EABB37DC56D7DFDB728076BE7 /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager-tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E9D2E1EB5BDB802F719F2A2AC2826A0C /* Debug */,
-				8765BB89E0AA6AF36DA62C0DBFA92CCF /* Release */,
+				6283A32A2125315370BE4AA2EC4FA5E5 /* Debug */,
+				97C25DA9E783BC1A0E86477795A389AB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A1775DB7741425333C73CECE600A5C0A /* Build configuration list for PBXNativeTarget "VOKUtilities-iOS10.0" */ = {
+		E53D4B1EDA84FB1B08D637DF1B0D94D9 /* Build configuration list for PBXNativeTarget "VOKUtilities-iOS10.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A3B22FB0177E91C701660AB8A1BD04D6 /* Debug */,
-				E6B7B0700ACEBCC134A001E32FF71D2E /* Release */,
+				A527C379D40B9DBF1DE2363599292046 /* Debug */,
+				95AC4ACC470596989C19E4B20C699541 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C473BD9CD0AE43CD7A719CAFD9D60E3E /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager" */ = {
+		F4E51430E7F4B2C74C6BCD3ED56BBCBB /* Build configuration list for PBXNativeTarget "Pods-VOKCoreDataManager" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9196CC5B534B0BDCF160FA16DE078B28 /* Debug */,
-				7A66C3B529E8249BF5AF09908F06AB5A /* Release */,
+				F0DD4656D31D1DA609CEE3D8835A10FB /* Debug */,
+				F68FCE1C7A31E4E42D8A7999E89A4B2E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		04F6BD7BD49CC5A702D74146B10EDC66 /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-watchOS3.0" */ = {
+		F7BB2C691D05F5A123D7465954664E0A /* Build configuration list for PBXNativeTarget "ILGDynamicObjC-watchOS3.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D5E5DE921EE3F0D6E5730BEAFE9323FA /* Debug */,
-				75D1A7A39E9F938C16476EC758E77775 /* Release */,
+				672EB2B1C7EDE7A3F2A5FCC4531E1C9B /* Debug */,
+				2B9DAECCDEE612EFFD2D559D9B1EC735 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7870541348C0CB4241F54434A4988AB7 /* Build configuration list for PBXNativeTarget "VOKUtilities-watchOS3.0" */ = {
+		FB0D60C2F1723A1254AE87478178C6ED /* Build configuration list for PBXNativeTarget "VOKUtilities-watchOS3.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D3C612E967EB15DF7BA75473A5DB09B1 /* Debug */,
-				9C20C986E8D87BF73D274C05A1ECEC3A /* Release */,
+				D5B12452D9CA509979F0A0CF112B262E /* Debug */,
+				3044312644AFC30AEB23FC99E0E5898A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 }

--- a/SwiftSampleProject/Podfile.lock
+++ b/SwiftSampleProject/Podfile.lock
@@ -1,23 +1,10 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (5.0.0):
+  - Vokoder/Core (5.0.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.11.0)
-  - Vokoder/DataSources (5.0.0):
+  - Vokoder/Swift (5.0.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 5.0.0)
-    - Vokoder/DataSources/FetchedResults (= 5.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 5.0.0)
-  - Vokoder/DataSources/Collection (5.0.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (5.0.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (5.0.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (5.0.0):
-    - Vokoder/DataSources
   - VOKUtilities/VOKKeyPathHelper (0.11.0)
   - xUnique (4.1.2)
 
@@ -39,7 +26,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 36b3c173b1f8933aebd419ff6e740fece076be06
+  Vokoder: 2e571a4e2290fdf9431d923ae6be2fd094f3ab0f
   VOKUtilities: e831207f9217bd8060467d28f26b5f7a902db63c
   xUnique: d1303d8023f7bcc68dbb3086ffa760d1ea800812
 

--- a/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
+++ b/SwiftSampleProject/Pods/Local Podspecs/Vokoder.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Vokoder",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "summary": "Vokal's Core Data Manager",
   "homepage": "https://github.com/vokal/Vokoder",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/Vokoder.git",
-    "tag": "5.0.0"
+    "tag": "5.0.1"
   },
   "platforms": {
     "ios": "8.0",
@@ -95,10 +95,11 @@
       "name": "Swift",
       "platforms": {
         "ios": "8.0",
-        "tvos": "9.0"
+        "tvos": "9.0",
+        "watchos": "3.0"
       },
       "dependencies": {
-        "Vokoder/DataSources": [
+        "Vokoder/Core": [
 
         ]
       },

--- a/SwiftSampleProject/Pods/Manifest.lock
+++ b/SwiftSampleProject/Pods/Manifest.lock
@@ -1,23 +1,10 @@
 PODS:
   - ILGDynamicObjC/ILGClasses (0.1.1)
-  - Vokoder/Core (5.0.0):
+  - Vokoder/Core (5.0.1):
     - ILGDynamicObjC/ILGClasses (~> 0.1.1)
     - VOKUtilities/VOKKeyPathHelper (~> 0.11.0)
-  - Vokoder/DataSources (5.0.0):
+  - Vokoder/Swift (5.0.1):
     - Vokoder/Core
-    - Vokoder/DataSources/Collection (= 5.0.0)
-    - Vokoder/DataSources/FetchedResults (= 5.0.0)
-    - Vokoder/DataSources/PagingFetchedResults (= 5.0.0)
-  - Vokoder/DataSources/Collection (5.0.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/DataSources/FetchedResults (5.0.0):
-    - Vokoder/Core
-  - Vokoder/DataSources/PagingFetchedResults (5.0.0):
-    - Vokoder/Core
-    - Vokoder/DataSources/FetchedResults
-  - Vokoder/Swift (5.0.0):
-    - Vokoder/DataSources
   - VOKUtilities/VOKKeyPathHelper (0.11.0)
   - xUnique (4.1.2)
 
@@ -39,7 +26,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   ILGDynamicObjC: 63443567f8ce851067ea3070d3b8c7f93d37207c
-  Vokoder: 36b3c173b1f8933aebd419ff6e740fece076be06
+  Vokoder: 2e571a4e2290fdf9431d923ae6be2fd094f3ab0f
   VOKUtilities: e831207f9217bd8060467d28f26b5f7a902db63c
   xUnique: d1303d8023f7bcc68dbb3086ffa760d1ea800812
 

--- a/SwiftSampleProject/Pods/Pods.xcodeproj/project.pbxproj
+++ b/SwiftSampleProject/Pods/Pods.xcodeproj/project.pbxproj
@@ -8,20 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		022C6C891A4BA6EA86619318085AFFE2 /* ILGDynamicObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 458C5BD0AEBC1031A6C0CFBBCDBE7A0E /* ILGDynamicObjC.framework */; };
-		0FBF15D82D6887E4507BAEC5AE7D44A5 /* VOKPagingFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */; };
 		13860E57730CB68C980144C1246E8166 /* VOKUtilities-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 812A6DF58E85CCC1E9280954D46182B9 /* VOKUtilities-dummy.m */; };
 		1523ECABEAC8045673063FA3D6E70899 /* ILGDynamicObjC-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 801B9204844DE86EC73A5E7EFC5627E1 /* ILGDynamicObjC-dummy.m */; };
 		191F67BC31A55B010EEDC6CA04C5F797 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */; };
-		1B49270969167C22DCCCF46AD88EB2DB /* VOKPagingFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1BFB7C298FD5C3D2FD390190D0ECA769 /* VOKCoreDataManagerInternalMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		235B0187FBBF4AE11D3AE502DA0ECD58 /* VOKCollectionDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23DA4A38A0F5999A47726AD2E3A3CB64 /* ILGClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6876275B2F95CC0781382D994E1DE3 /* ILGClasses.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		24251378DC9175E56D1DBC9CA0A414C4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
 		266C2EB085F2A07622C62FB075718E2C /* ILGClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 869B5154502141C012BA472A1C847BDE /* ILGClasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26A5F9C895CB34BF97F17CE571E759A5 /* VOKCoreDataManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		275AFAF4656AB8170B4E6BD5EABF9505 /* VOKFetchedResultsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */; };
 		2A12A0F766D622588FB6DBE55D841D51 /* VOKManagedObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */; };
-		2C7030DBF426C627A98E271E3996DD9B /* VOKFetchedResultsDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2CF862AE0354E60F9EB1599FBCBFB023 /* Pods-SwiftyVokoder-SwiftyVokoderTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = AB10787E1F52E9A9A7C18342E1D71B1E /* Pods-SwiftyVokoder-SwiftyVokoderTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		37263F32223698E656E9E7F3261EB020 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
 		388C22BC0C6295739569BEFD0E62A532 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */; };
@@ -35,7 +30,6 @@
 		5FEF85C834ED6D2FD83EDF4EB4C5A288 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
 		7EB42B389B749898F687AD12B231C384 /* VOKManagedObjectMap+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F958437794067505C704E31ADBD9C574 /* VOKManagedObjectMap+Swift.swift */; };
 		8B360D8BEF266C15195F936EBF783B1B /* Vokoder-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DA9C741F6731B52E65F064260E35589 /* Vokoder-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		95B9BB48A25AB5F7D0AEE23B75C52B90 /* VOKCollectionDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */; };
 		9B931AD17FA3518651FAB463A8B8D9E1 /* Vokoder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 79B1BD8DE394FE1FD0C6D56BEB1B1398 /* Vokoder-dummy.m */; };
 		9DAC5F1FCC91C4B9DA5DE65CD6C06FF9 /* VOKMappableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A5C22E889A9E7C681C810D7BDE8790D5 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 563CF8C518F67DD641BFBE412A57F91A /* NSManagedObject+VOKManagedObjectAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -43,12 +37,10 @@
 		B537D546DC0FB414D44A3BF8F44BFCD7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */; };
 		B87D64353F8A87327BD8580EF1704EE1 /* Pods-SwiftyVokoder-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 487F1C283548C9AAFDC75A8E801700A0 /* Pods-SwiftyVokoder-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BA01ACF653FD84D67AA2A9F07B7A142E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F0B6F8987F1B858DDB47A0CB37AB97 /* NSManagedObject+VOKManagedObjectAdditions.m */; };
-		CB4A4C09DE45A0847DA2F19BB3614B00 /* VOKDefaultPagingAccessory.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D36F28073218405C5AC61EFE60512689 /* VOKCoreDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */; };
 		D5D5268A466A625A4B99B43992B3F7BD /* Vokoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 311BC35339F4C1841DFE9FADB2C7842C /* Vokoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D88DFF6934B408DB7166E3FE6326D411 /* VOKNullabilityFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DFB79B555DF37784C7A6261D837D5CD8 /* VOKCoreDataManager+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC7668B975281E05CAFA3AE3853BF09 /* VOKCoreDataManager+Swift.swift */; };
-		E0CEEB884037F2326F94FFD21AA555A5 /* VOKDefaultPagingAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */; };
 		E4F0D448B9ACA0588BA05ECBF3C4E4C9 /* VOKManagedObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D2D1AA9CAC50C7BF1A1009F3D7EED83 /* VOKManagedObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E63EFB9B228A5DBAA0A19CAF3F531E93 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F0DDF2A2AF18593F10C360BE5443B757 /* VOKManagedObjectMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A5294456A06DB5042E6E9FCFA15458 /* VOKManagedObjectMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -130,7 +122,6 @@
 		458C5BD0AEBC1031A6C0CFBBCDBE7A0E /* ILGDynamicObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ILGDynamicObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		487F1C283548C9AAFDC75A8E801700A0 /* Pods-SwiftyVokoder-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SwiftyVokoder-umbrella.h"; sourceTree = "<group>"; };
 		4A7705560B3306A6F7F9C55497E7A692 /* VOKCoreDataManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCoreDataManager.h; sourceTree = "<group>"; };
-		4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKDefaultPagingAccessory.h; sourceTree = "<group>"; };
 		4B9D172E38B5D027E0DA63D693FBB99A /* Pods-SwiftyVokoder-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SwiftyVokoder-resources.sh"; sourceTree = "<group>"; };
 		4C1BE87FA376FBA6EF026E8F856CF5E2 /* Pods-SwiftyVokoder-SwiftyVokoderTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SwiftyVokoder-SwiftyVokoderTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		4DA9C741F6731B52E65F064260E35589 /* Vokoder-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Vokoder-umbrella.h"; sourceTree = "<group>"; };
@@ -143,16 +134,13 @@
 		5E650073B80F1881DBB2C396F620B746 /* VOKUtilities.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = VOKUtilities.modulemap; sourceTree = "<group>"; };
 		5ED4077304AB1720B21D628EFD7A11F4 /* ILGDynamicObjC.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ILGDynamicObjC.xcconfig; sourceTree = "<group>"; };
 		5F7A8EF0DD971D869C8A288FE09E9643 /* VOKUtilities-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-umbrella.h"; sourceTree = "<group>"; };
-		63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKCollectionDataSource.h; sourceTree = "<group>"; };
 		6A4CAAC6A0E340B7E4FD99F597A6A6FF /* Pods-SwiftyVokoder-SwiftyVokoderTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SwiftyVokoder-SwiftyVokoderTests-resources.sh"; sourceTree = "<group>"; };
 		6FCB1E991B78EEF42E1B6BEA38AA24C4 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7439C9D64D93E5A00DEF8CF8AB0BE9AB /* VOKManagedObjectMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKManagedObjectMapper.m; sourceTree = "<group>"; };
-		78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKPagingFetchedResultsDataSource.m; sourceTree = "<group>"; };
 		79B1BD8DE394FE1FD0C6D56BEB1B1398 /* Vokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Vokoder-dummy.m"; sourceTree = "<group>"; };
 		7C29E03CF82F29FD12CC924C20C6D59E /* VOKNullabilityFeatures.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKNullabilityFeatures.h; sourceTree = "<group>"; };
 		7D33A8B40F88FCFB124EAF5610808AD0 /* VOKCoreDataManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCoreDataManager.m; sourceTree = "<group>"; };
 		801B9204844DE86EC73A5E7EFC5627E1 /* ILGDynamicObjC-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ILGDynamicObjC-dummy.m"; sourceTree = "<group>"; };
-		809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKCollectionDataSource.m; sourceTree = "<group>"; };
 		812A6DF58E85CCC1E9280954D46182B9 /* VOKUtilities-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VOKUtilities-dummy.m"; sourceTree = "<group>"; };
 		869B5154502141C012BA472A1C847BDE /* ILGClasses.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ILGClasses.h; path = Pod/ILGClasses/ILGClasses.h; sourceTree = "<group>"; };
 		86BA5C9F5E34AB041378F240DF219CA0 /* Vokoder.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Vokoder.modulemap; sourceTree = "<group>"; };
@@ -169,7 +157,6 @@
 		AF191E87FDAED503E8A252547280F918 /* ILGDynamicObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = ILGDynamicObjC.framework; path = ILGDynamicObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1C973CB0B571FCE681E1B4004E2D31F /* Pods-SwiftyVokoder-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SwiftyVokoder-frameworks.sh"; sourceTree = "<group>"; };
 		C4902ACEB6F9D234A1C2BF2DA248D53D /* ILGDynamicObjC-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ILGDynamicObjC-prefix.pch"; sourceTree = "<group>"; };
-		CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKDefaultPagingAccessory.m; sourceTree = "<group>"; };
 		CD88F0AAFA2539E326897370447A0A47 /* Pods_SwiftyVokoder_SwiftyVokoderTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SwiftyVokoder_SwiftyVokoderTests.framework; path = "Pods-SwiftyVokoder-SwiftyVokoderTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
 		D04EC1A9C6BA5D4E222D9E5525D6D641 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -178,9 +165,7 @@
 		DFC7668B975281E05CAFA3AE3853BF09 /* VOKCoreDataManager+Swift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "VOKCoreDataManager+Swift.swift"; sourceTree = "<group>"; };
 		E0DE510C15B9A1726BBC6B790ED8E549 /* Vokoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Vokoder.framework; path = Vokoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2F8C22CB3768609583EDBDECED582C9 /* VOKMappableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKMappableModel.h; sourceTree = "<group>"; };
-		E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKPagingFetchedResultsDataSource.h; sourceTree = "<group>"; };
 		E80288B65E5968A53DA762BB141A20B3 /* Pods-SwiftyVokoder.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SwiftyVokoder.release.xcconfig"; sourceTree = "<group>"; };
-		E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = VOKFetchedResultsDataSource.m; sourceTree = "<group>"; };
 		E9AE77247D364B4EBA993EA41A0D701F /* Pods_SwiftyVokoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SwiftyVokoder.framework; path = "Pods-SwiftyVokoder.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC12225D9ADEC1D4EA29E8E3EE7DB4EB /* VOKUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VOKUtilities.framework; path = VOKUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC4FAF2D2460C8C4F41584E688AE563A /* ILGDynamicObjC-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ILGDynamicObjC-umbrella.h"; sourceTree = "<group>"; };
@@ -189,7 +174,6 @@
 		F958437794067505C704E31ADBD9C574 /* VOKManagedObjectMap+Swift.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "VOKManagedObjectMap+Swift.swift"; sourceTree = "<group>"; };
 		FBA8A86A0428E18A079E5B98CC3C6270 /* ILGDynamicObjC.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = ILGDynamicObjC.modulemap; sourceTree = "<group>"; };
 		FD262795740FE0F8B403D3D3BF0AAA0F /* Pods-SwiftyVokoder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SwiftyVokoder-dummy.m"; sourceTree = "<group>"; };
-		FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = VOKFetchedResultsDataSource.h; sourceTree = "<group>"; };
 		FFBCB5680F6EE947B6B4F82A6FE7F005 /* Pods-SwiftyVokoder-SwiftyVokoderTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SwiftyVokoder-SwiftyVokoderTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -240,6 +224,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		FC25032629219E710CFD3F9E2885B49A /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				DAF43F297D5CF42BF64C58D59E3F34E5 /* Swift */,
+			);
+			name = Classes;
+			path = Classes;
+			sourceTree = "<group>";
+		};
 		DC48BCE815EC154A59BCA69936CF7135 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -270,45 +263,6 @@
 			path = xUnique;
 			sourceTree = "<group>";
 		};
-		DAF43F297D5CF42BF64C58D59E3F34E5 /* Swift */ = {
-			isa = PBXGroup;
-			children = (
-				DFC7668B975281E05CAFA3AE3853BF09 /* VOKCoreDataManager+Swift.swift */,
-				F958437794067505C704E31ADBD9C574 /* VOKManagedObjectMap+Swift.swift */,
-				DF30ECF27987776BECCD96663C0D3700 /* VokoderTypedManagedObject.swift */,
-			);
-			name = Swift;
-			path = Swift;
-			sourceTree = "<group>";
-		};
-		A82DCA28FABF1F9080B1B2234FFB9045 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */,
-				9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		1432AA59D8B53139E350543A9C80D7F8 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				BD69F150A8C2569270FC79BDA1504428 /* ILGDynamicObjC */,
-				0628D34B912C2431236471EF4C7720C0 /* VOKUtilities */,
-				73AB5E5F94B4DE5984CD16FDB5EABFD4 /* xUnique */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		0D628D92F46B96670EB6FF1B86D31B39 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				6871642A62DD48369704DBF18892621C /* Optional Data Sources */,
-			);
-			name = Classes;
-			path = Classes;
-			sourceTree = "<group>";
-		};
 		D1623DACC3E535903FFF1F09759DB50E /* Classes */ = {
 			isa = PBXGroup;
 			children = (
@@ -330,21 +284,59 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		0BA6A3697D7736F3A930525826963BB3 /* Classes */ = {
+		A82DCA28FABF1F9080B1B2234FFB9045 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				CA9F64BFACD9A6B9EFC6C13F107B6ABF /* Optional Data Sources */,
+				CEB59BB85EC7E22208C8A9DC78B41673 /* CoreData.framework */,
+				9AD7F7B2FD0271A000FCD221B7247089 /* Foundation.framework */,
 			);
-			name = Classes;
-			path = Classes;
+			name = iOS;
 			sourceTree = "<group>";
 		};
-		DC922EC5F6A4C858F3D3657B1D19245D /* PagingFetchedResults */ = {
+		1432AA59D8B53139E350543A9C80D7F8 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2757FE2226489748E1B034F311E8325A /* Pod */,
+				BD69F150A8C2569270FC79BDA1504428 /* ILGDynamicObjC */,
+				0628D34B912C2431236471EF4C7720C0 /* VOKUtilities */,
+				73AB5E5F94B4DE5984CD16FDB5EABFD4 /* xUnique */,
 			);
-			name = PagingFetchedResults;
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		7A433FE6A343961BAD2B564426630D78 /* VOKKeyPathHelper */ = {
+			isa = PBXGroup;
+			children = (
+				F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */,
+				2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */,
+			);
+			name = VOKKeyPathHelper;
+			sourceTree = "<group>";
+		};
+		4C41F011FF8ED22F05291E655C2F2619 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				FC25032629219E710CFD3F9E2885B49A /* Classes */,
+			);
+			name = Pod;
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		7B6B69F12063310EFEBC024790A2398E /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				D1623DACC3E535903FFF1F09759DB50E /* Classes */,
+			);
+			name = Pod;
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		851707713AFD3E95A0F4A2181FE71857 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */,
+			);
+			name = Internal;
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		21C815DB339F7DD825A5E4CB08881309 /* Support Files */ = {
@@ -361,73 +353,6 @@
 			path = "SwiftSampleProject/Pods/Target Support Files/Vokoder";
 			sourceTree = "<group>";
 		};
-		CA9F64BFACD9A6B9EFC6C13F107B6ABF /* Optional Data Sources */ = {
-			isa = PBXGroup;
-			children = (
-				FE46347C6BA726BAA9C3E7F52DF2F405 /* VOKFetchedResultsDataSource.h */,
-				E98A40F384AACA2D3D29DC7F618E8BD8 /* VOKFetchedResultsDataSource.m */,
-			);
-			name = "Optional Data Sources";
-			path = "Optional Data Sources";
-			sourceTree = "<group>";
-		};
-		7A433FE6A343961BAD2B564426630D78 /* VOKKeyPathHelper */ = {
-			isa = PBXGroup;
-			children = (
-				F85E018BD172DDC2A1ABD7C777AC1268 /* VOKKeyPathHelper.h */,
-				2FBBCFFA37F19790C3C413A6040D3409 /* VOKKeyPathHelper.m */,
-			);
-			name = VOKKeyPathHelper;
-			sourceTree = "<group>";
-		};
-		7B6B69F12063310EFEBC024790A2398E /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				D1623DACC3E535903FFF1F09759DB50E /* Classes */,
-			);
-			name = Pod;
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		FC25032629219E710CFD3F9E2885B49A /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				DAF43F297D5CF42BF64C58D59E3F34E5 /* Swift */,
-			);
-			name = Classes;
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		2757FE2226489748E1B034F311E8325A /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				0D628D92F46B96670EB6FF1B86D31B39 /* Classes */,
-			);
-			name = Pod;
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		61BB1467B6A83D6A6A4953981C7A0F3D /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				871C6B29616861FE22F20252EE41CB6B /* Classes */,
-			);
-			name = Pod;
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		6871642A62DD48369704DBF18892621C /* Optional Data Sources */ = {
-			isa = PBXGroup;
-			children = (
-				4A79F77C4C11FB87B480AFCE3949C899 /* VOKDefaultPagingAccessory.h */,
-				CC8DC84CD7368660327087E59AD57D32 /* VOKDefaultPagingAccessory.m */,
-				E319E4660CA328616444A9F27C52B0C8 /* VOKPagingFetchedResultsDataSource.h */,
-				78389936FB087287339297E746EE53D8 /* VOKPagingFetchedResultsDataSource.m */,
-			);
-			name = "Optional Data Sources";
-			path = "Optional Data Sources";
-			sourceTree = "<group>";
-		};
 		5DECD2D2DDBCF1DF25E1166EAF85634C = {
 			isa = PBXGroup;
 			children = (
@@ -438,22 +363,6 @@
 				F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */,
 				27E772C472EE5BD87EA005C1E920FEC6 /* Targets Support Files */,
 			);
-			sourceTree = "<group>";
-		};
-		6D1EB8A38E8CBA4A4B0D3C897A545D0A /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				2841E6A5AFA6C5740FA47D68784B43B8 /* Vokoder */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		92AA232EE3E496566240A00B61598355 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				7B6B69F12063310EFEBC024790A2398E /* Pod */,
-			);
-			name = Core;
 			sourceTree = "<group>";
 		};
 		FA69128BA538E22FB0AF31EEBAD8D0E8 /* Support Files */ = {
@@ -470,24 +379,12 @@
 			path = "../Target Support Files/VOKUtilities";
 			sourceTree = "<group>";
 		};
-		8EB4618C736DD6BDEC8CFC9A74CBE387 /* FetchedResults */ = {
+		6D1EB8A38E8CBA4A4B0D3C897A545D0A /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				478C110C179740FF4A342BF721CA277F /* Pod */,
+				2841E6A5AFA6C5740FA47D68784B43B8 /* Vokoder */,
 			);
-			name = FetchedResults;
-			sourceTree = "<group>";
-		};
-		2841E6A5AFA6C5740FA47D68784B43B8 /* Vokoder */ = {
-			isa = PBXGroup;
-			children = (
-				92AA232EE3E496566240A00B61598355 /* Core */,
-				D291960F19FD2FE625E66028614C79A8 /* DataSources */,
-				21C815DB339F7DD825A5E4CB08881309 /* Support Files */,
-				CB0492CD97B8E466E5C8C2E3442398C2 /* Swift */,
-			);
-			name = Vokoder;
-			path = ../..;
+			name = "Development Pods";
 			sourceTree = "<group>";
 		};
 		27E772C472EE5BD87EA005C1E920FEC6 /* Targets Support Files */ = {
@@ -497,15 +394,6 @@
 				1C5B6E97047618BC1F830BD6A5EC444A /* Pods-SwiftyVokoder-SwiftyVokoderTests */,
 			);
 			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		851707713AFD3E95A0F4A2181FE71857 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				5C6E34A1537EF66B0619EB50C5D4DC36 /* VOKCoreDataManagerInternalMacros.h */,
-			);
-			name = Internal;
-			path = Internal;
 			sourceTree = "<group>";
 		};
 		F653198251905F2D19DBEA48B7F9A7DC /* Support Files */ = {
@@ -522,23 +410,6 @@
 			path = "../Target Support Files/ILGDynamicObjC";
 			sourceTree = "<group>";
 		};
-		4C41F011FF8ED22F05291E655C2F2619 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				FC25032629219E710CFD3F9E2885B49A /* Classes */,
-			);
-			name = Pod;
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		CB0492CD97B8E466E5C8C2E3442398C2 /* Swift */ = {
-			isa = PBXGroup;
-			children = (
-				4C41F011FF8ED22F05291E655C2F2619 /* Pod */,
-			);
-			name = Swift;
-			sourceTree = "<group>";
-		};
 		BD69F150A8C2569270FC79BDA1504428 /* ILGDynamicObjC */ = {
 			isa = PBXGroup;
 			children = (
@@ -547,6 +418,14 @@
 			);
 			name = ILGDynamicObjC;
 			path = ILGDynamicObjC;
+			sourceTree = "<group>";
+		};
+		CB0492CD97B8E466E5C8C2E3442398C2 /* Swift */ = {
+			isa = PBXGroup;
+			children = (
+				4C41F011FF8ED22F05291E655C2F2619 /* Pod */,
+			);
+			name = Swift;
 			sourceTree = "<group>";
 		};
 		C0EADA668804F57D6D9AA862CE8EF321 /* ILGClasses */ = {
@@ -558,13 +437,34 @@
 			name = ILGClasses;
 			sourceTree = "<group>";
 		};
-		871C6B29616861FE22F20252EE41CB6B /* Classes */ = {
+		2841E6A5AFA6C5740FA47D68784B43B8 /* Vokoder */ = {
 			isa = PBXGroup;
 			children = (
-				6E64A72C77FF954E0048EEA6218BA40E /* Optional Data Sources */,
+				92AA232EE3E496566240A00B61598355 /* Core */,
+				21C815DB339F7DD825A5E4CB08881309 /* Support Files */,
+				CB0492CD97B8E466E5C8C2E3442398C2 /* Swift */,
 			);
-			name = Classes;
-			path = Classes;
+			name = Vokoder;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		DAF43F297D5CF42BF64C58D59E3F34E5 /* Swift */ = {
+			isa = PBXGroup;
+			children = (
+				DFC7668B975281E05CAFA3AE3853BF09 /* VOKCoreDataManager+Swift.swift */,
+				F958437794067505C704E31ADBD9C574 /* VOKManagedObjectMap+Swift.swift */,
+				DF30ECF27987776BECCD96663C0D3700 /* VokoderTypedManagedObject.swift */,
+			);
+			name = Swift;
+			path = Swift;
+			sourceTree = "<group>";
+		};
+		92AA232EE3E496566240A00B61598355 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				7B6B69F12063310EFEBC024790A2398E /* Pod */,
+			);
+			name = Core;
 			sourceTree = "<group>";
 		};
 		9548C5C0C1D5338AD3C65F40DF36F2EA /* Pods-SwiftyVokoder */ = {
@@ -583,35 +483,6 @@
 			);
 			name = "Pods-SwiftyVokoder";
 			path = "Target Support Files/Pods-SwiftyVokoder";
-			sourceTree = "<group>";
-		};
-		6E64A72C77FF954E0048EEA6218BA40E /* Optional Data Sources */ = {
-			isa = PBXGroup;
-			children = (
-				63969E0B4B9A4A3C6B5C042313BC729E /* VOKCollectionDataSource.h */,
-				809098F153C9133A3CFEDA0CC37B2E74 /* VOKCollectionDataSource.m */,
-			);
-			name = "Optional Data Sources";
-			path = "Optional Data Sources";
-			sourceTree = "<group>";
-		};
-		478C110C179740FF4A342BF721CA277F /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				0BA6A3697D7736F3A930525826963BB3 /* Classes */,
-			);
-			name = Pod;
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		D291960F19FD2FE625E66028614C79A8 /* DataSources */ = {
-			isa = PBXGroup;
-			children = (
-				62478C4BCC083549B2675083D4CE14F0 /* Collection */,
-				8EB4618C736DD6BDEC8CFC9A74CBE387 /* FetchedResults */,
-				DC922EC5F6A4C858F3D3657B1D19245D /* PagingFetchedResults */,
-			);
-			name = DataSources;
 			sourceTree = "<group>";
 		};
 		1C5B6E97047618BC1F830BD6A5EC444A /* Pods-SwiftyVokoder-SwiftyVokoderTests */ = {
@@ -642,44 +513,32 @@
 			path = VOKUtilities;
 			sourceTree = "<group>";
 		};
-		62478C4BCC083549B2675083D4CE14F0 /* Collection */ = {
-			isa = PBXGroup;
-			children = (
-				61BB1467B6A83D6A6A4953981C7A0F3D /* Pod */,
-			);
-			name = Collection;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		1796AA295D0C21900B10C57B17F2B05E /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A5C22E889A9E7C681C810D7BDE8790D5 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
-				235B0187FBBF4AE11D3AE502DA0ECD58 /* VOKCollectionDataSource.h in Headers */,
-				576AFEB70C4926DF9D90C402F04C1A91 /* VOKCoreDataCollectionTypes.h in Headers */,
-				26A5F9C895CB34BF97F17CE571E759A5 /* VOKCoreDataManager.h in Headers */,
-				1BFB7C298FD5C3D2FD390190D0ECA769 /* VOKCoreDataManagerInternalMacros.h in Headers */,
-				CB4A4C09DE45A0847DA2F19BB3614B00 /* VOKDefaultPagingAccessory.h in Headers */,
-				2C7030DBF426C627A98E271E3996DD9B /* VOKFetchedResultsDataSource.h in Headers */,
-				F0DDF2A2AF18593F10C360BE5443B757 /* VOKManagedObjectMap.h in Headers */,
-				E4F0D448B9ACA0588BA05ECBF3C4E4C9 /* VOKManagedObjectMapper.h in Headers */,
-				9DAC5F1FCC91C4B9DA5DE65CD6C06FF9 /* VOKMappableModel.h in Headers */,
-				D88DFF6934B408DB7166E3FE6326D411 /* VOKNullabilityFeatures.h in Headers */,
-				1B49270969167C22DCCCF46AD88EB2DB /* VOKPagingFetchedResultsDataSource.h in Headers */,
-				8B360D8BEF266C15195F936EBF783B1B /* Vokoder-umbrella.h in Headers */,
-				D5D5268A466A625A4B99B43992B3F7BD /* Vokoder.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		D22E50FBE57D326B186A324EF0EAF668 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				E63EFB9B228A5DBAA0A19CAF3F531E93 /* VOKKeyPathHelper.h in Headers */,
 				3AF9623A03CBDB6143C6AAA79FAFCBD5 /* VOKUtilities-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1796AA295D0C21900B10C57B17F2B05E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A5C22E889A9E7C681C810D7BDE8790D5 /* NSManagedObject+VOKManagedObjectAdditions.h in Headers */,
+				576AFEB70C4926DF9D90C402F04C1A91 /* VOKCoreDataCollectionTypes.h in Headers */,
+				26A5F9C895CB34BF97F17CE571E759A5 /* VOKCoreDataManager.h in Headers */,
+				1BFB7C298FD5C3D2FD390190D0ECA769 /* VOKCoreDataManagerInternalMacros.h in Headers */,
+				F0DDF2A2AF18593F10C360BE5443B757 /* VOKManagedObjectMap.h in Headers */,
+				E4F0D448B9ACA0588BA05ECBF3C4E4C9 /* VOKManagedObjectMapper.h in Headers */,
+				9DAC5F1FCC91C4B9DA5DE65CD6C06FF9 /* VOKMappableModel.h in Headers */,
+				D88DFF6934B408DB7166E3FE6326D411 /* VOKNullabilityFeatures.h in Headers */,
+				8B360D8BEF266C15195F936EBF783B1B /* Vokoder-umbrella.h in Headers */,
+				D5D5268A466A625A4B99B43992B3F7BD /* Vokoder.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -835,6 +694,21 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
+		48D61696053C90D4304CCE14AD7E6F96 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BA01ACF653FD84D67AA2A9F07B7A142E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
+				DFB79B555DF37784C7A6261D837D5CD8 /* VOKCoreDataManager+Swift.swift in Sources */,
+				D36F28073218405C5AC61EFE60512689 /* VOKCoreDataManager.m in Sources */,
+				7EB42B389B749898F687AD12B231C384 /* VOKManagedObjectMap+Swift.swift in Sources */,
+				421751C8646B1D9437AF8400FDEF78AB /* VOKManagedObjectMap.m in Sources */,
+				2A12A0F766D622588FB6DBE55D841D51 /* VOKManagedObjectMapper.m in Sources */,
+				9B931AD17FA3518651FAB463A8B8D9E1 /* Vokoder-dummy.m in Sources */,
+				3A4D43509F8507A38A697021211B6D16 /* VokoderTypedManagedObject.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		530EC35663471E8D1147EC79301EEE0C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -850,25 +724,6 @@
 			files = (
 				23DA4A38A0F5999A47726AD2E3A3CB64 /* ILGClasses.m in Sources */,
 				1523ECABEAC8045673063FA3D6E70899 /* ILGDynamicObjC-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		48D61696053C90D4304CCE14AD7E6F96 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BA01ACF653FD84D67AA2A9F07B7A142E /* NSManagedObject+VOKManagedObjectAdditions.m in Sources */,
-				95B9BB48A25AB5F7D0AEE23B75C52B90 /* VOKCollectionDataSource.m in Sources */,
-				DFB79B555DF37784C7A6261D837D5CD8 /* VOKCoreDataManager+Swift.swift in Sources */,
-				D36F28073218405C5AC61EFE60512689 /* VOKCoreDataManager.m in Sources */,
-				E0CEEB884037F2326F94FFD21AA555A5 /* VOKDefaultPagingAccessory.m in Sources */,
-				275AFAF4656AB8170B4E6BD5EABF9505 /* VOKFetchedResultsDataSource.m in Sources */,
-				7EB42B389B749898F687AD12B231C384 /* VOKManagedObjectMap+Swift.swift in Sources */,
-				421751C8646B1D9437AF8400FDEF78AB /* VOKManagedObjectMap.m in Sources */,
-				2A12A0F766D622588FB6DBE55D841D51 /* VOKManagedObjectMapper.m in Sources */,
-				0FBF15D82D6887E4507BAEC5AE7D44A5 /* VOKPagingFetchedResultsDataSource.m in Sources */,
-				9B931AD17FA3518651FAB463A8B8D9E1 /* Vokoder-dummy.m in Sources */,
-				3A4D43509F8507A38A697021211B6D16 /* VokoderTypedManagedObject.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
+++ b/SwiftSampleProject/Pods/Target Support Files/Vokoder/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>5.0.0</string>
+  <string>5.0.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/SwiftSampleProject/Pods/Target Support Files/Vokoder/Vokoder-umbrella.h
+++ b/SwiftSampleProject/Pods/Target Support Files/Vokoder/Vokoder-umbrella.h
@@ -19,10 +19,6 @@
 #import "VOKNullabilityFeatures.h"
 #import "Vokoder.h"
 #import "VOKCoreDataManagerInternalMacros.h"
-#import "VOKCollectionDataSource.h"
-#import "VOKFetchedResultsDataSource.h"
-#import "VOKPagingFetchedResultsDataSource.h"
-#import "VOKDefaultPagingAccessory.h"
 
 FOUNDATION_EXPORT double VokoderVersionNumber;
 FOUNDATION_EXPORT const unsigned char VokoderVersionString[];

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Vokoder"
-  s.version          = "5.0.0"
+  s.version          = "5.0.1"
   s.summary          = "Vokal's Core Data Manager"
   s.homepage         = "https://github.com/vokal/Vokoder"
   s.license          = { :type => "MIT", :file => "LICENSE"}
@@ -32,8 +32,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'DataSources' do |ss|
     ss.dependency 'Vokoder/Core'
-    ss.ios.deployment_target = '8.0'
-    ss.tvos.deployment_target = '9.0'
 
     ss.subspec 'FetchedResults' do |sss|
       sss.source_files = 'Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.{h,m}'
@@ -54,8 +52,6 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Swift' do |sw|
-    sw.ios.deployment_target = '8.0'
-    sw.tvos.deployment_target = '9.0'
     sw.dependency 'Vokoder/DataSources'
     sw.source_files = 'Pod/Classes/Swift/*.swift'
   end

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -32,6 +32,9 @@ Pod::Spec.new do |s|
 
   s.subspec 'DataSources' do |ss|
     ss.dependency 'Vokoder/Core'
+    ss.ios.deployment_target = '8.0'
+    ss.tvos.deployment_target = '9.0'
+    ss.watchos.deployment_target = '3.0'
 
     ss.subspec 'FetchedResults' do |sss|
       sss.source_files = 'Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.{h,m}'
@@ -52,6 +55,10 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Swift' do |sw|
+    sw.ios.deployment_target = '8.0'
+    sw.tvos.deployment_target = '9.0'
+    sw.watchos.deployment_target = '3.0'
+    
     sw.dependency 'Vokoder/DataSources'
     sw.source_files = 'Pod/Classes/Swift/*.swift'
   end

--- a/Vokoder.podspec
+++ b/Vokoder.podspec
@@ -34,7 +34,6 @@ Pod::Spec.new do |s|
     ss.dependency 'Vokoder/Core'
     ss.ios.deployment_target = '8.0'
     ss.tvos.deployment_target = '9.0'
-    ss.watchos.deployment_target = '3.0'
 
     ss.subspec 'FetchedResults' do |sss|
       sss.source_files = 'Pod/Classes/Optional Data Sources/VOKFetchedResultsDataSource.{h,m}'
@@ -59,7 +58,7 @@ Pod::Spec.new do |s|
     sw.tvos.deployment_target = '9.0'
     sw.watchos.deployment_target = '3.0'
     
-    sw.dependency 'Vokoder/DataSources'
+    sw.dependency 'Vokoder/Core'
     sw.source_files = 'Pod/Classes/Swift/*.swift'
   end
 end


### PR DESCRIPTION
Derp, still couldn't install the swift subspec on watchOS because that subspec had a different restriction because of former dependency on older version of iOS. 

Bumped the spec version but I can take it off if we want to re-tag master 5.0.0